### PR TITLE
Add a macro benchmark command

### DIFF
--- a/ansible/macrobench.yml
+++ b/ansible/macrobench.yml
@@ -20,12 +20,15 @@
 - hosts: etcd
   roles:
     - etcd
+
 - hosts: vtctld
   roles:
     - vtctld
+
 - hosts: vtgate
   roles:
     - vtgate
+
 - hosts: vttablet
   roles:
     - vttablet
@@ -161,3 +164,7 @@
       shell: |
         vtctlclient -server {{ groups['vtctld'][0] }}:15999 ApplyVSchema -vschema="$(cat /tmp/vschema_sysbench.json)" main
       when: tpcc is defined
+
+- hosts: macrobench
+  roles:
+    - macrobench

--- a/ansible/macrobench_sharded_inventory.yml
+++ b/ansible/macrobench_sharded_inventory.yml
@@ -1,0 +1,100 @@
+# Copyright 2021 The Vitess Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+all:
+  hosts:
+    DEVICE_IP_0:
+      storage_device:
+        device: nvme0n1
+        partition: nvme0n1p1
+  vars:
+    vitess_git_version: "HEAD"
+    arewefastyet_git_repo: "https://github.com/frouioui/arewefastyet.git"
+    arewefastyet_git_version: "macrobench-cmd"
+    macrobenchmark_vschema: "./vitess-benchmark/sysbench.json"
+    macrobenchmarks_local_config: "LOCAL_CONFIG_PATH_0"
+    cell: local
+    keyspace: main
+    provision: 1
+  children:
+    macrobench:
+      hosts:
+        DEVICE_IP_0:
+    sysbench:
+      hosts:
+        DEVICE_IP_0:
+    prometheus:
+      hosts:
+        DEVICE_IP_0:
+    etcd:
+      hosts:
+        DEVICE_IP_0:
+    vtctld:
+      hosts:
+        DEVICE_IP_0:
+    vtgate:
+      vars:
+        vtgate_query_cache_size: 1000
+        vtgate_max_goproc: 6
+      hosts:
+        DEVICE_IP_0:
+          gateways:
+            - id: 1
+              port: 15001
+              mysql_port: 13306
+              grpc_port: 15306
+            - id: 2
+              port: 15002
+              mysql_port: 13307
+              grpc_port: 15307
+            - id: 3
+              port: 15003
+              mysql_port: 13308
+              grpc_port: 15308
+            - id: 4
+              port: 15004
+              mysql_port: 13309
+              grpc_port: 15309
+            - id: 5
+              port: 15005
+              mysql_port: 13310
+              grpc_port: 15310
+            - id: 6
+              port: 15006
+              mysql_port: 13311
+              grpc_port: 15311
+    vttablet:
+      vars:
+        vitess_memory_ratio: 0.6
+        vttablet_query_cache_size: 10000
+        vttablet_max_goproc: 24
+      hosts:
+        DEVICE_IP_0:
+          tablets:
+            - id: 1001
+              keyspace: main
+              shard: -80
+              pool_size: 500
+              transaction_cap: 2000
+              port: 16001
+              grpc_port: 17001
+              mysql_port: 18001
+              mysqld_exporter_port: 9104
+            - id: 2001
+              keyspace: main
+              shard: 80-
+              pool_size: 500
+              transaction_cap: 2000
+              port: 16002
+              grpc_port: 17002
+              mysql_port: 18002
+              mysqld_exporter_port: 9105

--- a/ansible/macrobench_unsharded_inventory.yml
+++ b/ansible/macrobench_unsharded_inventory.yml
@@ -1,0 +1,71 @@
+# Copyright 2021 The Vitess Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+all:
+  hosts:
+    DEVICE_IP_0:
+      storage_device:
+        device: nvme0n1
+        partition: nvme0n1p1
+  vars:
+    vitess_git_version: "HEAD"
+    arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
+    arewefastyet_git_version: "HEAD"
+    macrobenchmark_vschema: "./vitess-benchmark/sysbench.json"
+    macrobenchmarks_local_config: "LOCAL_CONFIG_PATH_0"
+    cell: local
+    keyspace: main
+    provision: 1
+  children:
+    macrobench:
+      hosts:
+        DEVICE_IP_0:
+    sysbench:
+      hosts:
+        DEVICE_IP_0:
+    prometheus:
+      hosts:
+        DEVICE_IP_0:
+    etcd:
+      hosts:
+        DEVICE_IP_0:
+    vtctld:
+      hosts:
+        DEVICE_IP_0:
+    vtgate:
+      vars:
+        vtgate_query_cache_size: 1000
+        vtgate_max_goproc: 6
+      hosts:
+        DEVICE_IP_0:
+          gateways:
+            - id: 1
+              port: 15001
+              mysql_port: 13306
+              grpc_port: 15306
+            - id: 2
+              port: 15002
+              mysql_port: 13307
+              grpc_port: 15307
+    vttablet:
+      vars:
+        vitess_memory_ratio: 0.6
+        vttablet_query_cache_size: 10000
+        vttablet_max_goproc: 24
+      hosts:
+        DEVICE_IP_0:
+          tablets:
+            - id: 1001
+              keyspace: main
+              shard: 0
+              pool_size: 500
+              transaction_cap: 2000

--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -1,0 +1,47 @@
+# Copyright 2021 The Vitess Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Install arewefastyet
+  become: yes
+  become_user: root
+  block:
+    - name: git clone arewefastyet
+      git:
+        repo: "{{ arewefastyet_git_repo }}"
+        dest: /go/src/github.com/vitessio/arewefastyet
+        version: "{{ arewefastyet_git_version }}"
+        refspec: "{{ arewefastyet_git_version_fetch_pr if arewefastyet_git_version_pr_nb is defined | default('') }}"
+        force: true
+
+    - name: Build arewefastyet CLI
+      shell: |
+        cd /go/src/github.com/vitessio/arewefastyet
+        go build -o arewefastyetcli ./go/main.go
+      changed_when: false
+
+    - name: Install arewefastyet CLI
+      shell: |
+        cd /go/src/github.com/vitessio/arewefastyet
+        cp arewefastyetcli /usr/bin/arewefastyetcli
+      changed_when: false
+
+- name: Get macrobenchmarks config.yaml
+  ansible.builtin.copy:
+    src: "{{ macrobenchmarks_local_config }}"
+    dest: /tmp/config.yaml
+    mode: '0644'
+
+- name: Run macrobenchmarks
+  shell: |
+    arewefastyetcli macrobench run --config /tmp/config.yaml
+  register: arewefastyetcli
+  changed_when: False

--- a/ansible/roles/sysbench/tasks/main.yml
+++ b/ansible/roles/sysbench/tasks/main.yml
@@ -81,7 +81,7 @@
   changed_when: false
 
 - name: Set up VTGate Loadbalancing
-  shell: iptables -t nat -A OUTPUT -p tcp --dport 3306 -m state --state NEW -m statistic --mode nth --every {{ ((gateways | length) - index) }} --packet 0 -j DNAT --to-destination {{ gateway }}
+  shell: iptables -t nat -A OUTPUT -p tcp --dport 13306 -m state --state NEW -m statistic --mode nth --every {{ ((gateways | length) - index) }} --packet 0 -j DNAT --to-destination {{ gateway }}
   with_items: '{{ gateways }}'
   changed_when: false
   loop_control:

--- a/docs/arewefastyet.md
+++ b/docs/arewefastyet.md
@@ -15,6 +15,7 @@
 * [arewefastyet exec](arewefastyet_exec.md)	 - Execute a task
 * [arewefastyet gen](arewefastyet_gen.md)	 - Generate things
 * [arewefastyet infra](arewefastyet_infra.md)	 - Manage infrastructure
