### PR TITLE
Preprocessing of microbenchmark results and render in web UI

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -63,3 +63,14 @@ func (c Client) Insert(query string, args ...interface{}) (ID int64, err error) 
 	}
 	return res.LastInsertId()
 }
+
+func (c Client) Select(query string, args ...interface{}) (rows *sql.Rows, err error) {
+	if c.db == nil {
+		return nil, errors.New(ErrorClientConnectionNotInitialized)
+	}
+	rows, err = c.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -20,34 +20,43 @@ package server
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/vitessio/arewefastyet/go/tools/microbench"
+	"log"
 	"net/http"
 )
 
-func informationHandler(c *gin.Context) {
+func (s *Server) informationHandler(c *gin.Context) {
 	c.HTML(http.StatusOK, "information.tmpl", gin.H{
 		"title": "Vitess benchmark",
 	})
 }
 
-func homeHanlder(c *gin.Context) {
+func (s *Server) homeHanlder(c *gin.Context) {
 	c.HTML(http.StatusOK, "index.tmpl", gin.H{
 		"title": "Vitess benchmark",
 	})
 }
 
-func searchCompareHandler(c *gin.Context) {
+func (s *Server) searchCompareHandler(c *gin.Context) {
 	c.HTML(http.StatusOK, "search_compare.tmpl", gin.H{
 		"title": "Vitess benchmark",
 	})
 }
 
-func requestBenchmarkHandler(c *gin.Context) {
+func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 	c.HTML(http.StatusOK, "request_benchmark.tmpl", gin.H{
 		"title": "Vitess benchmark",
 	})
 }
 
-func microbenchmarkResultsHandler(c *gin.Context) {
+func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
+	mrs, err := microbench.GetResultsForGitRef("36110d81be87fdd11e0626eeff529ce67df27661", s.dbClient)
+	if err != nil {
+		log.Println(err)
+	}
+	mrs = mrs.ReduceSimpleMedian()
+	log.Println(mrs)
+
 	c.HTML(http.StatusOK, "microbench.tmpl", gin.H{
 		"title": "Vitess benchmark - microbenchmark s",
 	})

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/tools/microbench"
 	"log"
 	"net/http"
+	"sort"
 )
 
 func (s *Server) informationHandler(c *gin.Context) {
@@ -51,7 +52,7 @@ func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 
 func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	// get current results
-	currentSHA := "36110d81be87fdd11e0626eeff529ce67df27661"
+	currentSHA := "92584e9bf60f354a6b980717c86a336465ab0354"
 	currentMbd, err := microbench.GetResultsForGitRef(currentSHA, s.dbClient)
 	if err != nil {
 		log.Println(err)
@@ -70,6 +71,10 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 
 	matrix := microbench.MergeMicroBenchmarkDetails(currentMbd, lastReleaseMbd)
 
+	sort.SliceStable(matrix, func(i, j int) bool {
+		return !(matrix[i].Current.NSPerOp < matrix[j].Current.NSPerOp)
+	})
+	
 	c.HTML(http.StatusOK, "microbench.tmpl", gin.H{
 		"title":          "Vitess benchmark - microbenchmark",
 		"currentSHA":     currentSHA,

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -50,14 +50,30 @@ func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 }
 
 func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
-	mrs, err := microbench.GetResultsForGitRef("36110d81be87fdd11e0626eeff529ce67df27661", s.dbClient)
+	// get current results
+	currentSHA := "36110d81be87fdd11e0626eeff529ce67df27661"
+	currentMbd, err := microbench.GetResultsForGitRef(currentSHA, s.dbClient)
 	if err != nil {
 		log.Println(err)
+		return
 	}
-	mrs = mrs.ReduceSimpleMedian()
-	log.Println(mrs)
+	currentMbd = currentMbd.ReduceSimpleMedian()
+
+	// get last release results
+	lastReleaseSHA := "daa60859822ff85ce18e2d10c61a27b7797ec6b8"
+	lastReleaseMbd, err := microbench.GetResultsForGitRef(lastReleaseSHA, s.dbClient)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	lastReleaseMbd = lastReleaseMbd.ReduceSimpleMedian()
+
+	matrix := microbench.MergeMicroBenchmarkDetails(currentMbd, lastReleaseMbd)
 
 	c.HTML(http.StatusOK, "microbench.tmpl", gin.H{
-		"title": "Vitess benchmark - microbenchmark s",
+		"title":          "Vitess benchmark - microbenchmark",
+		"currentSHA":     currentSHA,
+		"lastReleaseSHA": lastReleaseSHA,
+		"resultMatrix":   matrix,
 	})
 }

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -52,7 +52,7 @@ func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 
 func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	// get current results
-	currentSHA := "92584e9bf60f354a6b980717c86a336465ab0354"
+	currentSHA := "92584e9bf60f354a6b980717c86a336465ab0354" // todo: dynamic value
 	currentMbd, err := microbench.GetResultsForGitRef(currentSHA, s.dbClient)
 	if err != nil {
 		log.Println(err)
@@ -61,7 +61,7 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	currentMbd = currentMbd.ReduceSimpleMedian()
 
 	// get last release results
-	lastReleaseSHA := "daa60859822ff85ce18e2d10c61a27b7797ec6b8"
+	lastReleaseSHA := "daa60859822ff85ce18e2d10c61a27b7797ec6b8" // todo: dynamic value
 	lastReleaseMbd, err := microbench.GetResultsForGitRef(lastReleaseSHA, s.dbClient)
 	if err != nil {
 		log.Println(err)

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -52,7 +52,11 @@ func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 
 func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	// get current results
-	currentSHA := "92584e9bf60f354a6b980717c86a336465ab0354" // todo: dynamic value
+	currentSHA := c.Query("csh")
+	if currentSHA == "" {
+		// https://github.com/vitessio/vitess/commit/92584e9bf60f354a6b980717c86a336465ab0354
+		currentSHA = "92584e9bf60f354a6b980717c86a336465ab0354" // todo: dynamic value
+	}
 	currentMbd, err := microbench.GetResultsForGitRef(currentSHA, s.dbClient)
 	if err != nil {
 		log.Println(err)
@@ -61,7 +65,11 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	currentMbd = currentMbd.ReduceSimpleMedian()
 
 	// get last release results
-	lastReleaseSHA := "daa60859822ff85ce18e2d10c61a27b7797ec6b8" // todo: dynamic value
+	lastReleaseSHA := c.Query("lrsh")
+	if lastReleaseSHA == "" {
+		// https://github.com/vitessio/vitess/commit/daa60859822ff85ce18e2d10c61a27b7797ec6b8
+		lastReleaseSHA = "daa60859822ff85ce18e2d10c61a27b7797ec6b8" // todo: dynamic value
+	}
 	lastReleaseMbd, err := microbench.GetResultsForGitRef(lastReleaseSHA, s.dbClient)
 	if err != nil {
 		log.Println(err)
@@ -70,7 +78,6 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	lastReleaseMbd = lastReleaseMbd.ReduceSimpleMedian()
 
 	matrix := microbench.MergeMicroBenchmarkDetails(currentMbd, lastReleaseMbd)
-
 	sort.SliceStable(matrix, func(i, j int) bool {
 		return !(matrix[i].Current.NSPerOp < matrix[j].Current.NSPerOp)
 	})

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -46,3 +46,9 @@ func requestBenchmarkHandler(c *gin.Context) {
 		"title": "Vitess benchmark",
 	})
 }
+
+func microbenchmarkResultsHandler(c *gin.Context) {
+	c.HTML(http.StatusOK, "microbench.tmpl", gin.H{
+		"title": "Vitess benchmark - microbenchmark s",
+	})
+}

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func informationHandler(c *gin.Context) {
+	c.HTML(http.StatusOK, "information.tmpl", gin.H{
+		"title": "Vitess benchmark",
+	})
+}
+
+func homeHanlder(c *gin.Context) {
+	c.HTML(http.StatusOK, "index.tmpl", gin.H{
+		"title": "Vitess benchmark",
+	})
+}
+
+func searchCompareHandler(c *gin.Context) {
+	c.HTML(http.StatusOK, "search_compare.tmpl", gin.H{
+		"title": "Vitess benchmark",
+	})
+}
+
+func requestBenchmarkHandler(c *gin.Context) {
+	c.HTML(http.StatusOK, "request_benchmark.tmpl", gin.H{
+		"title": "Vitess benchmark",
+	})
+}

--- a/go/server/mysql.go
+++ b/go/server/mysql.go
@@ -1,0 +1,35 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package server
+
+import "github.com/vitessio/arewefastyet/go/mysql"
+
+func (s *Server) setupMySQL() (err error) {
+	if s.dbCfg == nil {
+		return nil
+	}
+
+	if s.dbCfg.IsValid() {
+		s.dbClient, err = mysql.New(*s.dbCfg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vitessio/arewefastyet/go/mysql"
-	"net/http"
 )
 
 const (
@@ -58,32 +57,16 @@ func (s *Server) Run() error {
 	s.router.LoadHTMLGlob(s.templatePath + "/*")
 
 	// Information page
-	s.router.GET("/information", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "information.tmpl", gin.H{
-			"title": "Vitess benchmark",
-		})
-	})
+	s.router.GET("/information", informationHandler)
 
 	// Home page
-	s.router.GET("/", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "index.tmpl", gin.H{
-			"title": "Vitess benchmark",
-		})
-	})
+	s.router.GET("/", homeHanlder)
+
+	// Search and compare page
+	s.router.GET("/search_compare", searchCompareHandler)
 
 	// Request benchmark page
-	s.router.GET("/search_compare", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "search_compare.tmpl", gin.H{
-			"title": "Vitess benchmark",
-		})
-	})
-
-	// Request benchmark page
-	s.router.GET("/request_benchmark", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "request_benchmark.tmpl", gin.H{
-			"title": "Vitess benchmark",
-		})
-	})
+	s.router.GET("/request_benchmark", requestBenchmarkHandler)
 
 	return s.router.Run(":" + s.port)
 }

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	apiKey       string
 	router       *gin.Engine
 	dbCfg        *mysql.ConfigDB
+	dbClient     *mysql.Client
 }
 
 func (s *Server) AddToCommand(cmd *cobra.Command) {
@@ -50,7 +51,13 @@ func (s Server) isReady() bool {
 func (s *Server) Run() error {
 	if s.isReady() == false {
 		return errors.New(ErrorIncorrectConfiguration)
+
 	}
+
+	if err := s.setupMySQL(); err != nil {
+		return err
+	}
+
 	s.router = gin.Default()
 	s.router.Static("/static", s.staticPath)
 
@@ -67,6 +74,9 @@ func (s *Server) Run() error {
 
 	// Request benchmark page
 	s.router.GET("/request_benchmark", requestBenchmarkHandler)
+
+	// Request benchmark page
+	s.router.GET("/microbench", microbenchmarkResultsHandler)
 
 	return s.router.Run(":" + s.port)
 }

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -64,19 +64,19 @@ func (s *Server) Run() error {
 	s.router.LoadHTMLGlob(s.templatePath + "/*")
 
 	// Information page
-	s.router.GET("/information", informationHandler)
+	s.router.GET("/information", s.informationHandler)
 
 	// Home page
-	s.router.GET("/", homeHanlder)
+	s.router.GET("/", s.homeHanlder)
 
 	// Search and compare page
-	s.router.GET("/search_compare", searchCompareHandler)
+	s.router.GET("/search_compare", s.searchCompareHandler)
 
 	// Request benchmark page
-	s.router.GET("/request_benchmark", requestBenchmarkHandler)
+	s.router.GET("/request_benchmark", s.requestBenchmarkHandler)
 
 	// Request benchmark page
-	s.router.GET("/microbench", microbenchmarkResultsHandler)
+	s.router.GET("/microbench", s.microbenchmarkResultsHandler)
 
 	return s.router.Run(":" + s.port)
 }

--- a/go/server/templates/index.tmpl
+++ b/go/server/templates/index.tmpl
@@ -6,34 +6,8 @@
 <body>
   <!-- Loader for home page only -->
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-      <div class="container">
-        <a class="navbar-brand" href="/"><img src="https://vitess.io/img/logos/vitess.png" style="height:2rem" />
-          Benchmark</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive"
-          aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-item active">
-              <a class="nav-link" href="/">Home
-                <span class="sr-only">(current)</span>
-              </a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/information">Information</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/search_compare">Search or Compare</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/request_benchmark">Request Benchmark Run</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+    {{ template "navigation" "/" }}
+
 
     <!--------------------------------------------------------------------------- OLTP ---------------------------------------------------------------------------------------------->
 

--- a/go/server/templates/information.tmpl
+++ b/go/server/templates/information.tmpl
@@ -6,34 +6,7 @@
 <body>
 
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-        <div class="container">
-            <a class="navbar-brand" href="/"><img src="https://vitess.io/img/logos/vitess.png" style="height:2rem" />
-                Benchmark</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive"
-                aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <ul class="navbar-nav ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/">Home</a>
-                    </li>
-                    <li class="nav-item active">
-                        <a class="nav-link" href="/information">Information
-                            <span class="sr-only">(current)</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/search_compare">Search or Compare</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/request_benchmark">Request Benchmark Run</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
+    {{ template "navigation" "/information" }}
 
     <!--------------------------------------------------------------------------- Information ---------------------------------------------------------------------------------------------->
 
@@ -54,7 +27,7 @@
             <br>- 1x 3.8TB NVME
             <br>- 384GB RAM
             <br>- 2x 10Gbps</p>
-
+        </div>
     </section>
 
     <hr style="background:black">

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -13,26 +13,28 @@
     <section class="py-5">
         <div class="container">
             <h1>Microbenchmarks</h1>
-            <p class="lead"></p>
+            <p class="lead">Displaying results for commit hash {{ .currentSHA }}</p>
+            <a href="https://github.com/vitessio/vitess/commit/{{ .currentSHA }}" target="_blank">See commit on GitHub.</a>
         </div>
 
         <div class="container">
-            <table class="table">
+            <table class="table table-striped table-hover table-sm table-bordered">
                 <thead>
-                <tr>
-                    <th scope="col">#</th>
-                    <th scope="col">First</th>
-                    <th scope="col">Last</th>
-                    <th scope="col">Handle</th>
-                </tr>
+                    <tr>
+                        <th scope="col">Package</th>
+                        <th scope="col">Benchmark Name</th>
+                        <th scope="col" colspan="2" class="text-center">nanosecond/op</th>
+                    </tr>
                 </thead>
                 <tbody>
-                <tr>
-                    <th scope="row">1</th>
-                    <td>Mark</td>
-                    <td>Otto</td>
-                    <td>@mdo</td>
-                </tr>
+                {{range $val := .resultMatrix}}
+                    <tr>
+                        <td>{{ $val.PkgName }}</td>
+                        <td><a href="https://github.com/vitessio/vitess/search?q={{ $val.Name }}&type=code" target="_blank">{{ $val.Name }}</a></td>
+                        <td class="text-right">{{ $val.Current.NSPerOp }}</td>
+                        <td class="text-right">{{ $val.Last.NSPerOp }}</td>
+                    </tr>
+                {{end}}
                 </tbody>
             </table>
         </div>

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -34,8 +34,8 @@
                         <td><a href="https://github.com/vitessio/vitess/search?q={{ $val.Name }}&type=code" target="_blank">{{ $val.Name }}</a></td>
                         <td class="text-right">{{ $val.Current.Ops }}</td>
                         <td class="text-right">{{ $val.Last.Ops }}</td>
-                        <td class="text-right">{{ $val.Current.NSPerOp }}</td>
-                        <td class="text-right">{{ $val.Last.NSPerOp }}</td>
+                        <td class="text-right">{{ printf "%.2f" $val.Current.NSPerOp }}</td>
+                        <td class="text-right">{{ printf "%.2f" $val.Last.NSPerOp }}</td>
                     </tr>
                 {{end}}
                 </tbody>

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -34,7 +34,7 @@
                         <td><a href="https://github.com/vitessio/vitess/search?q={{ $val.Name }}&type=code" target="_blank">{{ $val.Name }}</a></td>
                         <td class="text-right">{{ $val.Current.Ops }}</td>
                         <td class="text-right">{{ $val.Last.Ops }}</td>
-                        <td class="text-right">{{ printf "%.2f" $val.Current.NSPerOp }}</td>
+                        <td class="text-right {{if lt $val.Current.NSPerOp $val.Last.NSPerOp }} bg-success {{ else if ge $val.Current.NSPerOp $val.Last.NSPerOp }} bg-danger {{ end }}">{{ printf "%.2f" $val.Current.NSPerOp }}</td>
                         <td class="text-right">{{ printf "%.2f" $val.Last.NSPerOp }}</td>
                     </tr>
                 {{end}}

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -23,6 +23,7 @@
                     <tr>
                         <th scope="col">Package</th>
                         <th scope="col">Benchmark Name</th>
+                        <th scope="col" colspan="2" class="text-center">number of iterations</th>
                         <th scope="col" colspan="2" class="text-center">nanosecond/op</th>
                     </tr>
                 </thead>
@@ -31,6 +32,8 @@
                     <tr>
                         <td>{{ $val.PkgName }}</td>
                         <td><a href="https://github.com/vitessio/vitess/search?q={{ $val.Name }}&type=code" target="_blank">{{ $val.Name }}</a></td>
+                        <td class="text-right">{{ $val.Current.Ops }}</td>
+                        <td class="text-right">{{ $val.Last.Ops }}</td>
                         <td class="text-right">{{ $val.Current.NSPerOp }}</td>
                         <td class="text-right">{{ $val.Last.NSPerOp }}</td>
                     </tr>

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -17,7 +17,7 @@
             <a href="https://github.com/vitessio/vitess/commit/{{ .currentSHA }}" target="_blank">See commit on GitHub.</a>
         </div>
 
-        <div class="container">
+        <div class="container-xl">
             <table class="table table-striped table-hover table-sm table-bordered">
                 <thead>
                     <tr>
@@ -25,6 +25,9 @@
                         <th scope="col">Benchmark Name</th>
                         <th scope="col" colspan="2" class="text-center">number of iterations</th>
                         <th scope="col" colspan="2" class="text-center">nanosecond/op</th>
+                        <th scope="col" colspan="2" class="text-center">B/op</th>
+                        <th scope="col" colspan="2" class="text-center">MB/s</th>
+                        <th scope="col" colspan="2" class="text-center">Allocs/op</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -34,8 +37,18 @@
                         <td><a href="https://github.com/vitessio/vitess/search?q={{ $val.Name }}&type=code" target="_blank">{{ $val.Name }}</a></td>
                         <td class="text-right">{{ $val.Current.Ops }}</td>
                         <td class="text-right">{{ $val.Last.Ops }}</td>
-                        <td class="text-right {{if lt $val.Current.NSPerOp $val.Last.NSPerOp }} bg-success {{ else if ge $val.Current.NSPerOp $val.Last.NSPerOp }} bg-danger {{ end }}">{{ printf "%.2f" $val.Current.NSPerOp }}</td>
+
+                        <td class="text-right {{if le $val.CurrLastDiff 0.90 }} bg-success {{ else if ge $val.CurrLastDiff 1.10 }} bg-danger {{ end }}">{{ printf "%.2f" $val.Current.NSPerOp }}</td>
                         <td class="text-right">{{ printf "%.2f" $val.Last.NSPerOp }}</td>
+
+                        <td class="text-right">{{ printf "%.2f" $val.Current.MBPerSec }}</td>
+                        <td class="text-right">{{ printf "%.2f" $val.Last.MBPerSec }}</td>
+
+                        <td class="text-right">{{ printf "%.2f" $val.Current.BytesPerOp }}</td>
+                        <td class="text-right">{{ printf "%.2f" $val.Last.BytesPerOp }}</td>
+
+                        <td class="text-right">{{ printf "%.2f" $val.Current.AllocsPerOp }}</td>
+                        <td class="text-right">{{ printf "%.0f" $val.Last.AllocsPerOp }}</td>
                     </tr>
                 {{end}}
                 </tbody>

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+{{template "headHTML" .}}
+
+<body>
+
+    <!-- Navigation -->
+    {{ template "navigation" "/microbench" }}
+
+    <!--------------------------------------------------------------------------- Information ---------------------------------------------------------------------------------------------->
+
+    <section class="py-5">
+        <div class="container">
+            <h1>Microbenchmarks</h1>
+            <p class="lead"></p>
+        </div>
+
+        <div class="container">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">First</th>
+                    <th scope="col">Last</th>
+                    <th scope="col">Handle</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <th scope="row">1</th>
+                    <td>Mark</td>
+                    <td>Otto</td>
+                    <td>@mdo</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    {{template "footerHTML" .}}
+
+</body>
+
+</html>

--- a/go/server/templates/navigation.tmpl
+++ b/go/server/templates/navigation.tmpl
@@ -1,0 +1,67 @@
+<!--
+  ~ /*
+  ~ Copyright 2021 The Vitess Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ */
+  -->
+
+
+{{ define "navigation" }}
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container">
+        <a class="navbar-brand" href="/"><img src="https://vitess.io/img/logos/vitess.png" style="height:2rem" />
+            Benchmark
+        </a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarResponsive">
+            <ul class="navbar-nav ml-auto">
+                <li class="nav-item {{if eq . `/`}} active {{end}}">
+                    <a class="nav-link" href="/">
+                        Home
+                        {{ if eq . "/" }}
+                            <span class="sr-only">(current)</span>
+                        {{ end }}
+                    </a>
+                </li>
+                <li class="nav-item {{if eq . `/information`}} active {{end}}">
+                    <a class="nav-link" href="/information">
+                        Information
+                        {{ if eq . "/information" }}
+                            <span class="sr-only">(current)</span>
+                        {{ end }}
+                    </a>
+                </li>
+                <li class="nav-item {{if eq . `/search_compare`}} active {{end}}">
+                    <a class="nav-link" href="/search_compare">
+                        Search or Compare
+                        {{ if eq . "/search_compare" }}
+                            <span class="sr-only">(current)</span>
+                        {{ end }}
+                    </a>
+                </li>
+                <li class="nav-item {{if eq . `/request_benchmark`}} active {{end}}">
+                    <a class="nav-link" href="/request_benchmark">
+                        Request Benchmark Run
+                        {{ if eq . "/request_benchmark" }}
+                            <span class="sr-only">(current)</span>
+                        {{ end }}
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+{{ end }}

--- a/go/server/templates/navigation.tmpl
+++ b/go/server/templates/navigation.tmpl
@@ -60,6 +60,14 @@
                         {{ end }}
                     </a>
                 </li>
+                <li class="nav-item {{if eq . `/microbench`}} active {{end}}">
+                    <a class="nav-link" href="/microbench">
+                        Microbenchmarks
+                        {{ if eq . "/microbench" }}
+                        <span class="sr-only">(current)</span>
+                        {{ end }}
+                    </a>
+                </li>
             </ul>
         </div>
     </div>

--- a/go/server/templates/request_benchmark.tmpl
+++ b/go/server/templates/request_benchmark.tmpl
@@ -6,34 +6,8 @@
 <body>
 
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-        <div class="container">
-            <a class="navbar-brand" href="/"><img src="https://vitess.io/img/logos/vitess.png" style="height:2rem" />
-                Benchmark</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive"
-                aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <ul class="navbar-nav ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/">Home
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/information">Information</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/search_compare">Search or Compare</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link active" href="/request_benchmark">Request Benchmark Run</a>
-                        <span class="sr-only">(current)</span>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
+    {{ template "navigation" "/request_benchmark" }}
+
 
     <section class="py-5">
         <div class="container">

--- a/go/server/templates/search_compare.tmpl
+++ b/go/server/templates/search_compare.tmpl
@@ -6,34 +6,7 @@
 <body>
 
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-        <div class="container">
-            <a class="navbar-brand" href="/"><img src="https://vitess.io/img/logos/vitess.png" style="height:2rem" />
-                Benchmark</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive"
-                aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <ul class="navbar-nav ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/">Home
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/information">Information</a>
-                    </li>
-                    <li class="nav-item active">
-                        <a class="nav-link" href="/search_compare">Search or Compare</a>
-                        <span class="sr-only">(current)</span>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/request_benchmark">Request Benchmark Run</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
+    {{ template "navigation" "/search_compare" }}
 
 <!--------------------------------------------------------------------------- SEARCH USING COMMIT HASH ---------------------------------------------------------------------------------------------->
 

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -86,8 +86,8 @@ func MergeMicroBenchmarkDetails(currentMbd, lastReleaseMbd MicroBenchmarkDetails
 }
 
 func (mbd MicroBenchmarkDetailsArray) ReduceSimpleMedian() (reduceMbd MicroBenchmarkDetailsArray) {
-	sort.Slice(mbd, func(i, j int) bool {
-		return mbd[i].PkgName < mbd[j].PkgName && mbd[i].Name < mbd[j].Name
+	sort.SliceStable(mbd, func(i, j int) bool {
+		return mbd[i].PkgName < mbd[j].PkgName || mbd[i].Name < mbd[j].Name
 	})
 	for i := 0; i < len(mbd); {
 		var j int

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -44,6 +44,9 @@ type (
 	MicroBenchmarkComparison struct {
 		BenchmarkId
 		Current, Last MicroBenchmarkResult
+
+		// Difference of NSPerOp in % for Current and Last
+		CurrLastDiff float64
 	}
 
 	MicroBenchmarkDetailsArray    []MicroBenchmarkDetails
@@ -80,9 +83,11 @@ func MergeMicroBenchmarkDetails(currentMbd, lastReleaseMbd MicroBenchmarkDetails
 		var compareMb MicroBenchmarkComparison
 		compareMb.BenchmarkId = details.BenchmarkId
 		compareMb.Current = details.Result
+		compareMb.CurrLastDiff = 1.00
 		for j := 0; j < len(lastReleaseMbd); j++ {
 			if lastReleaseMbd[j].BenchmarkId == details.BenchmarkId {
 				compareMb.Last = lastReleaseMbd[j].Result
+				compareMb.CurrLastDiff = compareMb.Current.NSPerOp / compareMb.Last.NSPerOp
 				break
 			}
 		}

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -1,0 +1,83 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package microbench
+
+import (
+	"github.com/vitessio/arewefastyet/go/mysql"
+	"sort"
+)
+
+type MicroBenchmarkResult struct {
+	PkgName string
+	Name string
+	NSPerOp float64
+}
+
+type MicroBenchmarkResults []MicroBenchmarkResult
+
+func (mrs MicroBenchmarkResults) ReduceSimpleMedian() MicroBenchmarkResults {
+	var results MicroBenchmarkResults
+
+	sort.Slice(mrs, func(i, j int) bool {
+		return mrs[i].PkgName < mrs[i].PkgName && mrs[i].Name < mrs[j].Name
+	})
+	for i := 0; i < len(mrs); {
+		var j int
+		var interNSPerOp []float64
+		for j = i; j < len(mrs) && mrs[i].Name == mrs[j].Name; j++ {
+			interNSPerOp = append(interNSPerOp, mrs[j].NSPerOp)
+		}
+
+		sort.Float64s(interNSPerOp)
+		var interNSPerOpResult float64
+		middle := len(interNSPerOp) / 2
+		if len(interNSPerOp) % 2 == 1 {
+			interNSPerOpResult = interNSPerOp[middle]
+		} else {
+			interNSPerOpResult = (interNSPerOp[middle - 1] + interNSPerOp[middle]) / 2
+		}
+
+		results = append(results, MicroBenchmarkResult{
+			PkgName: mrs[i].PkgName,
+			Name:    mrs[i].Name,
+			NSPerOp: interNSPerOpResult,
+		})
+		i = j
+	}
+	return results
+}
+
+func GetResultsForGitRef(ref string, client *mysql.Client) (mrs MicroBenchmarkResults, err error) {
+	rows, err := client.Select("select m.pkg_name, m.name, md.ns_per_op FROM " +
+		"microbenchmark m, microbenchmark_details  md where m.git_ref = ? AND " +
+		"md.microbenchmark_no = m.microbenchmark_no order by m.microbenchmark_no desc;", ref)
+	if err != nil {
+		return nil, err
+	}
+
+	for rows.Next() {
+		var res MicroBenchmarkResult
+		err = rows.Scan(&res.PkgName, &res.Name, &res.NSPerOp)
+		if err != nil {
+			return nil, err
+		}
+		mrs = append(mrs, res)
+	}
+	return mrs, nil
+}

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -47,6 +47,28 @@ type (
 	MicroBenchmarkComparisonArray []MicroBenchmarkComparison
 )
 
+func NewMicroBenchmarkDetails(benchmarkId BenchmarkId, gitRef string, result MicroBenchmarkResult) *MicroBenchmarkDetails {
+	return &MicroBenchmarkDetails{
+		BenchmarkId: benchmarkId,
+		GitRef: gitRef,
+		Result: result,
+	}
+}
+
+func NewBenchmarkId(pkgName string, name string) *BenchmarkId {
+	return &BenchmarkId{
+		PkgName: pkgName,
+		Name: name,
+	}
+}
+
+func NewMicroBenchmarkResult(ops int, NSPerOp float64) *MicroBenchmarkResult {
+	return &MicroBenchmarkResult{
+		Ops: ops,
+		NSPerOp: NSPerOp,
+	}
+}
+
 func MergeMicroBenchmarkDetails(currDetails, lastDetails MicroBenchmarkDetailsArray) MicroBenchmarkComparisonArray {
 	var comparisons MicroBenchmarkComparisonArray
 

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -93,7 +93,10 @@ func MergeMicroBenchmarkDetails(currentMbd, lastReleaseMbd MicroBenchmarkDetails
 
 func (mbd MicroBenchmarkDetailsArray) ReduceSimpleMedian() (reduceMbd MicroBenchmarkDetailsArray) {
 	sort.SliceStable(mbd, func(i, j int) bool {
-		return mbd[i].PkgName < mbd[j].PkgName || mbd[i].Name < mbd[j].Name
+		return mbd[i].Name < mbd[j].Name
+	})
+	sort.SliceStable(mbd, func(i, j int) bool {
+		return mbd[i].PkgName < mbd[j].PkgName
 	})
 	for i := 0; i < len(mbd); {
 		var j int

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -42,9 +42,28 @@ type (
 		BenchmarkId
 		Current, Last MicroBenchmarkResult
 	}
+
+	MicroBenchmarkDetailsArray    []MicroBenchmarkDetails
+	MicroBenchmarkComparisonArray []MicroBenchmarkComparison
 )
 
-type MicroBenchmarkDetailsArray []MicroBenchmarkDetails
+func MergeMicroBenchmarkDetails(currDetails, lastDetails MicroBenchmarkDetailsArray) MicroBenchmarkComparisonArray {
+	var comparisons MicroBenchmarkComparisonArray
+
+	for _, details := range currDetails {
+		var comparison MicroBenchmarkComparison
+		comparison.BenchmarkId = details.BenchmarkId
+		comparison.Current = details.Result
+		for j := 0; j < len(lastDetails); j++ {
+			if lastDetails[j].BenchmarkId == details.BenchmarkId {
+				comparison.Last = lastDetails[j].Result
+				break
+			}
+		}
+		comparisons = append(comparisons, comparison)
+	}
+	return comparisons
+}
 
 func (mrs MicroBenchmarkDetailsArray) ReduceSimpleMedian() MicroBenchmarkDetailsArray {
 	var details MicroBenchmarkDetailsArray
@@ -69,10 +88,10 @@ func (mrs MicroBenchmarkDetailsArray) ReduceSimpleMedian() MicroBenchmarkDetails
 		details = append(details, MicroBenchmarkDetails{
 			BenchmarkId: BenchmarkId{
 				PkgName: mrs[i].PkgName,
-				Name: mrs[i].Name,
+				Name:    mrs[i].Name,
 			},
-			GitRef:      mrs[i].GitRef,
-			Result:      MicroBenchmarkResult{
+			GitRef: mrs[i].GitRef,
+			Result: MicroBenchmarkResult{
 				Ops:     interOpsResult,
 				NSPerOp: interNSPerOpResult,
 			},

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -26,64 +26,84 @@ import (
 func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 	tests := []struct {
 		name string
-		mrs  MicroBenchmarkResults
-		want MicroBenchmarkResults
+		mrs  MicroBenchmarkDetailsArray
+		want MicroBenchmarkDetailsArray
 	}{
 		// tc1
-		{name: "Few simple values in same package but different benchmark names", mrs: MicroBenchmarkResults{
+		{name: "Few simple values in same package but different benchmark names", mrs: MicroBenchmarkDetailsArray{
 			// input bench 1
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
 
 			// input bench 2
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
-		}, want: MicroBenchmarkResults{
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
+		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
 
 			// want bench 2
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
 		}},
 
 		// tc2
-		{name: "Few values in different packages and different benchmark names", mrs: MicroBenchmarkResults{
+		{name: "Few values in different packages and different benchmark names", mrs: MicroBenchmarkDetailsArray{
 			// input bench 1 in pkg 1
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 5.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 10.00, Name: "bench1-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 10.00 }},
 
 			// input bench 1 in pkg 2
-			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 2.00, Name: "bench1-pkg2"},
-			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 2.50, Name: "bench1-pkg2"},
-			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 3.00, Name: "bench1-pkg2"},
-		}, want: MicroBenchmarkResults{
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 2.50 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 3.00 }},
+		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1 from pkg1
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 5.00, Name: "bench1-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
 
 			// want bench 1 from pkg2
-			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 2.50, Name: "bench1-pkg2"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 2.50 }},
 		}},
 
 		// tc3
-		{name: "More unordered values with single package and benchmark name", mrs: MicroBenchmarkResults{
+		{name: "More unordered values with single package and benchmark name", mrs: MicroBenchmarkDetailsArray{
 			// input bench 1
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 30.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 5.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 15.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 10.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 40.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 25.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 20.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 0.00, Name: "bench1-pkg1"},
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 35.00, Name: "bench1-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 30.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 15.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 10.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 40.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 25.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 20.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 0.00 }},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 35.00 }},
 
-		}, want: MicroBenchmarkResults{
+		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 20.00, Name: "bench1-pkg1"},
+			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 20.00 }},
 		}},
+
+		// tc4
+		// {name: "Verify ordering by names", mrs: MicroBenchmarkDetailsArray{
+		// 	// input bench 2
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+		//
+		// 	// input bench 1
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+		//
+		// }, want: MicroBenchmarkResults{
+		// 	// want bench 1
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+		//
+		// 	// want bench 2
+		// 	MicroBenchmarkDetails{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+		// }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -32,57 +32,56 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 		// tc1
 		{name: "Few simple values in same package but different benchmark names", mrs: MicroBenchmarkDetailsArray{
 			// input bench 1
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 
 			// input bench 2
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 
 			// want bench 2
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
 		}},
 
 		// tc2
 		{name: "Few values in different packages and different benchmark names", mrs: MicroBenchmarkDetailsArray{
 			// input bench 1 in pkg 1
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 10.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 10.00)),
 
 			// input bench 1 in pkg 2
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 2.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 2.50 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 3.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.50)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 3.00)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1 from pkg1
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
 
 			// want bench 1 from pkg2
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"} , Result: MicroBenchmarkResult{NSPerOp: 2.50 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.50)),
 		}},
 
 		// tc3
 		{name: "More unordered values with single package and benchmark name", mrs: MicroBenchmarkDetailsArray{
 			// input bench 1
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 30.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 15.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 10.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 40.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 25.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 20.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 0.00 }},
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 35.00 }},
-
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 30.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 15.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 10.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 40.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 25.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 20.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 0.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 35.00)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 20.00 }},
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 20.00)),
 		}},
 	}
 	for _, tt := range tests {
@@ -92,6 +91,30 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 			got := tt.mrs.ReduceSimpleMedian()
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})
+	}
+}
+
+func BenchmarkReduceSimpleMedian(b *testing.B) {
+	mrs := MicroBenchmarkDetailsArray{
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		got := mrs.ReduceSimpleMedian()
+
+		// Must be reduced to two indexes (bench1-pkg1 AND bench2-pkg1).
+		if len(got) != 2 {
+			b.Error("must be reduced to two elements")
+		}
+		if got[0].Result.NSPerOp != 1.00 || got[1].Result.NSPerOp != 2.00 {
+			b.Error("wrong output from ReduceSimpleMedian")
+		}
 	}
 }
 
