### PR TITLE
Tasks report zip and upload to S3

### DIFF
--- a/bench_cli/aws.py
+++ b/bench_cli/aws.py
@@ -10,17 +10,22 @@
 #  limitations under the License.
 
 import boto3
+from typing import Optional
 from botocore.exceptions import ClientError
 
-def upload_file(file_name, bucket="arewefastyet", object_name=None):
+
+def upload_file(file_name, bucket="arewefastyet", object_name=None, link_exp=86400) -> Optional[str]:
     if object_name is None:
         object_name = file_name
 
     s3_client = boto3.client('s3')
     try:
-        response = s3_client.upload_file(file_name, bucket, object_name)
+        s3_client.upload_file(file_name, bucket, object_name)
+        url = s3_client.generate_presigned_url('get_object',
+                                                    Params={'Bucket': bucket, 'Key': object_name},
+                                                    ExpiresIn=link_exp
+                                                    )
     except ClientError as e:
         print(e)
-        return False
-    print(response)
-    return True
+        return None
+    return url

--- a/bench_cli/aws.py
+++ b/bench_cli/aws.py
@@ -1,0 +1,26 @@
+#  Copyright 2021 The Vitess Authors.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import boto3
+from botocore.exceptions import ClientError
+
+def upload_file(file_name, bucket="arewefastyet", object_name=None):
+    if object_name is None:
+        object_name = file_name
+
+    s3_client = boto3.client('s3')
+    try:
+        response = s3_client.upload_file(file_name, bucket, object_name)
+    except ClientError as e:
+        print(e)
+        return False
+    print(response)
+    return True

--- a/bench_cli/cli.py
+++ b/bench_cli/cli.py
@@ -34,6 +34,7 @@ import bench_cli.packet_vps as vps
 @click.option("--tasks-scripts-dir",        help="Path to tasks scripts directory", envvar="BCLI_TASKS_SCRIPTS_DIR")
 @click.option("--tasks-reports-dir",        help="Path to tasks reports directory", envvar="BCLI_TASKS_REPORTS_DIR")
 @click.option("--tasks-pprof",              help="Profiling option for Vitess")
+@click.option("--tasks-upload-to-aws", "-aws", is_flag=True, help="Upload the task report to AWS S3")
 @click.option("--ansible-dir",              help="Path to the Ansible directory", envvar="BCLI_ANSIBLE_DIR")
 @click.option("--inventory-file", "-invf",  help="Mention inventory file to call", envvar="BCLI_INVENTORY_FILE")
 @click.option("--mysql-host",               help="MySQL server hostname", envvar="BCLI_MYSQL_HOST")

--- a/bench_cli/configuration.py
+++ b/bench_cli/configuration.py
@@ -42,6 +42,7 @@ class Config:
         self.tasks_reports_dir: str = None
         self.tasks_pprof: str = None
         self.tasks_pprof_options = None
+        self.tasks_upload_to_aws = None
 
         # MySQL related
         self.mysql_host: str = None

--- a/bench_cli/run_benchmark.py
+++ b/bench_cli/run_benchmark.py
@@ -56,7 +56,12 @@ class BenchmarkRunner:
             task.run(self.config.tasks_scripts_dir)
             task.save_report()
             task.download_remote_pprof_folder()
+
+            report_url = None
             if self.config.tasks_upload_to_aws:
-                task.upload_report_to_aws()
+                report_url = task.upload_report_to_aws()
             reporting.save_to_mysql(self.config, task.report, task.table_name())
-            reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel, task.report_path())
+            reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel,
+                                         task_id=task.task_id.__str__(),
+                                         report_url=report_url,
+                                         filename=task.report_path())

