### PR TITLE
Change Make invocation to use shell

### DIFF
--- a/ansible/roles/vitess-build/tasks/main.yml
+++ b/ansible/roles/vitess-build/tasks/main.yml
@@ -78,9 +78,9 @@
         force: 1
 
     - name: Build Vitess Binaries
-      make:
+      shell:
         chdir: /go/src/vitess.io/vitess
-        target: build
+        cmd: makebuild
 
     - name: Install Vitess Binaries
       shell:


### PR DESCRIPTION
Something is causing the build to fail when make is called without a shell environment. This changes it to use shell to call make rather then use the make module