@@ -106,30 +129,48 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 		want MicroBenchmarkComparisonArray
 	}{
 		// tc1
-		{name: "Simple compare with array of one elements", args: args{
+		{name: "Simple compare with ordered array of one elements", args: args{
 			currDetails: MicroBenchmarkDetailsArray{
-				MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 			},
 			lastDetails: MicroBenchmarkDetailsArray{
-				MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}},
 		}},
 
 		// tc2
-		{name: "Simple compare with array of two elements", args: args{
+		{name: "Simple compare with ordered array of two elements", args: args{
 			currDetails: MicroBenchmarkDetailsArray{
-				MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 1.00 }},
-				MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 98.00 }},
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 98.00)),
 			},
 			lastDetails: MicroBenchmarkDetailsArray{
-				MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 5.00 }},
-				MicroBenchmarkDetails{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"} , Result: MicroBenchmarkResult{NSPerOp: 89.00 }},
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 89.00)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 98.00}, Last: MicroBenchmarkResult{NSPerOp: 89.00}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
+		}},
+
+		// tc3
+		{name: "Compare with unordered array", args: args{
+			currDetails: MicroBenchmarkDetailsArray{
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
+			},
+			lastDetails: MicroBenchmarkDetailsArray{
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
+			},
+		}, want: MicroBenchmarkComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00), Last: *NewMicroBenchmarkResult(0, 56.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
 		}},
 	}
 	for _, tt := range tests {

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -137,7 +137,7 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}, CurrLastDiff: 0.2},
 		}},
 
 		// tc2