+* [arewefastyet macrobench](arewefastyet_macrobench.md)	 - 
 * [arewefastyet microbench](arewefastyet_microbench.md)	 - 
 * [arewefastyet web](arewefastyet_web.md)	 - Starts the HTTP web server
 

--- a/docs/arewefastyet_macrobench.md
+++ b/docs/arewefastyet_macrobench.md
@@ -1,0 +1,21 @@
+## arewefastyet macrobench
+
+
+
+### Options
+
+```
+  -h, --help   help for macrobench
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+```
+
+### SEE ALSO
+
+* [arewefastyet](arewefastyet.md)	 - 
+* [arewefastyet macrobench run](arewefastyet_macrobench_run.md)	 - 
+

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -19,6 +19,7 @@ arewefastyet macrobench run [flags]
       --macrobench-source string                
       --macrobench-sysbench-executable string   
       --macrobench-type MacroBenchmarkType      
+      --macrobench-working-directory string     
       --macrobench-workload-path string         
 ```
 

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -1,0 +1,24 @@
+## arewefastyet macrobench run
+
+
+
+```
+arewefastyet macrobench run [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for run
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+```
+
+### SEE ALSO
+
+* [arewefastyet macrobench](arewefastyet_macrobench.md)	 - 
+

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -14,13 +14,13 @@ arewefastyet macrobench run [flags]
       --db-password string                      Password to authenticate the database.
       --db-user string                          User used to connect to the database
   -h, --help                                    help for run
-      --macrobench-git-ref string               
-      --macrobench-skip-steps strings           
-      --macrobench-source string                
-      --macrobench-sysbench-executable string   
-      --macrobench-type MacroBenchmarkType      
-      --macrobench-working-directory string     
-      --macrobench-workload-path string         
+      --macrobench-git-ref string               Git SHA referring to the macro benchmark.
+      --macrobench-skip-steps strings           Slice of sysbench steps to skip.
+      --macrobench-source string                The source or origin of the macro benchmark trigger.
+      --macrobench-sysbench-executable string   Path to the sysbench binary.
+      --macrobench-type MacroBenchmarkType      Type of macro benchmark.
+      --macrobench-working-directory string     Directory on which to execute sysbench.
+      --macrobench-workload-path string         Path to the workload used by sysbench.
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -14,6 +14,7 @@ arewefastyet macrobench run [flags]
       --db-password string                      Password to authenticate the database.
       --db-user string                          User used to connect to the database
   -h, --help                                    help for run
+      --macrobench-skip-steps strings           
       --macrobench-sysbench-executable string   
       --macrobench-workload-path string         
 ```

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -14,8 +14,11 @@ arewefastyet macrobench run [flags]
       --db-password string                      Password to authenticate the database.
       --db-user string                          User used to connect to the database
   -h, --help                                    help for run
+      --macrobench-git-ref string               
       --macrobench-skip-steps strings           
+      --macrobench-source string                
       --macrobench-sysbench-executable string   
+      --macrobench-type MacroBenchmarkType      
       --macrobench-workload-path string         
 ```
 

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -9,7 +9,11 @@ arewefastyet macrobench run [flags]
 ### Options
 
 ```
-  -h, --help   help for run
+      --db-database string   Database to use.
+      --db-host string       Hostname of the database
+      --db-password string   Password to authenticate the database.
+      --db-user string       User used to connect to the database
+  -h, --help                 help for run
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -9,11 +9,13 @@ arewefastyet macrobench run [flags]
 ### Options
 
 ```
-      --db-database string   Database to use.
-      --db-host string       Hostname of the database
-      --db-password string   Password to authenticate the database.
-      --db-user string       User used to connect to the database
-  -h, --help                 help for run
+      --db-database string                      Database to use.
+      --db-host string                          Hostname of the database
+      --db-password string                      Password to authenticate the database.
+      --db-user string                          User used to connect to the database
+  -h, --help                                    help for run
+      --macrobench-sysbench-executable string   
+      --macrobench-workload-path string         
 ```
 
 ### Options inherited from parent commands

--- a/go/cmd/macrobench/macrobench.go
+++ b/go/cmd/macrobench/macrobench.go
@@ -1,0 +1,30 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package macrobench
+
+import "github.com/spf13/cobra"
+
+func MacroBenchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "macrobench <command>",
+		Aliases: []string{"mab"},
+	}
+
+	return cmd
+}

--- a/go/cmd/macrobench/run.go
+++ b/go/cmd/macrobench/run.go
@@ -25,14 +25,14 @@ import (
 )
 
 func run() *cobra.Command {
-	mabcfg := macrobench.MacroBenchConfig{
+	mabcfg := macrobench.Config{
 		DatabaseConfig: &mysql.ConfigDB{},
 	}
 
 	cmd := &cobra.Command{
 		Use: "run",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := macrobench.MacroBench(mabcfg)
+			err := macrobench.Run(mabcfg)
 			if err != nil {
 				return err
 			}

--- a/go/cmd/macrobench/run.go
+++ b/go/cmd/macrobench/run.go
@@ -20,13 +20,13 @@ package macrobench
 
 import "github.com/spf13/cobra"
 
-func MacroBenchCmd() *cobra.Command {
+func run() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "macrobench <command>",
-		Aliases: []string{"mab"},
+		Use: "run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// todo: run the macrobench
+			return nil
+		},
 	}
-
-	cmd.AddCommand(run())
-
 	return cmd
 }

--- a/go/cmd/macrobench/run.go
+++ b/go/cmd/macrobench/run.go
@@ -32,11 +32,7 @@ func run() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "run",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := macrobench.Run(mabcfg)
-			if err != nil {
-				return err
-			}
-			return nil
+			return macrobench.Run(mabcfg)
 		},
 	}
 	mabcfg.AddToCommand(cmd)

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/cmd/exec"
 	"github.com/vitessio/arewefastyet/go/cmd/gen"
 	"github.com/vitessio/arewefastyet/go/cmd/infra"
+	"github.com/vitessio/arewefastyet/go/cmd/macrobench"
 	"github.com/vitessio/arewefastyet/go/cmd/microbench"
 	"github.com/vitessio/arewefastyet/go/cmd/web"
 	"log"
@@ -59,6 +60,7 @@ func init() {
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.AddCommand(microbench.MicroBenchCmd())
+	rootCmd.AddCommand(macrobench.MacroBenchCmd())
 	rootCmd.AddCommand(infra.InfraCmd())
 	rootCmd.AddCommand(web.WebCmd())
 	rootCmd.AddCommand(exec.ExecCmd())

--- a/go/server/templates/index.tmpl
+++ b/go/server/templates/index.tmpl
@@ -312,12 +312,12 @@
       others = []
 
       for (var i = 0; i < graph_oltp.length; i++) {
-        data_tps.push(graph_oltp[i].Result.TPS);
-        latency.push(graph_oltp[i].Result.Latency);
-        total.push(graph_oltp[i].Result.Total)
-        reads.push(graph_oltp[i].Result.Reads)
-        writes.push(graph_oltp[i].Result.Writes)
-        others.push(graph_oltp[i].Result.Others)
+        data_tps.push(graph_oltp[i].Result.tps);
+        latency.push(graph_oltp[i].Result.latency);
+        total.push(graph_oltp[i].Result.qps.total)
+        reads.push(graph_oltp[i].Result.qps.reads)
+        writes.push(graph_oltp[i].Result.qps.writes)
+        others.push(graph_oltp[i].Result.qps.others)
 
         label_oltp.push(graph_oltp[i].GitRef + " | " + graph_oltp[i].CreatedAt);
       }
@@ -336,13 +336,14 @@
       writes = []
       others = []
 
+      console.log(graph_tpcc[0])
       for (var i = 0; i < graph_tpcc.length; i++) {
-        data_tps.push(graph_tpcc[i].Result.TPS);
-        latency.push(graph_tpcc[i].Result.Latency);
-        total.push(graph_tpcc[i].Result.Total)
-        reads.push(graph_tpcc[i].Result.Reads)
-        writes.push(graph_tpcc[i].Result.Writes)
-        others.push(graph_tpcc[i].Result.Others)
+        data_tps.push(graph_tpcc[i].Result.tps);
+        latency.push(graph_tpcc[i].Result.latency);
+        total.push(graph_tpcc[i].Result.qps.total)
+        reads.push(graph_tpcc[i].Result.qps.reads)
+        writes.push(graph_tpcc[i].Result.qps.writes)
+        others.push(graph_tpcc[i].Result.qps.others)
 
         label_tpcc.push(graph_tpcc[i].GitRef + " | " + graph_tpcc[i].CreatedAt);
       }

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -107,9 +107,9 @@ func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {
 	}
 }
 
