### PR TITLE
Destroy terraform infrastructure after running an exec command

### DIFF
--- a/go/cmd/exec/exec.go
+++ b/go/cmd/exec/exec.go
@@ -45,6 +45,10 @@ func ExecCmd() *cobra.Command {
 				return err
 			}
 
+			// cleanup
+			if err := ex.CleanUp(); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -67,6 +67,8 @@ func (e *Exec) Execute() error {
 	return nil
 }
 
+// CleanUp cleans and removes all things required only during the execution flow
+// and not after it is done.
 func (e Exec) CleanUp() error {
 	err := e.Infra.CleanUp()
 	if err != nil {

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -67,6 +67,14 @@ func (e *Exec) Execute() error {
 	return nil
 }
 
+func (e Exec) CleanUp() error {
+	err := e.Infra.CleanUp()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func NewExec() (*Exec, error) {
 	// todo: dynamic choice for infra provider
 	inf, err := construct.NewInfra(equinix.Name)

--- a/go/infra/equinix/equinix.go
+++ b/go/infra/equinix/equinix.go
@@ -63,6 +63,22 @@ func (e Equinix) TerraformVarArray() (vars []*tfexec.VarOption) {
 	return vars
 }
 
+func (e *Equinix) CleanUp() error {
+	if e.tf != nil {
+		return fmt.Errorf("%s: equinix terraform not prepared", infra.ErrorInvalidConfiguration)
+	}
+	destroyOpts := &[]tfexec.DestroyOption{}
+	if err := infra.PopulateTfOption(e.TerraformVarArray(), destroyOpts); err != nil {
+		return fmt.Errorf("%s: %s", infra.ErrorProvision, err.Error())
+	}
+
+	err := e.tf.Destroy(context.Background())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (e Equinix) Create(wantOutputs ...string) (output map[string]string, err error) {
 	if e.tf == nil {
 		return nil, fmt.Errorf("%s: equinix terraform not prepared", infra.ErrorInvalidConfiguration)

--- a/go/infra/equinix/equinix.go
+++ b/go/infra/equinix/equinix.go
@@ -63,8 +63,9 @@ func (e Equinix) TerraformVarArray() (vars []*tfexec.VarOption) {
 	return vars
 }
 
+// CleanUp destroys the infrastructure provisioned by terraform.
 func (e *Equinix) CleanUp() error {
-	if e.tf != nil {
+	if e.tf == nil {
 		return fmt.Errorf("%s: equinix terraform not prepared", infra.ErrorInvalidConfiguration)
 	}
 	destroyOpts := &[]tfexec.DestroyOption{}
@@ -72,7 +73,7 @@ func (e *Equinix) CleanUp() error {
 		return fmt.Errorf("%s: %s", infra.ErrorProvision, err.Error())
 	}
 
-	err := e.tf.Destroy(context.Background())
+	err := e.tf.Destroy(context.Background(), *destroyOpts...)
 	if err != nil {
 		return err
 	}

--- a/go/infra/infra.go
+++ b/go/infra/infra.go
@@ -35,6 +35,7 @@ const (
 
 type Infra interface {
 	AddToCommand(cmd *cobra.Command)
+	CleanUp() error
 	Create(wantOutputs ...string) (output map[string]string, err error)
 	ValidConfig() error
 	Prepare() error
@@ -63,6 +64,10 @@ func PopulateTfOption(vars []*tfexec.VarOption, opts interface{}) error {
 			*optsT = append(*optsT, varValue)
 		}
 	case *[]tfexec.ApplyOption:
+		for _, varValue := range vars {
+			*optsT = append(*optsT, varValue)
+		}
+	case *[]tfexec.DestroyOption:
 		for _, varValue := range vars {
 			*optsT = append(*optsT, varValue)
 		}

--- a/go/infra/infra_test.go
+++ b/go/infra/infra_test.go
@@ -36,6 +36,7 @@ func TestPopulateTfOption(t *testing.T) {
 	}{
 		{name: "PlanOption with a single var", args: args{vars: []*tfexec.VarOption{tfexec.Var("auth_token=token")}, opts: &[]tfexec.PlanOption{}}, wantErr: false},
 		{name: "ApplyOption with a single var", args: args{vars: []*tfexec.VarOption{tfexec.Var("amb=false")}, opts: &[]tfexec.ApplyOption{}}, wantErr: false},
+		{name: "DestroyOption with a single var", args: args{vars: []*tfexec.VarOption{tfexec.Var("amb=false")}, opts: &[]tfexec.DestroyOption{}}, wantErr: false},
 		{name: "Invalid opts type", args: args{vars: []*tfexec.VarOption{tfexec.Var("import=true")}, opts: &[]tfexec.ImportOption{}}, wantErr: true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Resolves #99 by adding a `CleanUp` method to both the `Exec` struct and the `Infra` interface. In both places, the method will be responsible for cleaning up the post-execution.

The code in the pull request handle the destruction of the infrastructure.