--- a/bench_cli/run_benchmark.py
+++ b/bench_cli/run_benchmark.py
@@ -51,9 +51,12 @@ class BenchmarkRunner:
         """
         for task in self.tasks:
             task.create_device(self.config.packet_token, self.config.packet_project_id)
+            task.create_task_data_directory()
             task.build_ansible_inventory(self.config.commit)
             task.run(self.config.tasks_scripts_dir)
             task.save_report()
             task.download_remote_pprof_folder()
+            if self.config.tasks_upload_to_aws:
+                task.upload_report_to_aws()
             reporting.save_to_mysql(self.config, task.report, task.table_name())
             reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel, task.report_path())

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -13,6 +13,8 @@ import os
 import uuid
 import shutil
 import json
+from typing import Optional
+
 import yaml
 import abc
 
@@ -153,9 +155,9 @@ class Task:
         dest_dir = os.path.join(self.report_dir, "pprof")
         get_from_remote.get_from_remote(self.device_ip, "root", src_dir, dest_dir, is_directory=True, create_dest=True)
 
-    def upload_report_to_aws(self):
+    def upload_report_to_aws(self) -> Optional[str]:
         zip.zipdir(self.report_dir, "zip", self.report_dir)
-        aws.upload_file(self.report_dir+".zip", object_name=self.name()+"-"+self.task_id.__str__())
+        return aws.upload_file(self.report_dir+".zip", object_name=os.path.basename(self.report_dir+".zip"))
 
     def save_report(self):
         """

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -19,6 +19,8 @@ import abc
 import bench_cli.packet_vps as packet_vps
 import bench_cli.get_head_hash as get_head_hash
 import bench_cli.get_from_remote as get_from_remote
+import bench_cli.zip as zip
+import bench_cli.aws as aws
 
 
 class Task:
@@ -45,6 +47,12 @@ class Task:
     def __build_built_inventory_filename(self):
         splits = os.path.basename(self.ansible_inventory_file).split('.')
         return splits[0] + "-" + str(self.task_id) + '.yml'
+
+    def create_task_data_directory(self):
+        dir = os.path.join(self.report_dir, self.name() + "-"+ self.task_id.__str__()[:8])
+        if os.path.exists(dir) is False:
+            os.mkdir(dir)
+        self.report_dir = dir
 
     def append_state_to_file(self, filepath: str):
         """
@@ -144,6 +152,10 @@ class Task:
         src_dir = '/tmp/pprof'
         dest_dir = os.path.join(self.report_dir, "pprof")
         get_from_remote.get_from_remote(self.device_ip, "root", src_dir, dest_dir, is_directory=True, create_dest=True)
+
+    def upload_report_to_aws(self):
+        zip.zipdir(self.report_dir, "zip", self.report_dir)
+        aws.upload_file(self.report_dir+".zip", object_name=self.name()+"-"+self.task_id.__str__())
 
     def save_report(self):
         """

--- a/bench_cli/zip.py
+++ b/bench_cli/zip.py
@@ -1,0 +1,16 @@
+#  Copyright 2021 The Vitess Authors.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import shutil
+
+
+def zipdir(archive, type, location):
+    shutil.make_archive(archive, type, location)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,6 +56,7 @@ The `Env` column represents the environment variable name, and `Config name` rep
 | `--config-file`   | `BCLI_CONFIG_FILE` | `config_file` | Path to configuration file |
 | `--delete-benchmark`   | _none_ | `vps_id` | deletes a specific VPS given the VPS ID which can be found in Config-lock file |
 | `--tasks-pprof`   | _none_ | `tasks_pprof` | Specify the profile configuration of vitess |
+| `--tasks-upload-to-aws` `-aws`  | _none_ | `tasks_upload_to_aws` | Boolean specifying if tasks reports should be uploaded to S3 |
 
 
 ### Profiling

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ flask_sslify
 pyOpenSSL
 click
 setuptools
+boto3


### PR DESCRIPTION
After downloading and computing the report of a task, we now zip it and upload it to S3. We then generate a temporary link to the newly created object and send it over to the benchmark slack channel along with the report JSON.

The arborescence of the `tasks_reports_dir` has changed. Instead of dumping all the reports in `tasks_reports_dir`, we take it as a basepath and make new subdirectories from there. Now, each task has its own report subdirectory, making it easier to navigate through the different tasks and runs.