-// InsertBenchmarkToSQL will insert a new row in the benchmark table based on
+// insertBenchmarkToSQL will insert a new row in the benchmark table based on
 // the given MacroBenchConfig. The newly created row's unique ID is returned.
-func (mabcfg MacroBenchConfig) InsertBenchmarkToSQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
+func (mabcfg MacroBenchConfig) insertBenchmarkToSQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
 	if client == nil {
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -21,24 +21,12 @@ package macrobench
 import (
 	"github.com/spf13/cobra"
 	"github.com/vitessio/arewefastyet/go/mysql"
-	"github.com/vitessio/arewefastyet/go/tools/macrobench"
 )
 
-func run() *cobra.Command {
-	mabcfg := macrobench.MacroBenchConfig{
-		DatabaseConfig: &mysql.ConfigDB{},
-	}
+type MacroBenchConfig struct {
+	DatabaseConfig *mysql.ConfigDB
+}
 
-	cmd := &cobra.Command{
-		Use: "run",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			err := macrobench.MacroBench(mabcfg)
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-	}
-	mabcfg.AddToCommand(cmd)
-	return cmd
+func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command)  {
+	mabcfg.DatabaseConfig.AddToCommand(cmd)
 }

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -107,9 +107,9 @@ func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {
 	}
 }
 
-// RegisterNewBenchmarkToMySQL will insert a new row in the benchmark table based on
+// InsertBenchmarkToSQL will insert a new row in the benchmark table based on
 // the given MacroBenchConfig. The newly created row's unique ID is returned.
-func (mabcfg MacroBenchConfig) RegisterNewBenchmarkToMySQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
+func (mabcfg MacroBenchConfig) InsertBenchmarkToSQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
 	if client == nil {
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -33,6 +33,7 @@ type MacroBenchConfig struct {
 	DatabaseConfig *mysql.ConfigDB
 	M              map[string]string
 	SkipSteps      []string
+	Type           MacroBenchmarkType
 }
 
 const (

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -80,13 +80,13 @@ const (
 func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 	mabcfg.DatabaseConfig.AddToCommand(cmd)
 
-	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "")
-	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "")
-	cmd.Flags().StringSliceVar(&mabcfg.SkipSteps, flagSkipSteps, []string{}, "")
-	cmd.Flags().Var(&mabcfg.Type, flagType, "")
-	cmd.Flags().StringVar(&mabcfg.Source, flagSource, "", "")
-	cmd.Flags().StringVar(&mabcfg.GitRef, flagGitRef, "", "")
-	cmd.Flags().StringVar(&mabcfg.WorkingDirectory, flagWorkingDirectory, "", "")
+	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "Path to the workload used by sysbench.")
+	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "Path to the sysbench binary.")
+	cmd.Flags().StringSliceVar(&mabcfg.SkipSteps, flagSkipSteps, []string{}, "Slice of sysbench steps to skip.")
+	cmd.Flags().Var(&mabcfg.Type, flagType, "Type of macro benchmark.")
+	cmd.Flags().StringVar(&mabcfg.Source, flagSource, "", "The source or origin of the macro benchmark trigger.")
+	cmd.Flags().StringVar(&mabcfg.GitRef, flagGitRef, "", "Git SHA referring to the macro benchmark.")
+	cmd.Flags().StringVar(&mabcfg.WorkingDirectory, flagWorkingDirectory, "", "Directory on which to execute sysbench.")
 
 	_ = viper.BindPFlag(flagSysbenchPath, cmd.Flags().Lookup(flagSysbenchPath))
 	_ = viper.BindPFlag(flagSysbenchExecutable, cmd.Flags().Lookup(flagSysbenchExecutable))

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -26,14 +26,14 @@ import (
 	"strings"
 )
 
