### PR TITLE
Addition of unit test and go mod tidy to GitHub Actions workflow

### DIFF
--- a/.github/workflows/golang_build.yaml
+++ b/.github/workflows/golang_build.yaml
@@ -1,0 +1,19 @@
+name: Golang Build CLI
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    name: Build CLI binary
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Build
+        run: go build ./go/...

--- a/.github/workflows/golang_tidy.yaml
+++ b/.github/workflows/golang_tidy.yaml
@@ -1,0 +1,30 @@
+name: Golang Tidy
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    name: Check go mod tidy
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+
+      # https://github.com/vitessio/vitess/blob/b5177cd4d09f661350137ef46de2bd3e27949d2e/.github/workflows/gomod-tidy.yml#L17-L28
+      - name: Run go mod tidy
+        run: |
+          set -e
+          go mod tidy
+          output=$(git status -s)
+          if [ -z "${output}" ]; then
+           exit 0
+          fi
+          echo 'We wish to maintain a tidy state for go mod. Please run `go mod tidy` on your branch, commit and push again.'
+          echo 'Running `go mod tidy` on this CI test yields with the following changes:'
+          echo "$output"
+          exit 1

--- a/.github/workflows/golang_unit_test.yaml
+++ b/.github/workflows/golang_unit_test.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Golang Unit Tests
+    name: Execute all the unit tests
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/golang_unit_test.yaml
+++ b/.github/workflows/golang_unit_test.yaml
@@ -1,0 +1,19 @@
+name: Golang Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    name: Golang Unit Tests
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Test
+        run: go test -v ./go/...

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,10 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/otiai10/copy v1.5.0 h1:SoXDGnlTUZoqB/wSuj/Y5L6T5i6iN4YRAcMCd+JnLNU=
 github.com/otiai10/copy v1.5.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.2 h1:VYWnrP5fXmz1MXvjuUvcBrXSjGE6xjON+axB/UrpO3E=
 github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
### Description

This pull request proposes three new workflows:

- `Golang Unit Tests`
- `Golang Build CLI`
- `Golang Tidy`

They all aim to validate or invalidate any new golang code that we push. `Golang Unit Tests` runs all the unit tests from the `./go` directory and its subdirectories. `Golang Build CLI` builds the CLI's binary. Finally, `Golang Tidy` will run a go mod tidy and fails if the repository needs to be tidied up.

All workflows are executed on go 1.15.

### Related issue(s)

Resolves #98.