### PR TITLE
Addition of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2021 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PY_VERSION = 3.7
+VIRTUALENV_PATH = benchmark
+
+ANSIBLE_PATH = ansible
+
+RUN_COMMIT = HEAD
+RUN_INVENTORY_FILE = koz-inventory-unsharded-test.yml
+
+.PHONY: install virtual_env oltp tpcc molecule_converge_all
+
+virtual_env:
+	test -d $(VIRTUALENV_PATH) || virtualenv -p python$(PY_VERSION) $(VIRTUALENV_PATH)
+
+install: requirements.txt virtual_env $(VIRTUALENV_PATH)
+	source $(VIRTUALENV_PATH)/bin/activate && \
+	pip install -r ./requirements.txt
+	ansible-galaxy install cloudalchemy.prometheus
+	ansible-galaxy install cloudalchemy.node-exporter
+
+oltp: cli virtual_env $(VIRTUALENV_PATH)
+	source $(VIRTUALENV_PATH)/bin/activate && \
+	./cli -c $(RUN_COMMIT) -s makefile_oltp -runo -invf $(RUN_INVENTORY_FILE)
+
+tpcc: cli virtual_env $(VIRTUALENV_PATH)
+	source $(VIRTUALENV_PATH)/bin/activate && \
+	./cli -c $(RUN_COMMIT) -s makefile_tpcc -runt -invf $(RUN_INVENTORY_FILE)
+
+molecule_converge_all: virtual_env $(VIRTUALENV_PATH)
+	source $(VIRTUALENV_PATH)/bin/activate && \
+	cd $(ANSIBLE_PATH)/roles/vitess_build && \
+	molecule create --scenario-name all && \
+	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES molecule converge --scenario-name all

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -5,53 +5,43 @@
 2. Python 3
 3. Mysql Server
 4. Packet API key
+5. Make
 
-### Install python 3.7.x and set up virtual environment
+### Install python 3.7.x
 Ubuntu: https://linuxize.com/post/how-to-install-python-3-7-on-ubuntu-18-04/
+
 CentOS: https://tecadmin.net/install-python-3-7-on-centos-8/
+
 Mac Os:
-```
+```shell
 brew update && brew upgrade
 brew install pyenv
 pyenv install 3.7.9
-// Add output to .zshrc file or .bashrc file
+# Add output to .zshrc file or .bashrc file
 pynev init -
 pyenv global 3.7.9
 ```
-#### Install virtual environment and configure
-```
-sudo pip3 install virtualenv
 
-// Linux
-virtualenv --python=python3.7 benchmark
-
-//Mac or if python 3.7 is your default python version
-virtualenv benchmark
-
-// activate virtual environment
-source benchmark/bin/activate
-```
-
-### Install python libraries
-```
-pip install -r requirements.txt
-```
 ### Install Ansible
 https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 
-### Configure Ansible
+#### Configure Ansible
 https://github.com/vitessio/arewefastyet/blob/modify-ansible/ansible/README.md
-#### Ansible dependencies
-```
-cd ansible
-ansible-galaxy install cloudalchemy.node-exporter
-ansible-galaxy install cloudalchemy.prometheus
-```
 
-### For MacOS Dependencies
-```
+### Install MacOS Dependencies
+
+> For OSX systems only
+
+```shell
 brew install jq
 brew install gnu-tar
+```
+
+### Install virtual environment and dependencies
+```shell
+sudo pip3 install virtualenv
+
+make install
 ```
 
 ### Create SSH key for ansible or use exsisting
@@ -61,13 +51,13 @@ https://docs.github.com/en/enterprise/2.15/user/articles/generating-a-new-ssh-ke
 https://vitess.io/docs/contributing/build-on-ubuntu/
 
 ### Change files to executables
-```
+```shell
 chmod +x run-benchmark
 chmod +x scheduler
 chmod +x cli
 ```
 ### Create file config.yaml
-```
+```yaml
 mysql_host: <mysql hostname>
 mysql_username: <mysql username>
 mysql_password: <mysql password>
@@ -80,7 +70,7 @@ slack_api_token: <slack_token>
 slack_channel: <channel name>
 ```
 Ex :
-```
+```yaml
 mysql_host: localhost:3306
 mysql_username: vitess
 mysql_password: vitess123

--- a/docs/Makefile.md
+++ b/docs/Makefile.md
@@ -1,0 +1,21 @@
+# Makefile
+
+### Targets
+
+| Name | Action |
+| -----| ------ |
+| `virtual_env`   | Check if virtualenv is present, if not, create it |
+| `install`   | Call `virtual_env`, then install all depedencies (ansible & pip) |
+| `oltp`   | Call `virtual_env`, then run an OLTP benchmark |
+| `tpcc`   | Call `virtual_env`, then run a TPCC benchmark |
+| `molecule_converge_all`   | Call `virtual_env`, then create a molecule and converge all the roles |
+
+### Variables
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| `PY_VERSION`   | Python version used | 3.7 |
+| `VIRTUALENV_PATH`   | Path to virtualenv folder | benchmark |
+| `ANSIBLE_PATH`   | Path to ansible folder | ansible |
+| `RUN_COMMIT`   | Vitess commit used to run the benchmark | HEAD |
+| `RUN_INVENTORY_FILE`   | Path to the ansible inventory file for benchmark| koz-inventory-unsharded-test.yml |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ The purpose of this project is to do a benchmark run when ever there is a push. 
 1. [Installation](Installation.md)
 2. [Api](Api.md)
 3. [Cli](cli.md)
+4. [Makefile](Makefile.md)


### PR DESCRIPTION
Signed-off-by: Florent Poinsard <florent.poinsard@outlook.fr>

Addition of a Makefile with these targets:

| Name        | Action           |
| ---------- | -------------- |
| `virtual_env`   | Check if virtualenv is present, if not, create it |
| `install`   | Call `virtual_env`, then install all depedencies (ansible & pip) |
| `oltp`   | Call `virtual_env`, then run an OLTP benchmark |
| `tpcc`   | Call `virtual_env`, then run a TPCC benchmark |
| `molecule_converge_all`   | Call `virtual_env`, then create a molecule and converge all the roles |

With the following variables:

| Name | Description | Default |
| ---- | ----------- | ------- |
| `PY_VERSION`   | Python version used | 3.7 |
| `VIRTUALENV_PATH`   | Path to virtualenv folder | benchmark |
| `ANSIBLE_PATH`   | Path to ansible folder | ansible |
| `RUN_COMMIT`   | Vitess commit used to run the benchmark | HEAD |
| `RUN_INVENTORY_FILE`   | Path to the ansible inventory file for benchmark| koz-inventory-unsharded-test.yml |

These two tables are added to the documentation.

Resolves #29.