-// MacroBenchConfig defines a configuration used to execute macro benchmark.
-// For instance, the MacroBench method uses MacroBenchConfig.
-type MacroBenchConfig struct {
+// Config defines a configuration used to execute macro benchmark.
+// For instance, the Run method uses MacroBenchConfig.
+type Config struct {
 	// SysbenchExec defines the path to sysbench binary
-	SysbenchExec   string
+	SysbenchExec string
 
 	// WorkloadPath defines the path to the lua file used by sysbench.
-	WorkloadPath   string
+	WorkloadPath string
 
 	// DatabaseConfig points to the required configuration to create
 	// a *mysql.Client. If no configuration, results and reports will
@@ -42,14 +42,14 @@ type MacroBenchConfig struct {
 
 	// M contains all metadata used to parameter sysbench execution.
 	// This key value map stores the value of each CLI parameters.
-	M              map[string]string
+	M map[string]string
 
 	// SkipSteps is a slice of string that is used to skip some of
 	// sysbench steps.
-	SkipSteps      []string
+	SkipSteps []string
 
 	// Type will be used to differentiate macro benchmarks.
-	Type           MacroBenchmarkType
+	Type MacroBenchmarkType
 
 	// Source defines from where the macro benchmark is triggered.
 	// This field is used to distinguish runs triggered by webhooks,
@@ -77,7 +77,7 @@ const (
 
 // AddToCommand will add the different CLI flags used by MacroBenchConfig into
 // the given *cobra.Command.
-func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
+func (mabcfg *Config) AddToCommand(cmd *cobra.Command) {
 	mabcfg.DatabaseConfig.AddToCommand(cmd)
 
 	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "Path to the workload used by sysbench.")
@@ -97,7 +97,7 @@ func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagWorkingDirectory, cmd.Flags().Lookup(flagWorkingDirectory))
 }
 
-func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {
+func (mabcfg *Config) parseIntoMap(prefix string) {
 	mabcfg.M = map[string]string{}
 	keys := viper.AllKeys()
 	for _, key := range keys {
@@ -109,7 +109,7 @@ func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {
 
 // insertBenchmarkToSQL will insert a new row in the benchmark table based on
 // the given MacroBenchConfig. The newly created row's unique ID is returned.
-func (mabcfg MacroBenchConfig) insertBenchmarkToSQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
+func (mabcfg Config) insertBenchmarkToSQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
 	if client == nil {
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -30,11 +30,13 @@ type MacroBenchConfig struct {
 	WorkloadPath   string
 	DatabaseConfig *mysql.ConfigDB
 	M              map[string]string
+	SkipSteps      []string
 }
 
 const (
 	flagSysbenchExecutable = "macrobench-sysbench-executable"
 	flagSysbenchPath       = "macrobench-workload-path"
+	flagSkipSteps          = "macrobench-skip-steps"
 )
 
 func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
@@ -42,9 +44,11 @@ func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "")
 	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "")
+	cmd.Flags().StringSliceVar(&mabcfg.SkipSteps, flagSkipSteps, []string{}, "")
 
 	_ = viper.BindPFlag(flagSysbenchPath, cmd.Flags().Lookup(flagSysbenchPath))
 	_ = viper.BindPFlag(flagSysbenchExecutable, cmd.Flags().Lookup(flagSysbenchExecutable))
+	_ = viper.BindPFlag(flagSkipSteps, cmd.Flags().Lookup(flagSkipSteps))
 }
 
 func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -44,6 +44,10 @@ type MacroBenchConfig struct {
 	// GitRef refers to the commit SHA pointing to the version
 	// of Vitess that we are currently macro benchmarking.
 	GitRef string
+
+	// WorkingDirectory defines from where sysbench commands will be executed.
+	// This parameter
+	WorkingDirectory string
 }
 
 const (
@@ -53,6 +57,7 @@ const (
 	flagType               = "macrobench-type"
 	flagSource             = "macrobench-source"
 	flagGitRef             = "macrobench-git-ref"
+	flagWorkingDirectory   = "macrobench-working-directory"
 )
 
 // AddToCommand will add the different CLI flags used by MacroBenchConfig into
@@ -66,6 +71,7 @@ func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().Var(&mabcfg.Type, flagType, "")
 	cmd.Flags().StringVar(&mabcfg.Source, flagSource, "", "")
 	cmd.Flags().StringVar(&mabcfg.GitRef, flagGitRef, "", "")
+	cmd.Flags().StringVar(&mabcfg.WorkingDirectory, flagWorkingDirectory, "", "")
 
 	_ = viper.BindPFlag(flagSysbenchPath, cmd.Flags().Lookup(flagSysbenchPath))
 	_ = viper.BindPFlag(flagSysbenchExecutable, cmd.Flags().Lookup(flagSysbenchExecutable))
@@ -73,6 +79,7 @@ func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagType, cmd.Flags().Lookup(flagType))
 	_ = viper.BindPFlag(flagSource, cmd.Flags().Lookup(flagSource))
 	_ = viper.BindPFlag(flagGitRef, cmd.Flags().Lookup(flagGitRef))
+	_ = viper.BindPFlag(flagWorkingDirectory, cmd.Flags().Lookup(flagWorkingDirectory))
 }
 
 func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -29,11 +29,26 @@ import (
 // MacroBenchConfig defines a configuration used to execute macro benchmark.
 // For instance, the MacroBench method uses MacroBenchConfig.
 type MacroBenchConfig struct {
+	// SysbenchExec defines the path to sysbench binary
 	SysbenchExec   string
+
+	// WorkloadPath defines the path to the lua file used by sysbench.
 	WorkloadPath   string
+
+	// DatabaseConfig points to the required configuration to create
+	// a *mysql.Client. If no configuration, results and reports will
+	// not be saved to MySQL, though the program won't fail.
 	DatabaseConfig *mysql.ConfigDB
+
+	// M contains all metadata used to parameter sysbench execution.
+	// This key value map stores the value of each CLI parameters.
 	M              map[string]string
+
+	// SkipSteps is a slice of string that is used to skip some of
+	// sysbench steps.
 	SkipSteps      []string
+
+	// Type will be used to differentiate macro benchmarks.
 	Type           MacroBenchmarkType
 
 	// Source defines from where the macro benchmark is triggered.
@@ -92,6 +107,8 @@ func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {
 	}
 }
 
+// RegisterNewBenchmarkToMySQL will insert a new row in the benchmark table based on
+// the given MacroBenchConfig. The newly created row's unique ID is returned.
 func (mabcfg MacroBenchConfig) RegisterNewBenchmarkToMySQL(client *mysql.Client) (newMacroBenchmarkID int, err error) {
 	if client == nil {
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 )
 
+// MacroBenchConfig defines a configuration used to execute macro benchmark.
+// For instance, the MacroBench method uses MacroBenchConfig.
 type MacroBenchConfig struct {
 	SysbenchExec   string
 	WorkloadPath   string
@@ -39,6 +41,8 @@ const (
 	flagSkipSteps          = "macrobench-skip-steps"
 )
 
+// AddToCommand will add the different CLI flags used by MacroBenchConfig into
+// the given *cobra.Command.
 func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 	mabcfg.DatabaseConfig.AddToCommand(cmd)
 

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -20,13 +20,39 @@ package macrobench
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/vitessio/arewefastyet/go/mysql"
+	"strings"
 )
 
 type MacroBenchConfig struct {
+	SysbenchExec   string
+	WorkloadPath   string
 	DatabaseConfig *mysql.ConfigDB
+	M              map[string]string
 }
 
-func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command)  {
+const (
+	flagSysbenchExecutable = "macrobench-sysbench-executable"
+	flagSysbenchPath       = "macrobench-workload-path"
+)
+
+func (mabcfg *MacroBenchConfig) AddToCommand(cmd *cobra.Command) {
 	mabcfg.DatabaseConfig.AddToCommand(cmd)
+
+	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "")
+	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "")
+
+	_ = viper.BindPFlag(flagSysbenchPath, cmd.Flags().Lookup(flagSysbenchPath))
+	_ = viper.BindPFlag(flagSysbenchExecutable, cmd.Flags().Lookup(flagSysbenchExecutable))
+}
+
+func (mabcfg *MacroBenchConfig) parseIntoMap(prefix string) {
+	mabcfg.M = map[string]string{}
+	keys := viper.AllKeys()
+	for _, key := range keys {
+		if strings.Index(key, prefix) == 0 {
+			mabcfg.M[key[len(prefix):]] = viper.GetString(key)
+		}
+	}
 }

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -18,27 +18,6 @@
 
 package macrobench
 
-import (
-	"github.com/spf13/cobra"
-	"github.com/vitessio/arewefastyet/go/mysql"
-	"github.com/vitessio/arewefastyet/go/tools/macrobench"
-)
-
-func run() *cobra.Command {
-	mabcfg := macrobench.MacroBenchConfig{
-		DatabaseConfig: &mysql.ConfigDB{},
-	}
-
-	cmd := &cobra.Command{
-		Use: "run",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			err := macrobench.MacroBench(mabcfg)
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-	}
-	mabcfg.AddToCommand(cmd)
-	return cmd
+func MacroBench(mabcfg MacroBenchConfig) error {
+	return nil
 }

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -25,6 +25,10 @@ import (
 	"strings"
 )
 
+const (
+	prefixMacrobenchSysbenchConfig = "macrobench_"
+)
+
 func buildSysbenchArgString(m map[string]string, step string) []string {
 	output := map[string]string{}
 	for k, v := range m {
@@ -52,16 +56,19 @@ func buildSysbenchArgString(m map[string]string, step string) []string {
 }
 
 func MacroBench(mabcfg MacroBenchConfig) error {
-	mabcfg.parseIntoMap("macrobench_")
+	mabcfg.parseIntoMap(prefixMacrobenchSysbenchConfig)
 
-	args := buildSysbenchArgString(mabcfg.M, "prepare")
-	args = append(args, mabcfg.WorkloadPath, "prepare")
-	command := exec.Command(mabcfg.SysbenchExec, args...)
-	out, err := command.Output()
-	if err != nil {
-		log.Println(err, string(out))
-		return err
+	for _, step := range steps {
+		log.Println("Step", step.name)
+		args := buildSysbenchArgString(mabcfg.M, step.name)
+		args = append(args, mabcfg.WorkloadPath, step.sysbenchName)
+		command := exec.Command(mabcfg.SysbenchExec, args...)
+		out, err := command.Output()
+		if err != nil {
+			log.Println(err, string(out))
+			return err
+		}
+		log.Println(string(out))
 	}
-	log.Println(string(out))
 	return nil
 }

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/vitessio/arewefastyet/go/mysql"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -120,7 +119,6 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	}
 
 	// Parse results
-	log.Println(string(resStr))
 	var results []MacroBenchmarkResult
 	err = json.Unmarshal(resStr, &results)
 	if err != nil {

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -89,7 +89,7 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	// Create new macro benchmark in MySQL
 	var macrobenchID int
 	if sqlClient != nil {
-		macrobenchID, err = mabcfg.InsertBenchmarkToSQL(sqlClient)
+		macrobenchID, err = mabcfg.insertBenchmarkToSQL(sqlClient)
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 
 	// Save results
 	if sqlClient != nil {
-		err = results[0].InsertToMySQL(mabcfg.Type, macrobenchID, sqlClient)
+		err = results[0].insertToMySQL(mabcfg.Type, macrobenchID, sqlClient)
 		if err != nil {
 			return err
 		}

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -123,7 +123,8 @@ func Run(mabcfg Config) error {
 	err = json.Unmarshal(resStr, &results)
 	if err != nil {
 		return fmt.Errorf("unmarshal results: %+v\n", err)
-	} else if len(results) == 0 {
+	}
+	if len(results) == 0 {
 		return errors.New(ErrorNoSysBenchResult)
 	}
 

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -123,7 +123,7 @@ func Run(mabcfg Config) error {
 	err = json.Unmarshal(resStr, &results)
 	if err != nil {
 		return fmt.Errorf("unmarshal results: %+v\n", err)
-	} else if len(results) < 0 {
+	} else if len(results) == 0 {
 		return errors.New(ErrorNoSysBenchResult)
 	}
 

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -30,7 +30,7 @@ import (
 const (
 	ErrorNoSysBenchResult          = "no sysbench results were found"
 
-	prefixMacrobenchSysbenchConfig = "macrobench_"
+	prefixMacroBenchSysbenchConfig = "macrobench_"
 )
 
 func buildSysbenchArgString(m map[string]string, step string) []string {
@@ -95,7 +95,7 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	}
 
 	// Prepare
-	mabcfg.parseIntoMap(prefixMacrobenchSysbenchConfig)
+	mabcfg.parseIntoMap(prefixMacroBenchSysbenchConfig)
 	newSteps := skipSteps(steps, mabcfg.SkipSteps)
 
 	// Execution

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/vitessio/arewefastyet/go/mysql"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -119,6 +120,7 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	}
 
 	// Parse results
+	log.Println(string(resStr))
 	var results []MacroBenchmarkResult
 	err = json.Unmarshal(resStr, &results)
 	if err != nil {

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -61,7 +61,9 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	var resStr []byte
 
 	mabcfg.parseIntoMap(prefixMacrobenchSysbenchConfig)
-	for _, step := range steps {
+
+	newSteps := skipSteps(steps, mabcfg.SkipSteps)
+	for _, step := range newSteps {
 		log.Println("Step", step.name)
 		args := buildSysbenchArgString(mabcfg.M, step.name)
 		args = append(args, mabcfg.WorkloadPath, step.sysbenchName)

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -89,7 +89,7 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	// Create new macro benchmark in MySQL
 	var macrobenchID int
 	if sqlClient != nil {
-		macrobenchID, err = mabcfg.RegisterNewBenchmarkToMySQL(sqlClient)
+		macrobenchID, err = mabcfg.InsertBenchmarkToSQL(sqlClient)
 		if err != nil {
 			return err
 		}

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -55,6 +55,20 @@ func buildSysbenchArgString(m map[string]string, step string) []string {
 	return results
 }
 
+// MacroBench executes a macro benchmark by using sysbench.
+// Based on the given MacroBenchConfig, the function will
+// parse the configuration to send down to sysbench (size of tables
+// duration of benchmark, mysql targets, etc...).
+// After the execution, the output of the last step (stepRun) is
+// converted to a slice of MacroBenchmarkResult, which is then
+// uploaded to MySQL using the mysql.ConfigDB in MacroBenchConfig.
+//
+// We use two forks of sysbench, one for oltp workloads
+// and the other for tpcc workload. We use these forks because
+// they implement a custom method to print results in JSON.
+//
+// Regular Sysbench: 	https://github.com/planetscale/sysbench
+// Sysbench-TPCC: 		https://github.com/planetscale/sysbench-tpcc
 func MacroBench(mabcfg MacroBenchConfig) error {
 	var results []MacroBenchmarkResult
 	var resStr []byte

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -21,7 +21,6 @@ package macrobench
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os/exec"
 	"strings"
 )
@@ -64,10 +63,8 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 
 	newSteps := skipSteps(steps, mabcfg.SkipSteps)
 	for _, step := range newSteps {
-		log.Println("Step", step.Name)
 		args := buildSysbenchArgString(mabcfg.M, step.Name)
 		args = append(args, mabcfg.WorkloadPath, step.SysbenchName)
-		log.Println(strings.Join(args, " "))
 		command := exec.Command(mabcfg.SysbenchExec, args...)
 		out, err := command.Output()
 		if err != nil {
@@ -82,7 +79,5 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	if err != nil {
 		return fmt.Errorf("unmarshal results: %+v\n", err)
 	}
-
-	log.Printf("%+v\n", results[0])
 	return nil
 }

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -67,11 +67,15 @@ func buildSysbenchArgString(m map[string]string, step string) []string {
 // and the other for tpcc workload. We use these forks because
 // they implement a custom method to print results in JSON.
 //
-// Regular Sysbench: 	https://github.com/planetscale/sysbench
-// Sysbench-TPCC: 		https://github.com/planetscale/sysbench-tpcc
+// Regular Sysbench: https://github.com/planetscale/sysbench
+// Sysbench-TPCC: https://github.com/planetscale/sysbench-tpcc
 func MacroBench(mabcfg MacroBenchConfig) error {
 	var results []MacroBenchmarkResult
 	var resStr []byte
+
+	// TODO: start MySQL client
+	// Starting it here to verify MySQL related error prior
+	// long running sysbench executions.
 
 	mabcfg.parseIntoMap(prefixMacrobenchSysbenchConfig)
 
@@ -93,5 +97,6 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 	if err != nil {
 		return fmt.Errorf("unmarshal results: %+v\n", err)
 	}
+	// TODO: insert results[0] to MySQL
 	return nil
 }

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -64,16 +64,16 @@ func MacroBench(mabcfg MacroBenchConfig) error {
 
 	newSteps := skipSteps(steps, mabcfg.SkipSteps)
 	for _, step := range newSteps {
-		log.Println("Step", step.name)
-		args := buildSysbenchArgString(mabcfg.M, step.name)
-		args = append(args, mabcfg.WorkloadPath, step.sysbenchName)
+		log.Println("Step", step.Name)
+		args := buildSysbenchArgString(mabcfg.M, step.Name)
+		args = append(args, mabcfg.WorkloadPath, step.SysbenchName)
 		log.Println(strings.Join(args, " "))
 		command := exec.Command(mabcfg.SysbenchExec, args...)
 		out, err := command.Output()
 		if err != nil {
 			return err
 		}
-		if step.name == stepRun {
+		if step.Name == stepRun {
 			resStr = out
 		}
 	}

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -60,7 +60,7 @@ func buildSysbenchArgString(m map[string]string, step string) []string {
 	return results
 }
 
-// MacroBench executes a macro benchmark by using sysbench.
+// Run executes a macro benchmark by using sysbench.
 // Based on the given MacroBenchConfig, the function will
 // parse the configuration to send down to sysbench (size of tables
 // duration of benchmark, mysql targets, etc...).
@@ -74,7 +74,7 @@ func buildSysbenchArgString(m map[string]string, step string) []string {
 //
 // Regular Sysbench: https://github.com/planetscale/sysbench
 // Sysbench-TPCC: https://github.com/planetscale/sysbench-tpcc
-func MacroBench(mabcfg MacroBenchConfig) error {
+func Run(mabcfg Config) error {
 	var err error
 	var sqlClient *mysql.Client
 

--- a/go/tools/macrobench/macrobench_test.go
+++ b/go/tools/macrobench/macrobench_test.go
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package macrobench
+
+import (
+	qt "github.com/frankban/quicktest"
+	"strings"
+	"testing"
+)
+
+func TestBuildSysbenchArgString(t *testing.T) {
+	type cfg = map[string]string
+	tts := []struct {
+		step string
+		m    cfg
+		want []string
+	}{
+		{step: "prepare", m: cfg{"all_luajit-cmd": "off"}, want: []string{"--luajit-cmd=off"}},
+		{step: "prepare", m: cfg{"prepare_luajit-cmd": "on"}, want: []string{"--luajit-cmd=on"}},
+		{step: "prepare", m: cfg{"luajit-cmd": "on"}, want: []string{}},
+		{step: "warmup", m: cfg{"prepare_luajit-cmd": "on", "warmup_luajit-cmd": "off"}, want: []string{"--luajit-cmd=off"}},
+		{step: "prepare", m: cfg{"all_luajit-cmd": "off", "prepare_luajit-cmd": "on"}, want: []string{"--luajit-cmd=on"}},
+		{m: cfg{}, want: []string{}},
+	}
+	for _, tt := range tts {
+		t.Run(strings.Join(tt.want, " "), func(t *testing.T) {
+			argString := buildSysbenchArgString(tt.m, tt.step)
+			c := qt.New(t)
+			if len(tt.want) == 0 {
+				c.Assert(argString, qt.HasLen, 0)
+			} else {
+
+				c.Assert(argString, qt.DeepEquals, tt.want)
+			}
+		})
+	}
+}

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -132,6 +132,10 @@ func (mbr *MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType,
 	return nil
 }
 
+// InsertToMySQL will insert QPS into MySQL using the *mysql.Client.
+// QPS table in MySQL contains two FK pointing to their parent test, namely
+// OLTP_no and TPCC_no, based on the given MacroBenchmarkType, the parentID
+// will be added to the proper column.
 func (q *QPS) InsertToMySQL(benchmarkType MacroBenchmarkType, parentID int, client *mysql.Client) error {
 	if client == nil {
 		return errors.New(mysql.ErrorClientConnectionNotInitialized)

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -20,6 +20,7 @@ package macrobench
 
 import (
 	"errors"
+	"fmt"
 	"github.com/vitessio/arewefastyet/go/mysql"
 	"strings"
 	"time"
@@ -113,6 +114,15 @@ func GetResultsForLastDays(macroType MacroBenchmarkType, source string, lastDays
 // The MacroBenchmarkResults gets added in one of macrobenchmark's children tables.
 // Depending on the MacroBenchmarkType, the insert will be routed to a specific children table.
 func (mbr MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType, macrobenchmarkID int, client *mysql.Client) error {
-	// TODO: insert
+	if client == nil {
+		return errors.New(mysql.ErrorClientConnectionNotInitialized)
+	}
+	query := fmt.Sprintf("INSERT INTO %s(test_no, tps, latency, errors, reconnects, time, threads) VALUES(?, ?, ?, ?, ?, ?, ?)", benchmarkType.String())
+	_, err := client.Insert(query, macrobenchmarkID, mbr.TPS, mbr.Latency, mbr.Errors, mbr.Reconnects, mbr.Time, mbr.Threads)
+	if err != nil {
+		return err
+	}
+	// TODO: add IDs
+	// mbr.ID = id
 	return nil
 }

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -31,23 +31,23 @@ type (
 	QPS struct {
 		ID     int
 		RefID  int
-		Total  float64
-		Reads  float64
-		Writes float64
-		Other  float64
+		Total  float64 `json:"total"`
+		Reads  float64 `json:"reads"`
+		Writes float64 `json:"writes"`
+		Other  float64 `json:"other"`
 	}
 
 	// MacroBenchmarkResult represents both OLTP and TPCC tables.
 	// The two tables share the same schema and can thus be grouped
 	// under an unique go struct.
 	MacroBenchmarkResult struct {
-		QPS
-		TPS        float64
-		Latency    float64
-		Errors     float64
-		Reconnects float64
-		Time       int
-		Threads    float64
+		QPS        QPS     `json:"qps"`
+		TPS        float64 `json:"tps"`
+		Latency    float64 `json:"latency"`
+		Errors     float64 `json:"errors"`
+		Reconnects float64 `json:"reconnects"`
+		Time       int     `json:"time"`
+		Threads    float64 `json:"threads"`
 	}
 
 	// BenchmarkID is used to identify a macro benchmark using its database's ID, the

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -42,7 +42,7 @@ type (
 	// The two tables share the same schema and can thus be grouped
 	// under an unique go struct.
 	MacroBenchmarkResult struct {
-		// TODO: add an ID here (referring to OLTP_no and TPCC_no)
+		ID         int
 		QPS        QPS     `json:"qps"`
 		TPS        float64 `json:"tps"`
 		Latency    float64 `json:"latency"`
@@ -113,16 +113,15 @@ func GetResultsForLastDays(macroType MacroBenchmarkType, source string, lastDays
 // InsertToMySQL inserts the given MacroBenchmarkResult to MySQL using a *mysql.Client.
 // The MacroBenchmarkResults gets added in one of macrobenchmark's children tables.
 // Depending on the MacroBenchmarkType, the insert will be routed to a specific children table.
-func (mbr MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType, macrobenchmarkID int, client *mysql.Client) error {
+func (mbr *MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType, macrobenchmarkID int, client *mysql.Client) error {
 	if client == nil {
 		return errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}
 	query := fmt.Sprintf("INSERT INTO %s(test_no, tps, latency, errors, reconnects, time, threads) VALUES(?, ?, ?, ?, ?, ?, ?)", benchmarkType.String())
-	_, err := client.Insert(query, macrobenchmarkID, mbr.TPS, mbr.Latency, mbr.Errors, mbr.Reconnects, mbr.Time, mbr.Threads)
+	id, err := client.Insert(query, macrobenchmarkID, mbr.TPS, mbr.Latency, mbr.Errors, mbr.Reconnects, mbr.Time, mbr.Threads)
 	if err != nil {
 		return err
 	}
-	// TODO: add IDs
-	// mbr.ID = id
+	mbr.ID = int(id)
 	return nil
 }

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -41,6 +41,7 @@ type (
 	// The two tables share the same schema and can thus be grouped
 	// under an unique go struct.
 	MacroBenchmarkResult struct {
+		// TODO: add an ID here (referring to OLTP_no and TPCC_no)
 		QPS        QPS     `json:"qps"`
 		TPS        float64 `json:"tps"`
 		Latency    float64 `json:"latency"`
@@ -106,4 +107,12 @@ func GetResultsForLastDays(macroType MacroBenchmarkType, source string, lastDays
 		macrodetails = append(macrodetails, res)
 	}
 	return macrodetails, nil
+}
+
+// InsertToMySQL inserts the given MacroBenchmarkResult to MySQL using a *mysql.Client.
+// The MacroBenchmarkResults gets added in one of macrobenchmark's children tables.
+// Depending on the MacroBenchmarkType, the insert will be routed to a specific children table.
+func (mbr MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType, macrobenchmarkID int, client *mysql.Client) error {
+	// TODO: insert
+	return nil
 }

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -116,8 +116,10 @@ func GetResultsForLastDays(macroType MacroBenchmarkType, source string, lastDays
 func (mbr *MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType, macrobenchmarkID int, client *mysql.Client) error {
 	if client == nil {
 		return errors.New(mysql.ErrorClientConnectionNotInitialized)
+	} else if benchmarkType == "" {
+		return errors.New(IncorrectMacroBenchmarkType)
 	}
-	query := fmt.Sprintf("INSERT INTO %s(test_no, tps, latency, errors, reconnects, time, threads) VALUES(?, ?, ?, ?, ?, ?, ?)", benchmarkType.String())
+	query := fmt.Sprintf("INSERT INTO %s(test_no, tps, latency, errors, reconnects, time, threads) VALUES(?, ?, ?, ?, ?, ?, ?)", benchmarkType.ToUpper().String())
 	id, err := client.Insert(query, macrobenchmarkID, mbr.TPS, mbr.Latency, mbr.Errors, mbr.Reconnects, mbr.Time, mbr.Threads)
 	if err != nil {
 		return err

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -117,7 +117,8 @@ func GetResultsForLastDays(macroType MacroBenchmarkType, source string, lastDays
 func (mbr *MacroBenchmarkResult) insertToMySQL(benchmarkType MacroBenchmarkType, macrobenchmarkID int, client *mysql.Client) error {
 	if client == nil {
 		return errors.New(mysql.ErrorClientConnectionNotInitialized)
-	} else if benchmarkType == "" {
+	}
+	if benchmarkType == "" {
 		return errors.New(IncorrectMacroBenchmarkType)
 	}
 

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -125,5 +125,24 @@ func (mbr *MacroBenchmarkResult) InsertToMySQL(benchmarkType MacroBenchmarkType,
 		return err
 	}
 	mbr.ID = int(id)
+	err = mbr.QPS.InsertToMySQL(benchmarkType, mbr.ID, client)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (q *QPS) InsertToMySQL(benchmarkType MacroBenchmarkType, parentID int, client *mysql.Client) error {
+	if client == nil {
+		return errors.New(mysql.ErrorClientConnectionNotInitialized)
+	} else if benchmarkType == "" {
+		return errors.New(IncorrectMacroBenchmarkType)
+	}
+	query := fmt.Sprintf("INSERT INTO qps(%s, total_qps, reads_qps, writes_qps, other_qps) VALUES(?, ?, ?, ?, ?)", benchmarkType.ToUpper().String() + "_no")
+	id, err := client.Insert(query, parentID, q.Total, q.Reads, q.Writes, q.Other)
+	if err != nil {
+		return err
+	}
+	q.ID = int(id)
 	return nil
 }

--- a/go/tools/macrobench/steps.go
+++ b/go/tools/macrobench/steps.go
@@ -1,0 +1,38 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package macrobench
+
+type step struct {
+	name         string
+	sysbenchName string
+}
+
+const (
+	stepPrepare = "prepare"
+	stepWarmUp  = "warmup"
+	stepRun     = "run"
+)
+
+var (
+	steps = []step{
+		{name: stepPrepare, sysbenchName: stepPrepare},
+		{name: stepWarmUp, sysbenchName: stepRun},
+		{name: stepRun, sysbenchName: stepRun},
+	}
+)

--- a/go/tools/macrobench/steps.go
+++ b/go/tools/macrobench/steps.go
@@ -19,8 +19,8 @@
 package macrobench
 
 type step struct {
-	name         string
-	sysbenchName string
+	Name         string
+	SysbenchName string
 }
 
 const (
@@ -31,18 +31,24 @@ const (
 
 var (
 	steps = []step{
-		{name: stepPrepare, sysbenchName: stepPrepare},
-		{name: stepWarmUp, sysbenchName: stepRun},
-		{name: stepRun, sysbenchName: stepRun},
+		{Name: stepPrepare, SysbenchName: stepPrepare},
+		{Name: stepWarmUp, SysbenchName: stepRun},
+		{Name: stepRun, SysbenchName: stepRun},
 	}
 )
 
 func skipSteps(steps []step, skip []string) (newSteps []step) {
-	for _, skipStep := range skip {
-		for _, step := range steps {
-			if step.name != skipStep {
-				newSteps = append(newSteps, step)
+	newSteps = []step{}
+	for _, step := range steps {
+		add := true
+		for _, skipStep := range skip {
+			if step.Name == skipStep {
+				add = false
+				break
 			}
+		}
+		if add {
+			newSteps = append(newSteps, step)
 		}
 	}
 	return newSteps

--- a/go/tools/macrobench/steps.go
+++ b/go/tools/macrobench/steps.go
@@ -36,3 +36,14 @@ var (
 		{name: stepRun, sysbenchName: stepRun},
 	}
 )
+
+func skipSteps(steps []step, skip []string) (newSteps []step) {
+	for _, skipStep := range skip {
+		for _, step := range steps {
+			if step.name != skipStep {
+				newSteps = append(newSteps, step)
+			}
+		}
+	}
+	return newSteps
+}

--- a/go/tools/macrobench/steps_test.go
+++ b/go/tools/macrobench/steps_test.go
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package macrobench
+
+import (
+	qt "github.com/frankban/quicktest"
+	"testing"
+)
+
+func Test_skipSteps(t *testing.T) {
+	prepare := step{Name: stepPrepare, SysbenchName: stepPrepare}
+	warmup := step{Name: stepWarmUp, SysbenchName: stepRun}
+	run := step{Name: stepRun, SysbenchName: stepRun}
+
+	type args struct {
+		steps []step
+		skip  []string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantNewSteps []step
+	}{
+		{name: "No skip step", args: args{steps: []step{prepare, warmup, run}, skip: []string{}}, wantNewSteps: []step{prepare, warmup, run}},
+		{name: "Skip prepare", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepPrepare}}, wantNewSteps: []step{warmup, run}},
+		{name: "Skip warm up", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepWarmUp}}, wantNewSteps: []step{prepare, run}},
+		{name: "Skip run", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepRun}}, wantNewSteps: []step{prepare, warmup}},
+		{name: "Skip prepare and run", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepPrepare, stepRun}}, wantNewSteps: []step{warmup}},
+		{name: "Skip all", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepPrepare, stepWarmUp, stepRun}}, wantNewSteps: []step{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			gotNewSteps := skipSteps(tt.args.steps, tt.args.skip)
+			c.Assert(gotNewSteps, qt.DeepEquals, tt.wantNewSteps)
+		})
+	}
+}

--- a/go/tools/macrobench/types.go
+++ b/go/tools/macrobench/types.go
@@ -35,6 +35,11 @@ const (
 	IncorrectMacroBenchmarkType = "incorrect macrobenchmark type"
 )
 
+// Type implements Cobra flag.Value interface.
+func (mbtype *MacroBenchmarkType) Type() string {
+	return "MacroBenchmarkType"
+}
+
 // Set implements Cobra flag.Value interface.
 func (mbtype *MacroBenchmarkType) Set(s string) error {
 	*mbtype = MacroBenchmarkType(s)
@@ -47,6 +52,7 @@ func (mbtype MacroBenchmarkType) ToUpper() MacroBenchmarkType {
 }
 
 // String returns the given MacroBenchmarkType as a string.
+// It also implements the flag.Value interface.
 func (mbtype MacroBenchmarkType) String() string {
 	return string(mbtype)
 }

--- a/go/tools/macrobench/types.go
+++ b/go/tools/macrobench/types.go
@@ -35,6 +35,11 @@ const (
 	IncorrectMacroBenchmarkType = "incorrect macrobenchmark type"
 )
 
+// Set implements Cobra flag.Value interface.
+func (mbtype *MacroBenchmarkType) Set(s string) error {
+	*mbtype = MacroBenchmarkType(s)
+	return nil
+}
 
 // ToUpper returns a new MacroBenchmarkType in upper case.
 func (mbtype MacroBenchmarkType) ToUpper() MacroBenchmarkType {

--- a/go/tools/macrobench/types_test.go
+++ b/go/tools/macrobench/types_test.go
@@ -55,9 +55,27 @@ func TestMacroBenchmarkType_ToUpper(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.mbtype.ToUpper(); got != tt.want {
-				t.Errorf("ToUpper() = %v, want %v", got, tt.want)
-			}
+			c := qt.New(t)
+			c.Assert(tt.mbtype.ToUpper(), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestMacroBenchmarkType_Set(t *testing.T) {
+	tests := []struct {
+		name   string
+		mbtype MacroBenchmarkType
+		s      string
+		want   MacroBenchmarkType
+	}{
+		{name: "Simple string", mbtype: "", s: "TPCC", want: MacroBenchmarkType("TPCC")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			err := tt.mbtype.Set(tt.s)
+			c.Assert(err, qt.IsNil)
+			c.Assert(tt.mbtype, qt.Equals, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This pull request adds a new command to the CLI. The command allows us to execute a macro benchmark independently. Just like what we already do for `microbench`, we will not have to **only** go through the `exec` command in order to start macro benchmarks.

## Why do we need this

I came up with four main reasons why we need to implement this change. _First_ of all, it offers more consistency in the codebase, we were already treating micro benchmark with a unique command, so why not macro benchmark. _Secondly_, it allows easy local debugging and increases reproducibility, there is no need to spin up the infrastructure and wait for it to be configured. _Thirdly_, it enables us to deal with results and errors in a better way, everything is executed and controlled within the Golang code, not third-party shell scripts. _And finally_, it brings us closer to a system with centralized configuration, we configure macro benchmark from our main `config.yaml` using Cobra.

Being a tenth skeptical at first about removing the responsibility of executing Sysbench to Ansible and passing it on to the Golang code, those four reasons are what drove me anyhow.

## The new command

The new command usage is:

```text
go run ./go/main.go  macrobench run --help
Usage:
  arewefastyet macrobench run [flags]

Flags:
      --db-database string                      Database to use.
      --db-host string                          Hostname of the database
      --db-password string                      Password to authenticate the database.
      --db-user string                          User used to connect to the database
  -h, --help                                    help for run
      --macrobench-git-ref string               Git SHA referring to the macro benchmark.
      --macrobench-skip-steps strings           Slice of sysbench steps to skip.
      --macrobench-source string                The source or origin of the macro benchmark trigger.
      --macrobench-sysbench-executable string   Path to the sysbench binary.
      --macrobench-type MacroBenchmarkType      Type of macro benchmark.
      --macrobench-working-directory string     Directory on which to execute sysbench.
      --macrobench-workload-path string         Path to the workload used by sysbench.
```

## Configurability

As I mentioned, this command offers increased configurability of the macro benchmarks. Instead of declaring variables for both OLTP and TPCC inside Ansible inventories, we define a single set of variables that can apply to both OLTP and TPCC in a single place. This set of variables will be read by the Golang code and transformed into a list of arguments that we pass to Sysbench. Below is an extract of a configuration file containing macro benchmarks configuration.

```yaml
#### MACRO BENCHMARKS CONFIGURATION

macrobench-sysbench-executable: /usr/local/bin/sysbench
macrobench-workload-path: oltp_read_only
macrobench-skip-steps:
macrobench-type: oltp
macrobench-source: local
macrobench-git-ref: head

## ALL
macrobench_all_mysql-db: main
macrobench_all_mysql-host: 127.0.0.1
macrobench_all_mysql-port: 13306
macrobench_all_db-ps-mode: disable
macrobench_all_db-driver: mysql
macrobench_all_luajit-cmd: "off"
macrobench_all_threads: 1
macrobench_all_auto-inc: "off"
macrobench_all_tables: 50
macrobench_all_table_size: 10
macrobench_all_range_selects: 0
macrobench_all_rand-type: uniform

## PREPARE
macrobench_prepare_time: 30
macrobench_prepare_report-interval: 10

## WARM UP
macrobench_warmup_time: 10
macrobench_warmup_report-interval: 10

## RUN
macrobench_run_time: 10
macrobench_run_report_json: true
macrobench_run_verbosity: 0
```

Variables are prefixed with `macrobench_` followed by the name of the sysbench step on which this variable applies. As we can see, the variables at the top of the file, those without a step prefix, are used to control the execution. They are not passed down to sysbench. Those can be configured through CLI flags, as well as a configuration file like that one.

The sysbench workload used by the macro benchmark is now configurable too through the `macrobench-workload-path` key. This takes the lua file that sysbench will use.

## Sysbench

We use forks of sysbench and sysbench-tpcc, they have been modified to generate JSON reports:
- https://github.com/planetscale/sysbench
- https://github.com/planetscale/sysbench-tpcc

## Testing

To test you'll need a sufficient configuration, with the following items:

> Here showing a config.yaml file used to execute TPCC macro benchmarks.

```yaml
equinix-token: <equinix token>
equinix-project-id: <equinix project id>
equinix-instance-type: m2.xlarge.x86

# database information is not mandatory, the command can ignore storing results
db-host: <your db hostname>
db-user: <your db user>
db-password: <your db password>
db-database: <your db name>

infra-path: ./infra/terraform/

ansible-inventory-files: macrobench_sharded_inventory.yml
ansible-playbook-files: macrobench.yml
ansible-root-directory: ./ansible/

#### MACRO BENCHMARKS CONFIGURATION

macrobench-sysbench-executable: /usr/local/bin/sysbench
macrobench-workload-path: /src/sysbench-tpcc/tpcc.lua
macrobench-skip-steps:
macrobench-type: tpcc
macrobench-source: local
macrobench-git-ref: head
macrobench-working-directory: /src/sysbench-tpcc

## ALL
macrobench_all_mysql-db: main
macrobench_all_mysql-host: 127.0.0.1
macrobench_all_mysql-port: 13306
macrobench_all_db-ps-mode: disable
macrobench_all_db-driver: mysql
macrobench_all_luajit-cmd: "off"
macrobench_all_threads: 1
macrobench_all_tables: 1
macrobench_all_scale: 1
macrobench_all_rand-type: uniform
macrobench_all_use_fk: 0
macrobench_all_mysql-ignore-errors: all

## PREPARE
macrobench_prepare_time: 5
macrobench_prepare_report-interval: 10

## WARM UP
macrobench_warmup_time: 5
macrobench_warmup_report-interval: 10

## RUN
macrobench_run_time: 10
macrobench_run_report_json: "yes"
macrobench_run_verbosity: 0
```

New inventories are added, they will permanently replace old ones in future PRs. Both `./ansible/macrobench_sharded_inventory.yml` and `./ansible/macrobench_unsharded_inventory.yml` can be used. Here is a sample of the configuration needed to execute those files:

```yaml
...
ansible-inventory-files: macrobench_sharded_inventory.yml
ansible-playbook-files: macrobench.yml
ansible-root-directory: ./ansible/
...
```

You can then execute the commands with two methods:

```sh
go build ./go/main.go

## Method 1: Execution from A to Z using Terraform and Ansible as interfaces
./main exec --config ./config/config.yaml

## Method 2: Local execution using the new command - Requires Sysbench to be installed
./main macrobench run --config ./config/config.yaml

```

## Cleaning and future work

Some housecleaning will need to be done in the future, some of the files located in `./ansible/` are redundant.

Future work includes setting up a cleaner configuration file and variables for sysbench's params. YAML supports arrays, I think that's something we can look at to make files look cleaner.

## Related issues

Resolves #115.