### PR TITLE
Addition of waitSig for vtgate/vttablet profiling

### DIFF
--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -22,7 +22,7 @@ EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
     -gate_query_cache_size {{ vtgate_query_cache_size }} \
     {% if pprof_targets is defined %}
         {% for target in pprof_targets if target == "vtgate" %}
-            -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }}
+            -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }},waitSig
         {%- endfor %}
     {% endif %}
     {{gateway.extra_flags|default("")}} \

--- a/ansible/roles/vttablet/templates/vttablet.conf.j2
+++ b/ansible/roles/vttablet/templates/vttablet.conf.j2
@@ -39,7 +39,7 @@ EXTRA_VTTABLET_FLAGS="-alsologtostderr \
     --binlog_use_v3_resharding_mode=true \
     {% if pprof_targets is defined %}
         {% for target in pprof_targets if target == "vttablet" %}
-            -pprof {{ pprof_args }},path=/tmp/pprof/vttablet-{{ tablet.id }}
+            -pprof {{ pprof_args }},path=/tmp/pprof/vttablet-{{ tablet.id }},waitSig
         {%- endfor %}
     {% endif %}
     {{ tablet.extra_flags | default("") }} \


### PR DESCRIPTION
## Description

Fixing a vtgate/vttablet configuration issue. The feature implemented in Vitess allowing us to start and stop profile recording at any time using `USR1`, [PR 7616](https://github.com/vitessio/vitess/pull/7616), was not correctly implemented in arewefastyet's side, resulting in recording starting way too early and finishing at inappropriate times. Thanks @vmg for finding this buggy behavior 🙏🏻 