### PR TITLE
New math package

### DIFF
--- a/go/tools/math/median.go
+++ b/go/tools/math/median.go
@@ -21,13 +21,13 @@ package math
 import "sort"
 
 // MedianInt computes the median of the given int array.
-func MedianInt(values []int) int {
+func MedianInt(values []int) float64 {
 	sort.Ints(values)
 	middle := len(values) / 2
 	if len(values)%2 == 1 {
-		return values[middle]
+		return float64(values[middle])
 	}
-	return (values[middle-1] + values[middle]) / 2
+	return float64(values[middle-1] + values[middle]) / 2
 }
 
 // MedianFloat computes the median of the given float64 array.

--- a/go/tools/math/median.go
+++ b/go/tools/math/median.go
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package math
+
+import "sort"
+
+// MedianInt computes the median of the given int array.
+func MedianInt(values []int) int {
+	sort.Ints(values)
+	middle := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[middle]
+	}
+	return (values[middle-1] + values[middle]) / 2
+}
+
+// MedianFloat computes the median of the given float64 array.
+func MedianFloat(values []float64) float64 {
+	sort.Float64s(values)
+	middle := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[middle]
+	}
+	return (values[middle-1] + values[middle]) / 2
+}

--- a/go/tools/math/median_test.go
+++ b/go/tools/math/median_test.go
@@ -1,0 +1,74 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package math
+
+import (
+	qt "github.com/frankban/quicktest"
+	"testing"
+)
+
+func TestMedianFloat(t *testing.T) {
+	tests := []struct {
+		name string
+		arr []float64
+		want float64
+	}{
+		{name: "Single element array", arr: []float64{5.00}, want: 5.00},
+		{name: "Two elements array", arr: []float64{5.00, 10.00}, want: 7.50},
+
+		{name: "Odd number of elements array (1)", arr: []float64{1.00, 3.00, 5.00, 10.00, 11.00}, want: 5.00},
+		{name: "Odd number of elements array (2)", arr: []float64{1, 20.5, 45.3, 78.1, 90.5}, want: 45.3},
+		{name: "Odd number of elements in unordered array", arr: []float64{78.1, 1, 90.5, 20.5, 45.3}, want: 45.3},
+
+		{name: "Even number of elements array", arr: []float64{4.5, 6.79, 55.3, 78, 86, 110.99}, want: 66.65},
+		{name: "Even number of elements in unordered array", arr: []float64{86, 4.5, 78, 6.79, 55.3, 110.99}, want: 66.65},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := MedianFloat(tt.arr)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestMedianInt(t *testing.T) {
+	tests := []struct {
+		name string
+		arr []int
+		want float64
+	}{
+		{name: "Single element array", arr: []int{5}, want: 5},
+		{name: "Two elements array", arr: []int{5.00, 10.00}, want: 7.5},
+
+		{name: "Odd number of elements array (1)", arr: []int{1, 3, 5, 10, 11}, want: 5.00},
+		{name: "Odd number of elements array (2)", arr: []int{1, 20, 45, 78, 90}, want: 45},
+		{name: "Odd number of elements in unordered array", arr: []int{78, 1, 90, 20, 45}, want: 45},
+
+		{name: "Even number of elements array", arr: []int{4, 6, 55, 78, 86, 110}, want: 66.5},
+		{name: "Even number of elements in unordered array", arr: []int{86, 4, 78, 6, 55, 110}, want: 66.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := MedianInt(tt.arr)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -136,12 +136,7 @@ func (mbd MicroBenchmarkDetailsArray) ReduceSimpleMedian() (reduceMbd MicroBench
 			interAllocsPerOp = append(interAllocsPerOp, mbd[j].Result.AllocsPerOp)
 		}
 
-		sort.Ints(interOps)
-		sort.Float64s(interNSPerOp)
-		sort.Float64s(interMBPerSec)
-		sort.Float64s(interBytesPerOp)
-		sort.Float64s(interAllocsPerOp)
-		interOpsResult := math.MedianInt(interOps)
+		interOpsResult := int(math.MedianInt(interOps))
 		interNSPerOpResult := math.MedianFloat(interNSPerOp)
 		interMBPerSecResult := math.MedianFloat(interMBPerSec)
 		interBytesPerOpResult := math.MedianFloat(interBytesPerOp)

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -21,6 +21,7 @@ package microbench
 import (
 	"github.com/dustin/go-humanize"
 	"github.com/vitessio/arewefastyet/go/mysql"
+	"github.com/vitessio/arewefastyet/go/tools/math"
 	"sort"
 )
 
@@ -140,11 +141,11 @@ func (mbd MicroBenchmarkDetailsArray) ReduceSimpleMedian() (reduceMbd MicroBench
 		sort.Float64s(interMBPerSec)
 		sort.Float64s(interBytesPerOp)
 		sort.Float64s(interAllocsPerOp)
-		interOpsResult := medianInt(interOps)
-		interNSPerOpResult := medianFloat(interNSPerOp)
-		interMBPerSecResult := medianFloat(interMBPerSec)
-		interBytesPerOpResult := medianFloat(interBytesPerOp)
-		interAllocsPerOpResult := medianFloat(interAllocsPerOp)
+		interOpsResult := math.MedianInt(interOps)
+		interNSPerOpResult := math.MedianFloat(interNSPerOp)
+		interMBPerSecResult := math.MedianFloat(interMBPerSec)
+		interBytesPerOpResult := math.MedianFloat(interBytesPerOp)
+		interAllocsPerOpResult := math.MedianFloat(interAllocsPerOp)
 		reduceMbd = append(reduceMbd, *NewMicroBenchmarkDetails(
 			*NewBenchmarkId(mbd[i].PkgName, mbd[i].Name),
 			mbd[i].GitRef,
@@ -153,22 +154,6 @@ func (mbd MicroBenchmarkDetailsArray) ReduceSimpleMedian() (reduceMbd MicroBench
 		i = j
 	}
 	return reduceMbd
-}
-
-func medianInt(values []int) int {
-	middle := len(values) / 2
-	if len(values)%2 == 1 {
-		return values[middle]
-	}
-	return (values[middle-1] + values[middle]) / 2
-}
-
-func medianFloat(values []float64) float64 {
-	middle := len(values) / 2
-	if len(values)%2 == 1 {
-		return values[middle]
-	}
-	return (values[middle-1] + values[middle]) / 2
 }
 
 // GetResultsForGitRef will fetch and return a MicroBenchmarkDetailsArray

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -32,20 +32,20 @@ func TestMicroBenchmarkResults_ReduceSimpleMedian(t *testing.T) {
 		// tc1
 		{name: "Few simple values in same package but different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
 
 			// input bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
 
 			// want bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
 		}},
 
 		// tc2


### PR DESCRIPTION
### Description

Previously, we integrated two functions that compute the median of integer/float arrays. These functions were added in the `go/tools/microbench` package inside the `results.go` file since we were using them only from there.

This pull request removes those two functions from the `go/tools/microbench` package and exports them inside the new `go/tools/math` package.

### Why do we need this

This change is required to respect DRY principle and enhance our testing policy.

### Implementation

Originally, the two functions' signatures were:

```go
func medianFloat(values []float64) float64
```
```go
func medianInt(values []int) int
```

Though, during testing, I realized that returning `int` for `medianInt` was incorrect, we need to return `float64` and let the caller cast or not the value to an `int`. Thus, the newly updated signatures are:

```go
func MedianFloat(values []float64) float64
```
```go
func MedianInt(values []int) float64 
```

Moreover, sorting the array was originally done before calling the functions. This was replaced by sorting the array directly inside the callees.