@@ -151,8 +151,8 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 0.2},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 1.101123595505618},
 		}},
 
 		// tc3
@@ -168,9 +168,9 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 1.0357142857142858},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 0.2},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 1.101123595505618},
 		}},
 
 		// tc4
@@ -192,12 +192,12 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 1.0357142857142858},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 0.2},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 1.101123595505618},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0), CurrLastDiff: 0.5833333333333334},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 1.1904761904761905},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0), CurrLastDiff: 0.931640625},
 		}},
 
 		// tc5
@@ -217,12 +217,12 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 1.0357142857142858},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 0.2},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 1.101123595505618},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0, 0, 0, 0), CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 1.1904761904761905},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0), CurrLastDiff: 1},
 		}},
 	}
 	for _, tt := range tests {

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -26,11 +26,11 @@ import (
 func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 	tests := []struct {
 		name string
-		mrs  MicroBenchmarkDetailsArray
+		mbd  MicroBenchmarkDetailsArray
 		want MicroBenchmarkDetailsArray
 	}{
 		// tc1
-		{name: "Few simple values in same package but different benchmark names", mrs: MicroBenchmarkDetailsArray{
+		{name: "Few simple values in same package but different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
 			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
@@ -49,7 +49,7 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 		}},
 
 		// tc2
-		{name: "Few values in different packages and different benchmark names", mrs: MicroBenchmarkDetailsArray{
+		{name: "Few values in different packages and different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1 in pkg 1
 			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
@@ -68,7 +68,7 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 		}},
 
 		// tc3
-		{name: "More unordered values with single package and benchmark name", mrs: MicroBenchmarkDetailsArray{
+		{name: "More unordered values with single package and benchmark name", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
 			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 30.00)),
 			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
@@ -88,14 +88,14 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			got := tt.mrs.ReduceSimpleMedian()
+			got := tt.mbd.ReduceSimpleMedian()
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})
 	}
 }
 
 func BenchmarkReduceSimpleMedian(b *testing.B) {
-	mrs := MicroBenchmarkDetailsArray{
+	mbd := MicroBenchmarkDetailsArray{
 		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
@@ -106,7 +106,7 @@ func BenchmarkReduceSimpleMedian(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		got := mrs.ReduceSimpleMedian()
+		got := mbd.ReduceSimpleMedian()
 
 		// Must be reduced to two indexes (bench1-pkg1 AND bench2-pkg1).
 		if len(got) != 2 {
@@ -120,8 +120,8 @@ func BenchmarkReduceSimpleMedian(b *testing.B) {
 
 func TestMergeMicroBenchmarkDetails(t *testing.T) {
 	type args struct {
-		currDetails MicroBenchmarkDetailsArray
-		lastDetails MicroBenchmarkDetailsArray
+		currentMbd     MicroBenchmarkDetailsArray
+		lastReleaseMbd MicroBenchmarkDetailsArray
 	}
 	tests := []struct {
 		name string
@@ -130,10 +130,10 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 	}{
 		// tc1
 		{name: "Simple compare with ordered array of one elements", args: args{
-			currDetails: MicroBenchmarkDetailsArray{
+			currentMbd: MicroBenchmarkDetailsArray{
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 			},
-			lastDetails: MicroBenchmarkDetailsArray{
+			lastReleaseMbd: MicroBenchmarkDetailsArray{
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
@@ -142,11 +142,11 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 
 		// tc2
 		{name: "Simple compare with ordered array of two elements", args: args{
-			currDetails: MicroBenchmarkDetailsArray{
+			currentMbd: MicroBenchmarkDetailsArray{
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 98.00)),
 			},
-			lastDetails: MicroBenchmarkDetailsArray{
+			lastReleaseMbd: MicroBenchmarkDetailsArray{
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 89.00)),
 			},
@@ -157,12 +157,12 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 
 		// tc3
 		{name: "Compare with unordered array", args: args{
-			currDetails: MicroBenchmarkDetailsArray{
+			currentMbd: MicroBenchmarkDetailsArray{
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
 			},
-			lastDetails: MicroBenchmarkDetailsArray{
+			lastReleaseMbd: MicroBenchmarkDetailsArray{
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
 				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
@@ -177,7 +177,7 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			got := MergeMicroBenchmarkDetails(tt.args.currDetails, tt.args.lastDetails)
+			got := MergeMicroBenchmarkDetails(tt.args.currentMbd, tt.args.lastReleaseMbd)
 			c.Assert(got, qt.HasLen, len(tt.want))
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -32,56 +32,56 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 		// tc1
 		{name: "Few simple values in same package but different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
 
 			// input bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
 
 			// want bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
 		}},
 
 		// tc2
 		{name: "Few values in different packages and different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1 in pkg 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 10.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
 
 			// input bench 1 in pkg 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.50)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 3.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1 from pkg1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
 
 			// want bench 1 from pkg2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.50)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
 		}},
 
 		// tc3
 		{name: "More unordered values with single package and benchmark name", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 30.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 15.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 10.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 40.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 25.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 20.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 0.00)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 35.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 20.00)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
 		}},
 	}
 	for _, tt := range tests {
@@ -96,12 +96,12 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 
 func BenchmarkReduceSimpleMedian(b *testing.B) {
 	mbd := MicroBenchmarkDetailsArray{
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
 	}
 
 	b.ReportAllocs()
@@ -131,10 +131,10 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 		// tc1
 		{name: "Simple compare with ordered array of one elements", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}},
@@ -143,86 +143,86 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 		// tc2
 		{name: "Simple compare with ordered array of two elements", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 98.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 89.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
 		}},
 
 		// tc3
 		{name: "Compare with unordered array", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00), Last: *NewMicroBenchmarkResult(0, 56.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
 		}},
 
 		// tc4
 		{name: "Compare with unordered array from multiple package", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 3.50)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2385.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2560.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 6.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00), Last: *NewMicroBenchmarkResult(0, 56.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50), Last: *NewMicroBenchmarkResult(0, 6.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00), Last: *NewMicroBenchmarkResult(0, 4.20)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00), Last: *NewMicroBenchmarkResult(0, 2560.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0)},
 		}},
 
 		// tc5
 		{name: "Compare with unordered and different size array from multiple package", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 3.50)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2385.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00), Last: *NewMicroBenchmarkResult(0, 56.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50), Last: *NewMicroBenchmarkResult(0, 0)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00), Last: *NewMicroBenchmarkResult(0, 4.20)},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00), Last: *NewMicroBenchmarkResult(0, 0.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)},
 		}},
 	}
 	for _, tt := range tests {

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package microbench
+
+import (
+	qt "github.com/frankban/quicktest"
+	"testing"
+)
+
+func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
+	tests := []struct {
+		name string
+		mrs  MicroBenchmarkResults
+		want MicroBenchmarkResults
+	}{
+		// tc1
+		{name: "Few simple values in same package but different benchmark names", mrs: MicroBenchmarkResults{
+			// input bench 1
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+
+			// input bench 2
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+		}, want: MicroBenchmarkResults{
+			// want bench 1
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+
+			// want bench 2
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 2.00, Name: "bench2-pkg1"},
+		}},
+
+		// tc2
+		{name: "Few values in different packages and different benchmark names", mrs: MicroBenchmarkResults{
+			// input bench 1 in pkg 1
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 1.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 5.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 10.00, Name: "bench1-pkg1"},
+
+			// input bench 1 in pkg 2
+			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 2.00, Name: "bench1-pkg2"},
+			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 2.50, Name: "bench1-pkg2"},
+			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 3.00, Name: "bench1-pkg2"},
+		}, want: MicroBenchmarkResults{
+			// want bench 1 from pkg1
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 5.00, Name: "bench1-pkg1"},
+
+			// want bench 1 from pkg2
+			MicroBenchmarkResult{PkgName: "pkg2", NSPerOp: 2.50, Name: "bench1-pkg2"},
+		}},
+
+		// tc3
+		{name: "More unordered values with single package and benchmark name", mrs: MicroBenchmarkResults{
+			// input bench 1
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 30.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 5.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 15.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 10.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 40.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 25.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 20.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 0.00, Name: "bench1-pkg1"},
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 35.00, Name: "bench1-pkg1"},
+
+		}, want: MicroBenchmarkResults{
+			// want bench 1
+			MicroBenchmarkResult{PkgName: "pkg1", NSPerOp: 20.00, Name: "bench1-pkg1"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got := tt.mrs.ReduceSimpleMedian()
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -172,6 +172,58 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
 		}},
