### PR TITLE
Updated terraform init options list

### DIFF
--- a/go/infra/equinix/equinix.go
+++ b/go/infra/equinix/equinix.go
@@ -148,7 +148,7 @@ func (e *Equinix) Prepare() error {
 		return err
 	}
 
-	err = tf.Init(context.Background(), tfexec.Upgrade(true), tfexec.LockTimeout("60s"))
+	err = tf.Init(context.Background(), tfexec.Upgrade(true))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

After upgrading to TF 0.15 the following error appeared and was caused by the use `tfexec.LockTimeout("60s")` as detailed in https://github.com/hashicorp/terraform-exec/issues/163

```
-lock, -lock-timeout, -verify-plugins, and -get-plugins options are no longer available as of Terraform 0.15: unexpected version 0.15.0 (min: -, max: 0.15.0)
```

## Related issues

Fixes #127.