### PR TITLE
enable runs on OSX systems

### DIFF
--- a/run-oltp
+++ b/run-oltp
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fixes https://github.com/ansible/ansible/issues/32499
-if [ "$(uname)" == "Darwin" ]
+if [ "$(uname)" == "Darwin" ];
 then
     export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 fi

--- a/run-oltp
+++ b/run-oltp
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+# Fixes https://github.com/ansible/ansible/issues/32499
+if [ "$(uname)" == "Darwin" ]
+then
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+fi
+
 #alias activate="benchmark/bin/activate"
 
 #Directory of ansible files
 cd ansible/
 
 #Run ansible script (Runs for all except sysbench)
-ANSIBLE_HOST_KEY_CHECKING=False /root/arewefastyet/benchmark/bin/ansible-playbook --private-key=/root/.ssh/id_rsa -i $1 full.yml -u root -e provision=True -e clean=True
+ANSIBLE_HOST_KEY_CHECKING=False ../benchmark/bin/ansible-playbook --private-key=~/.ssh/id_rsa -i $1 full.yml -u root -e provision=True -e clean=True

--- a/run-tpcc
+++ b/run-tpcc
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+# Fixes https://github.com/ansible/ansible/issues/32499
+if [ "$(uname)" == "Darwin" ];
+then
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+fi
+
 #alias activate="benchmark/bin/activate"
 
 #Directory of ansible files
 cd ansible/
 
 #Run ansible script (Runs for all except sysbench)
-ANSIBLE_HOST_KEY_CHECKING=False /root/arewefastyet/benchmark/bin/ansible-playbook --private-key=/root/.ssh/id_rsa -i $1 full.yml -u root -e provision=True -e tpcc=true -e clean=True
+ANSIBLE_HOST_KEY_CHECKING=False ../benchmark/bin/ansible-playbook --private-key=~/.ssh/id_rsa -i $1 full.yml -u root -e provision=True -e tpcc=true -e clean=True


### PR DESCRIPTION
Signed-off-by: Florent Poinsard <florent.poinsard@outlook.fr>

This PR contains the required changes to run both OLTP and TPCC tasks from an OSX system.

The issue that OSX systems will encounter is defined here: https://github.com/ansible/ansible/issues/32499. And is fixed using their workaround (https://github.com/ansible/ansible/issues/32499#issuecomment-341578864).