+
+		// tc4
+		{name: "Compare with unordered array from multiple package", args: args{
+			currentMbd: MicroBenchmarkDetailsArray{
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 3.50)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2385.00)),
+			},
+			lastReleaseMbd: MicroBenchmarkDetailsArray{
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2560.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 6.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20)),
+			},
+		}, want: MicroBenchmarkComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00), Last: *NewMicroBenchmarkResult(0, 56.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50), Last: *NewMicroBenchmarkResult(0, 6.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00), Last: *NewMicroBenchmarkResult(0, 4.20)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00), Last: *NewMicroBenchmarkResult(0, 2560.00)},
+		}},
+
+		// tc5
+		{name: "Compare with unordered and different size array from multiple package", args: args{
+			currentMbd: MicroBenchmarkDetailsArray{
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 58.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 1.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", *NewMicroBenchmarkResult(0, 98.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 3.50)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", *NewMicroBenchmarkResult(0, 2385.00)),
+			},
+			lastReleaseMbd: MicroBenchmarkDetailsArray{
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 89.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 56.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", *NewMicroBenchmarkResult(0, 5.00)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", *NewMicroBenchmarkResult(0, 4.20)),
+			},
+		}, want: MicroBenchmarkComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00), Last: *NewMicroBenchmarkResult(0, 56.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00), Last: *NewMicroBenchmarkResult(0, 5.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00), Last: *NewMicroBenchmarkResult(0, 89.00)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50), Last: *NewMicroBenchmarkResult(0, 0)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00), Last: *NewMicroBenchmarkResult(0, 4.20)},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00), Last: *NewMicroBenchmarkResult(0, 0.00)},
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request adds a template to the UI allowing us to visualize microbenchmarks' results. A new set of functions and structures are added to the `microbench` package to allow computation of results.

## UI

In the picture below we can see the new template with a table, which was truncated in this picture. Each column showing results (`nanosecond/op`, `B/op`, ...) are divided into two sub-columns, the left one is the commit SHA for which we want to see the results, the right one is the results from another commit SHA. In this example, it refers to the V9.0.0 version.

For demonstration purposes, the commit SHA can be modified through the URL using parameters `csh` (current SHA) and `lrsh` (last release SHA).

The red and green respectively show if we have a lower or higher performance. The threshold was manually configured to 10% but aims to be easily configurable in the future.

![image](https://user-images.githubusercontent.com/35779988/112477321-29625e00-8d73-11eb-89ae-5ffaa1a4229b.png) 

## How to run

```sh
go build ./go/main.go
./main --config ./config/config.yaml web
```

Resolves #79 and #62.