### PR TITLE
Link between the Go CLI and WebUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,8 +140,8 @@ cython_debug/
 # pyc extension
 *.pyc
 
-#Config yaml
-config.yaml
+# Config files
+config/*.yaml
 
 # hide config-lock.json
 config-lock.json

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.4.0
 	golang.org/x/tools v0.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -246,7 +246,6 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -302,7 +301,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vitessio/arewefastyet/go/cmd/infra"
 	"github.com/vitessio/arewefastyet/go/cmd/microbench"
+	"github.com/vitessio/arewefastyet/go/cmd/web"
 	"log"
 	"os"
 
@@ -58,6 +59,7 @@ func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.AddCommand(microbench.MicroBenchCmd())
 	rootCmd.AddCommand(infra.InfraCmd())
+	rootCmd.AddCommand(web.WebCmd())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go/cmd/web/web.go
+++ b/go/cmd/web/web.go
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package web
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/vitessio/arewefastyet/go/server"
+)
+
+func WebCmd() *cobra.Command {
+	var srv server.Server
+
+	cmd := &cobra.Command{
+		Use: "web",
+		Short: "Starts the HTTP web server",
+		Aliases: []string{"w"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return srv.Run()
+		},
+	}
+
+	srv.AddToCommand(cmd)
+
+	return cmd
+}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -88,10 +88,11 @@ func (s *Server) Run() error {
 	return s.router.Run(":" + s.port)
 }
 
-func Run(port, templatePath, apiKey string) error {
+func Run(port, templatePath, staticPath, apiKey string) error {
 	s := Server{
 		port:         port,
 		templatePath: templatePath,
+		staticPath:   staticPath,
 		apiKey:       apiKey,
 	}
 	return s.Run()

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/vitessio/arewefastyet/go/mysql"
 	"net/http"
 )
 
@@ -23,6 +24,7 @@ type Server struct {
 	staticPath   string
 	apiKey       string
 	router       *gin.Engine
+	dbCfg        *mysql.ConfigDB
 }
 
 func (s *Server) AddToCommand(cmd *cobra.Command) {
@@ -35,6 +37,11 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	viper.BindPFlag(flagTemplatePath, cmd.Flags().Lookup(flagTemplatePath))
 	viper.BindPFlag(flagStaticPath, cmd.Flags().Lookup(flagStaticPath))
 	viper.BindPFlag(flagAPIKey, cmd.Flags().Lookup(flagAPIKey))
+
+	if s.dbCfg == nil {
+		s.dbCfg = &mysql.ConfigDB{}
+	}
+	s.dbCfg.AddToCommand(cmd)
 }
 
 func (s Server) isReady() bool {
@@ -48,7 +55,7 @@ func (s *Server) Run() error {
 	s.router = gin.Default()
 	s.router.Static("/static", s.staticPath)
 
-	s.router.LoadHTMLGlob(s.templatePath+"/*")
+	s.router.LoadHTMLGlob(s.templatePath + "/*")
 
 	// Information page
 	s.router.GET("/information", func(c *gin.Context) {

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -1,47 +1,91 @@
-package main
+package server
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"net/http"
-	//"fmt"
 )
 
-func main() {
-	router := gin.Default()
-	router.Static("/static", "./static")
+const (
+	ErrorIncorrectConfiguration = "incorrect configuration"
 
-	router.LoadHTMLGlob("templates/*")
-	//router.LoadHTMLFiles("templates/information.tmpl")
-	router.GET("/information", func(c *gin.Context) {
+	flagPort         = "web-port"
+	flagTemplatePath = "web-template-path"
+	flagStaticPath   = "web-static-path"
+	flagAPIKey       = "web-api-key"
+)
+
+type Server struct {
+	port         string
+	templatePath string
+	staticPath   string
+	apiKey       string
+	router       *gin.Engine
+}
+
+func (s *Server) AddToCommand(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&s.port, flagPort, "8080", "Port used for the HTTP server")
+	cmd.Flags().StringVar(&s.templatePath, flagTemplatePath, "", "Path to the template directory")
+	cmd.Flags().StringVar(&s.staticPath, flagStaticPath, "", "Path to the static directory")
+	cmd.Flags().StringVar(&s.apiKey, flagAPIKey, "", "API key used to authenticate requests")
+
+	viper.BindPFlag(flagPort, cmd.Flags().Lookup(flagPort))
+	viper.BindPFlag(flagTemplatePath, cmd.Flags().Lookup(flagTemplatePath))
+	viper.BindPFlag(flagStaticPath, cmd.Flags().Lookup(flagStaticPath))
+	viper.BindPFlag(flagAPIKey, cmd.Flags().Lookup(flagAPIKey))
+}
+
+func (s Server) isReady() bool {
+	return s.port != "" && s.templatePath != "" && s.staticPath != "" && s.apiKey != ""
+}
+
+func (s *Server) Run() error {
+	if s.isReady() == false {
+		return errors.New(ErrorIncorrectConfiguration)
+	}
+	s.router = gin.Default()
+	s.router.Static("/static", s.staticPath)
+
+	s.router.LoadHTMLGlob(s.templatePath+"/*")
+
+	// Information page
+	s.router.GET("/information", func(c *gin.Context) {
 		c.HTML(http.StatusOK, "information.tmpl", gin.H{
 			"title": "Vitess benchmark",
 		})
 	})
 
-	//Home page
-	router.GET("/", func(c *gin.Context) {
+	// Home page
+	s.router.GET("/", func(c *gin.Context) {
 		c.HTML(http.StatusOK, "index.tmpl", gin.H{
 			"title": "Vitess benchmark",
 		})
 	})
 
-	//Request benchmark page
-	router.GET("/search_compare", func(c *gin.Context) {
+	// Request benchmark page
+	s.router.GET("/search_compare", func(c *gin.Context) {
 		c.HTML(http.StatusOK, "search_compare.tmpl", gin.H{
 			"title": "Vitess benchmark",
 		})
 	})
 
-	//Request benchmark page
-	router.GET("/request_benchmark", func(c *gin.Context) {
+	// Request benchmark page
+	s.router.GET("/request_benchmark", func(c *gin.Context) {
 		c.HTML(http.StatusOK, "request_benchmark.tmpl", gin.H{
 			"title": "Vitess benchmark",
 		})
 	})
 
+	return s.router.Run(":" + s.port)
+}
 
-
-
-	router.Run(":8080")
-
+func Run(port, templatePath, apiKey string) error {
+	s := Server{
+		port:         port,
+		templatePath: templatePath,
+		apiKey:       apiKey,
+	}
+	return s.Run()
 }

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -1,0 +1,101 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package server
+
+import (
+	qt "github.com/frankban/quicktest"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	type args struct {
+		port         string
+		templatePath string
+		staticPath   string
+		apiKey       string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		err     string
+	}{
+		{name: "Missing port", args: args{templatePath: "./", staticPath: "./", apiKey: "api_key"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing template path", args: args{port: "8888", staticPath: "./", apiKey: "424242-848484-ABC"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing static path", args: args{port: "9999", templatePath: "./", apiKey: "my key"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing api key", args: args{port: "8080", templatePath: "./", staticPath: "./static"}, wantErr: true, err: ErrorIncorrectConfiguration},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			gotErr := Run(tt.args.port, tt.args.templatePath, tt.args.staticPath, tt.args.apiKey)
+			if tt.wantErr == true {
+				c.Assert(gotErr, qt.Not(qt.IsNil))
+				c.Assert(gotErr, qt.ErrorMatches, tt.err)
+			}
+		})
+	}
+}
+
+func TestServer_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       Server
+		wantErr bool
+		err     string
+	}{
+		{name: "Server not ready", s: Server{}, wantErr: true, err: ErrorIncorrectConfiguration},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			gotErr := tt.s.Run()
+			if tt.wantErr == true {
+				c.Assert(gotErr, qt.Not(qt.IsNil))
+				c.Assert(gotErr, qt.ErrorMatches, tt.err)
+			}
+		})
+	}
+}
+
+func TestServer_isReady(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Server
+		want bool
+	}{
+		{name: "Server fully ready", s: Server{port: "8080", templatePath: "./", staticPath: "./", apiKey: "api_key"}, want: true},
+		{name: "Missing port", s: Server{templatePath: "./", staticPath: "./", apiKey: "api_key"}},
+		{name: "Missing template path", s: Server{port: "8888", staticPath: "./", apiKey: "424242-848484-ABC"}},
+		{name: "Missing static path", s: Server{port: "9999", templatePath: "./", apiKey: "my key"}},
+		{name: "Missing api key", s: Server{port: "8080", templatePath: "./", staticPath: "./static"}},
+		{name: "Missing multiple elements (1)", s: Server{port: "8080", staticPath: "", apiKey: ""}},
+		{name: "Missing multiple elements (2)", s: Server{templatePath: "", staticPath: "./", apiKey: "428484242-4284842-IUN81B5465"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			gotReady := tt.s.isReady()
+			c.Assert(gotReady, qt.Equals, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
### Description

Implementation of a `web` CLI command to start the HTTP server. The server will start using the above configuration (passed through config file or flags):

```yaml
web-port: 8080
web-template-path: ./go/server/templates
web-static-path: ./go/server/static
web-api-key: my_key
```

Additionally, `Server` is composed of a `mysql.ConfigDB` which will automatically be added to the `cobra.Command` when using the `Server`'s method `AddToCommand(cmd)`.

### How to run

```sh
go run ./go/main.go --config config/config.yaml web
```

### Related issues

Resolves #86.