### PR TITLE
Fix: send slack messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,4 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	golang.org/x/tools v0.1.0
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go/slack/config.go
+++ b/go/slack/config.go
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package slack
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	flagToken   = "slack-token"
+	flagChannel = "slack-channel"
+)
+
+type Config struct {
+	Token   string
+	Channel string
+}
+
+func (c *Config) AddToCommand(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&c.Token, flagToken, "", "Token used to authenticate Slack")
+	cmd.Flags().StringVar(&c.Token, flagChannel, "", "Slack channel on which to post messages")
+	
+	_ = viper.BindPFlag(flagToken, cmd.Flags().Lookup(flagToken))
+	_ = viper.BindPFlag(flagChannel, cmd.Flags().Lookup(flagChannel))
+}

--- a/go/slack/config.go
+++ b/go/slack/config.go
@@ -28,15 +28,17 @@ const (
 	flagChannel = "slack-channel"
 )
 
+// Config used for Slack.
 type Config struct {
 	Token   string
 	Channel string
 }
 
+// AddToCommand will add Config's CLI flags to the given *cobra.Command.
 func (c *Config) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.Token, flagToken, "", "Token used to authenticate Slack")
 	cmd.Flags().StringVar(&c.Token, flagChannel, "", "Slack channel on which to post messages")
-	
+
 	_ = viper.BindPFlag(flagToken, cmd.Flags().Lookup(flagToken))
 	_ = viper.BindPFlag(flagChannel, cmd.Flags().Lookup(flagChannel))
 }

--- a/go/slack/config.go
+++ b/go/slack/config.go
@@ -26,6 +26,8 @@ import (
 const (
 	flagToken   = "slack-token"
 	flagChannel = "slack-channel"
+
+	ErrorInvalidConfiguration = "invalid configuration"
 )
 
 // Config used for Slack.
@@ -41,4 +43,8 @@ func (c *Config) AddToCommand(cmd *cobra.Command) {
 
 	_ = viper.BindPFlag(flagToken, cmd.Flags().Lookup(flagToken))
 	_ = viper.BindPFlag(flagChannel, cmd.Flags().Lookup(flagChannel))
+}
+
+func (c Config) IsValid() bool {
+	return !(c.Token == "" || c.Channel == "")
 }

--- a/go/slack/slack.go
+++ b/go/slack/slack.go
@@ -15,7 +15,6 @@ type (
 	}
 
 	TextMessage struct {
-		Title string
 		Content string
 	}
 
@@ -59,5 +58,12 @@ func getFileType(f *FileUploadMessage) {
 }
 
 func (t TextMessage) Send(config Config) (err error) {
-	panic("implement me")
+	api := slack.New(config.Token)
+
+	_, _, err = api.PostMessage(config.Channel, slack.MsgOptionText(t.Content, false))
+
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/go/slack/slack_test.go
+++ b/go/slack/slack_test.go
@@ -59,6 +59,7 @@ func TestFileUploadMessage_Send(t *testing.T) {
 				c.Assert(err, qt.Not(qt.IsNil))
 				return
 			}
+			c.Assert(err, qt.IsNil)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This pull request tries to solve the issue with Slack mentioned in #104. It seems that the issue could be fixable by looking at the Vitess OSS Slack "vitess-benchmark" app configuration.

## Resolution of the issue

The app we were previously using "vitess-benchmark" was deactivated and could not be used. I created a new one "arewefastyet" and added it to Vitess OSS Slack with @askdba. The new OAuth token was then used in the YAML configuration file to authenticate new requests.

The `./go/slack` package underwent slight modifications. Support for Cobra command line was added to the `Config` (previously `config`) struct.

## Configuration

The following fields are appended to the configuration file:

```yaml
slack-token: <your app's token>
slack-channel: <your channel>
```

## Related issues

Fixes #104.