### PR TITLE
Fixed idempotence issue with Vitess Build and Ansible

### DIFF
--- a/ansible/roles/vitess_build/tasks/clean.yml
+++ b/ansible/roles/vitess_build/tasks/clean.yml
@@ -17,16 +17,13 @@
     systemctl stop cell@* || /bin/true
     systemctl stop vtgate@* || /bin/true
   ignore_errors: yes
-  changed_when: false
+  when: clean is defined
 
 - name: Find Elements to remove
   find:
     path: /vt
     file_type: directory
   register: directories
-
-- debug:
-    msg: '{{ directories }}'
 
 - name: Remove Elements
   file:

--- a/ansible/roles/vitess_build/tasks/main.yml
+++ b/ansible/roles/vitess_build/tasks/main.yml
@@ -77,6 +77,12 @@
   ignore_errors: yes
   when: ansible_os_family == 'RedHat'
 
+- name: Check if repo exists
+  become: yes
+  become_user: root
+  stat: path=/go/src/vitess.io/vitess
+  register: vitessrepopath
+
 - name: Update Vitess
   become: yes
   become_user: root
@@ -104,7 +110,6 @@
         export TMPDIR=~/tmp
         cd /go/src/vitess.io/vitess
         make build
-      changed_when: false
 
     - name: Install Vitess Binaries
       shell: |
@@ -117,9 +122,10 @@
       shell: |
         cd /go/src/vitess.io/vitess
         cp bin/vtctl /usr/local/bin/
-      changed_when: false
 
-  when: vtroot is undefined
+  when:
+    - vtroot is undefined
+    - not vitessrepopath.stat.exists
 
 - name: Copy Vitess Binaries
   become: yes


### PR DESCRIPTION
## Description

The issue fixed in this pull request is linked to the idempotence step of `molecule test`. The `Molecule Test vitess_build` workflow started to fail due to the role `vitess_build` not being idempotent. More on that [here](https://github.com/vitessio/arewefastyet/actions/runs/718746242).

The error was the following:
```
--> Action: 'idempotence'
ERROR: 
PLAY [Converge] ****************************************************************
An error occurred during the test sequence action: 'idempotence'. Cleaning up.
```

## Fix

The fix is a new condition on the block of tasks where we fetch Vitess's repository and build its binaries. The condition checks if the repository already exists in the system. Doing so allows us to skip unnecessary steps and thus making the role idempotent.