### PR TITLE
Addition of missing install and outdated oltp/tpcc targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VIRTUALENV_PATH = benchmark
 ANSIBLE_PATH = ansible
 CONFIG_PATH = config/config.yaml
 SCRIPTS_PATH = scripts
-REPORTS_PATH = reports
+REPORTS_PATH = report
 
 RUN_COMMIT = HEAD
 RUN_INVENTORY_FILE = koz-inventory-unsharded-test.yml

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ PY_VERSION = 3.7
 VIRTUALENV_PATH = benchmark
 
 ANSIBLE_PATH = ansible
+CONFIG_PATH = config/config.yaml
+SCRIPTS_PATH = scripts
+REPORTS_PATH = reports
 
 RUN_COMMIT = HEAD
 RUN_INVENTORY_FILE = koz-inventory-unsharded-test.yml
@@ -28,16 +31,29 @@ virtual_env:
 install: requirements.txt virtual_env $(VIRTUALENV_PATH)
 	source $(VIRTUALENV_PATH)/bin/activate && \
 	pip install -r ./requirements.txt
+	python setup.py install
 	ansible-galaxy install cloudalchemy.prometheus
 	ansible-galaxy install cloudalchemy.node-exporter
 
-oltp: cli virtual_env $(VIRTUALENV_PATH)
+install_dev_cli: virtual_env $(VIRTUALENV_PATH)
 	source $(VIRTUALENV_PATH)/bin/activate && \
-	./cli -c $(RUN_COMMIT) -s makefile_oltp -runo -invf $(RUN_INVENTORY_FILE)
+	python setup.py develop --user
 
-tpcc: cli virtual_env $(VIRTUALENV_PATH)
+oltp: virtual_env $(VIRTUALENV_PATH)
 	source $(VIRTUALENV_PATH)/bin/activate && \
-	./cli -c $(RUN_COMMIT) -s makefile_tpcc -runt -invf $(RUN_INVENTORY_FILE)
+	clibench -c $(RUN_COMMIT) -s makefile_oltp -runo -invf $(RUN_INVENTORY_FILE) \
+													--config-file $(CONFIG_PATH) \
+													--ansible-dir $(ANSIBLE_PATH) \
+													--tasks-scripts-dir $(SCRIPTS_PATH) \
+													--tasks-reports-dir $(REPORTS_PATH)
+
+tpcc: virtual_env $(VIRTUALENV_PATH)
+	source $(VIRTUALENV_PATH)/bin/activate && \
+	clibench -c $(RUN_COMMIT) -s makefile_tpcc -runt -invf $(RUN_INVENTORY_FILE) \
+													--config-file $(CONFIG_PATH) \
+													--ansible-dir $(ANSIBLE_PATH) \
+													--tasks-scripts-dir $(SCRIPTS_PATH) \
+													--tasks-reports-dir $(REPORTS_PATH)
 
 molecule_converge_all: virtual_env $(VIRTUALENV_PATH)
 	source $(VIRTUALENV_PATH)/bin/activate && \

--- a/docs/Makefile.md
+++ b/docs/Makefile.md
@@ -20,6 +20,6 @@
 | `ANSIBLE_PATH`   | Path to ansible folder | ansible |
 | `CONFIG_PATH`   | Path to config.yaml file | config/config.yaml |
 | `SCRIPTS_PATH`   | Path to scripts dir | scripts |
-| `REPORTS_PATH`   | Path to reports dir | reports |
+| `REPORTS_PATH`   | Path to reports dir | report |
 | `RUN_COMMIT`   | Vitess commit used to run the benchmark | HEAD |
 | `RUN_INVENTORY_FILE`   | Path to the ansible inventory file for benchmark| koz-inventory-unsharded-test.yml |

--- a/docs/Makefile.md
+++ b/docs/Makefile.md
@@ -5,7 +5,8 @@
 | Name | Action |
 | -----| ------ |
 | `virtual_env`   | Check if virtualenv is present, if not, create it |
-| `install`   | Call `virtual_env`, then install all depedencies (ansible & pip) |
+| `install`   | Call `virtual_env`, then install all dependencies (ansible & pip) |
+| `install_dev_cli`   | Call `virtual_env`, then install the CLI in development mode |
 | `oltp`   | Call `virtual_env`, then run an OLTP benchmark |
 | `tpcc`   | Call `virtual_env`, then run a TPCC benchmark |
 | `molecule_converge_all`   | Call `virtual_env`, then create a molecule and converge all the roles |
@@ -17,5 +18,8 @@
 | `PY_VERSION`   | Python version used | 3.7 |
 | `VIRTUALENV_PATH`   | Path to virtualenv folder | benchmark |
 | `ANSIBLE_PATH`   | Path to ansible folder | ansible |
+| `CONFIG_PATH`   | Path to config.yaml file | config/config.yaml |
+| `SCRIPTS_PATH`   | Path to scripts dir | scripts |
+| `REPORTS_PATH`   | Path to reports dir | reports |
 | `RUN_COMMIT`   | Vitess commit used to run the benchmark | HEAD |
 | `RUN_INVENTORY_FILE`   | Path to the ansible inventory file for benchmark| koz-inventory-unsharded-test.yml |


### PR DESCRIPTION
This pull request resolves #38 by fixing the existing targets `oltp` and `tpcc` of the Makefile. They now use the CLI binary using setuptools install.

A new target is added, `install_dev_cli` enabling the dev/edit install of setuptools.

Changes were reported in the documentation.