### PR TITLE
Enhance cleanup step in BenchmarkRunner

### DIFF
--- a/bench_cli/run_benchmark.py
+++ b/bench_cli/run_benchmark.py
@@ -65,3 +65,4 @@ class BenchmarkRunner:
                                          task_id=task.task_id.__str__(),
                                          report_url=report_url,
                                          filename=task.report_path())
+            task.clean_up()

--- a/bench_cli/run_benchmark.py
+++ b/bench_cli/run_benchmark.py
@@ -57,12 +57,12 @@ class BenchmarkRunner:
             task.save_report()
             task.download_remote_pprof_folder()
 
-            report_url = None
-            if self.config.tasks_upload_to_aws:
-                report_url = task.upload_report_to_aws()
-            reporting.save_to_mysql(self.config, task.report, task.table_name())
-            reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel,
-                                         task_id=task.task_id.__str__(),
-                                         report_url=report_url,
-                                         filename=task.report_path())
+            # report_url = None
+            # if self.config.tasks_upload_to_aws:
+            #     report_url = task.upload_report_to_aws()
+            # reporting.save_to_mysql(self.config, task.report, task.table_name())
+            # reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel,
+            #                              task_id=task.task_id.__str__(),
+            #                              report_url=report_url,
+            #                              filename=task.report_path())
             task.clean_up(packet_token=self.config.packet_token)

--- a/bench_cli/run_benchmark.py
+++ b/bench_cli/run_benchmark.py
@@ -57,12 +57,12 @@ class BenchmarkRunner:
             task.save_report()
             task.download_remote_pprof_folder()
 
-            # report_url = None
-            # if self.config.tasks_upload_to_aws:
-            #     report_url = task.upload_report_to_aws()
-            # reporting.save_to_mysql(self.config, task.report, task.table_name())
-            # reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel,
-            #                              task_id=task.task_id.__str__(),
-            #                              report_url=report_url,
-            #                              filename=task.report_path())
+            report_url = None
+            if self.config.tasks_upload_to_aws:
+                report_url = task.upload_report_to_aws()
+            reporting.save_to_mysql(self.config, task.report, task.table_name())
+            reporting.send_slack_message(self.config.slack_api_token, self.config.slack_channel,
+                                         task_id=task.task_id.__str__(),
+                                         report_url=report_url,
+                                         filename=task.report_path())
             task.clean_up(packet_token=self.config.packet_token)

--- a/bench_cli/run_benchmark.py
+++ b/bench_cli/run_benchmark.py
@@ -65,4 +65,4 @@ class BenchmarkRunner:
                                          task_id=task.task_id.__str__(),
                                          report_url=report_url,
                                          filename=task.report_path())
-            task.clean_up()
+            task.clean_up(packet_token=self.config.packet_token)

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -174,11 +174,13 @@ class Task:
         with open(self.report_path(), 'w') as f:
             json.dump(self.report, f)
 
-    def clean_up(self):
+    def clean_up(self, delete_device=True):
         """
         Removes the ansible_built_inventory_file of the file system.
         """
         os.remove(self.ansible_built_inventory_file)
+        if delete_device is True:
+            self.delete_device()
 
     @abc.abstractmethod
     def run(self, script_path: str):

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -174,13 +174,13 @@ class Task:
         with open(self.report_path(), 'w') as f:
             json.dump(self.report, f)
 
-    def clean_up(self, delete_device=True):
+    def clean_up(self, packet_token=None):
         """
         Removes the ansible_built_inventory_file of the file system.
         """
         os.remove(self.ansible_built_inventory_file)
-        if delete_device is True:
-            self.delete_device()
+        if packet_token is not None:
+            self.delete_device(packet_token)
 
     @abc.abstractmethod
     def run(self, script_path: str):

--- a/bench_cli/task.py
+++ b/bench_cli/task.py
@@ -174,13 +174,25 @@ class Task:
         with open(self.report_path(), 'w') as f:
             json.dump(self.report, f)
 
-    def clean_up(self, packet_token=None):
+    def clean_up(self, packet_token=None, rm_artifacts=True, rm_report=True):
         """
-        Removes the ansible_built_inventory_file of the file system.
+        Cleans up the task's data:
+            - Ansible built inventory file
+            - Ansible artifacts directory
+            - The VPS device
+            - The report directory and ZIP file
         """
-        os.remove(self.ansible_built_inventory_file)
+        os.remove(self.ansible_built_inventory_filepath)
         if packet_token is not None:
             self.delete_device(packet_token)
+        if rm_artifacts is True:
+            path_to_artifact = os.path.join(self.ansible_dir, "artifacts", self.task_id.__str__())
+            if os.path.exists(path_to_artifact) is True:
+                shutil.rmtree(path_to_artifact)
+        if rm_report is True:
+            if os.path.exists(self.report_dir+".zip") is True:
+                os.remove(self.report_dir+'.zip')
+            shutil.rmtree(self.report_dir)
 
     @abc.abstractmethod
     def run(self, script_path: str):


### PR DESCRIPTION
Integrated the `task.clean_up` method to the main loop of `BenchmarkRunner` and added options to delete the task's VPS, report directory, and artifacts.