### PR TITLE
Enable runs on pull request and any commit reference

### DIFF
--- a/ansible/roles/vitess_build/tasks/main.yml
+++ b/ansible/roles/vitess_build/tasks/main.yml
@@ -86,7 +86,8 @@
         repo: "{{ vitess_git_repo }}"
         dest: /go/src/vitess.io/vitess
         version: "{{ vitess_git_version }}"
-        force: 1
+        refspec: "{{ vitess_git_version_fetch_pr if vitess_git_version_pr_nb is defined | default('') }}"
+        force: false
 
     - name: Tmp directory gopath
       become: yes

--- a/bench_cli/github_api.py
+++ b/bench_cli/github_api.py
@@ -1,0 +1,32 @@
+#  Copyright 2021 The Vitess Authors.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional
+from github import Github, GithubException
+
+
+def get_sha_from_ref(ref) -> Optional[str]:
+    c = Github()
+    try:
+        sha = c.get_repo("vitessio/vitess").get_commit(ref).sha
+    except GithubException as e:
+        print(e.data.get("message"))
+        return None
+    return sha
+
+def get_sha_from_pr(pr: int) -> Optional[str]:
+    c = Github()
+    try:
+        sha = c.get_repo("vitessio/vitess").get_pull(pr).head.sha
+    except GithubException as e:
+        print(e.data.get("message"))
+        return None
+    return sha

--- a/bench_cli/github_api.py
+++ b/bench_cli/github_api.py
@@ -13,6 +13,17 @@ from typing import Optional
 from github import Github, GithubException
 
 
+def resolve_ref(initial_ref: str):
+    is_pr = False
+    ref = get_sha_from_ref(initial_ref)
+    if ref is None:
+        pr_nb = int(initial_ref)
+        ref = get_sha_from_pr(pr_nb)
+        if ref is not None:
+            is_pr = True
+    return ref, is_pr
+
+
 def get_sha_from_ref(ref) -> Optional[str]:
     c = Github()
     try:
@@ -21,6 +32,7 @@ def get_sha_from_ref(ref) -> Optional[str]:
         print(e.data.get("message"))
         return None
     return sha
+
 
 def get_sha_from_pr(pr: int) -> Optional[str]:
     c = Github()

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -23,6 +23,7 @@ import bench_cli.get_head_hash as get_head_hash
 import bench_cli.get_from_remote as get_from_remote
 import bench_cli.zip as zip
 import bench_cli.aws as aws
+import bench_cli.github_api as ghapi
 
 
 class Task:
@@ -116,10 +117,13 @@ class Task:
             invdata = yaml.load(invf, Loader=yaml.FullLoader)
         self.__recursive_dict(invdata)
 
-        self.commit_hash = commit_hash
-        if commit_hash == 'HEAD':
-            self.commit_hash = get_head_hash.head_commit_hash()
+        self.commit_hash, is_pr = ghapi.resolve_ref(commit_hash)
+        if self.commit_hash is None:
+            self.commit_hash = commit_hash
         invdata["all"]["vars"]["vitess_git_version"] = self.commit_hash
+        if is_pr:
+            invdata["all"]["vars"]["vitess_git_version_pr_nb"] = int(commit_hash)
+            invdata["all"]["vars"]["vitess_git_version_fetch_pr"] = "pull/{0}/head:{0}".format(commit_hash)
 
         if self.pprof:
             invdata["all"]["vars"]["pprof_targets"] = self.pprof["targets"]

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -116,7 +116,7 @@ class Task:
             invdata = yaml.load(invf, Loader=yaml.FullLoader)
         self.__recursive_dict(invdata)
 
-        # TODO: handle any commit
+        self.commit_hash = commit_hash
         if commit_hash == 'HEAD':
             self.commit_hash = get_head_hash.head_commit_hash()
         invdata["all"]["vars"]["vitess_git_version"] = self.commit_hash

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyOpenSSL
 click
 setuptools
 boto3
+PyGithub


### PR DESCRIPTION
## Description

Utilization of GitHub API through `PyGithub` to get more power out of the `--commit` CLI flag. We can now use the `--commit` flag with any reference (branch name, tag, partial commit SHA, release, pull request ID).

_**Example:**_

- `--commit "1"` will run the benchmarks on Vitess's pull request # 1
- `--commit "v9.0.0"` will run the benchmarks on Vitess's tag `v9.0.0`
- `--commit "79b93e2"` will run the benchmarks on Vitess's commit hash https://github.com/vitessio/vitess/commit/79b93e2215cf432678961beb0602fb9921629e19
- and so on ...

In addition to giving us more information, this start-off implementation of `PyGithub` allows us to implement more fancy features such as release report, commit status for each commit in Vitess.

## Related issues
- Resolves #56
- Resolves #57 