### PR TITLE
Wait for MySQL sockets to exist before creating vttablets

### DIFF
--- a/ansible/roles/vttablet/tasks/vttablet.yml
+++ b/ansible/roles/vttablet/tasks/vttablet.yml
@@ -13,7 +13,8 @@
     owner: '{{ vitess_user }}'
     group: '{{ vitess_group }}'
     mode: '0644'
-- name: start vttablet
+
+- name: start mysql
   become: yes
   become_user: root
   when:
@@ -24,5 +25,42 @@
     state: started
   with_items:
     - 'mysqlctld@{{ tablet.id }}'
-    - 'vttablet@{{ tablet.id }}'
     - 'mysqld_exporter@{{ tablet.id }}'
+
+- name: wait for mysql socket
+  become: yes
+  become_user: root
+  tags: filepresensevalidation
+  register: filepresensevalidation
+  wait_for:
+    path:  '{{vitess_root}}/socket/mysql{{ tablet.id }}.sock'
+    delay: 5
+    timeout: 60
+    state: present
+    msg: "mysql socket needs to be present {{vitess_root}}/socket/mysql{{ tablet.id }}.sock"
+  ignore_errors: true
+
+- name: wait for mysqlctl socket
+  become: yes
+  become_user: root
+  tags: filepresensevalidation
+  register: filepresensevalidation
+  wait_for:
+    path:  '{{vitess_root}}/socket/mysqlctl{{ tablet.id }}.sock'
+    delay: 5
+    timeout: 60
+    state: present
+    msg: "mysqlctl socket needs to be present at {{vitess_root}}/socket/mysqlctl{{ tablet.id }}.sock"
+  ignore_errors: true
+
+- name: start vttablet
+  become: yes
+  become_user: root
+  when:
+    - enable_vttablet | bool
+  service:
+    name: '{{ item }}'
+    enabled: yes
+    state: started
+  with_items:
+    - 'vttablet@{{ tablet.id }}'


### PR DESCRIPTION
Signed-off-by: Florent Poinsard <florent.poinsard@outlook.fr>

This PR introduces a fix to an issue happening when vttablet is created before (usually only a few seconds) MySQL has time to create its socket. When this happens, vttablet will fail to find the MySQL sockets, and thus future clients will not be able to use the vttablet.

The issue can be represented with the following log from vttablet:

```
E0212 07:15:02.389069   40885 tm_state.go:255] Cannot start query service: net.Dial(/vt/socket/mysql2001.sock) to local server failed: dial unix /vt/socket/mysql2001.sock: connect: no such file or directory (errno 2002) (sqlstate HY000)
```

To fix this, new ansible tasks for vttablet are added. These tasks, defined in `vttablet.yml`, split the creation of vttablet into two parts: MySQL and vttablet itself. Between these two parts, we `wait_for` the creation of MySQL's sockets.