### PR TITLE
Ensure webhook payload push ref is set to refs/heads/master

### DIFF
--- a/go/server/api.go
+++ b/go/server/api.go
@@ -59,6 +59,9 @@ func (s *Server) webhookHandler(c *gin.Context) {
 		slog.Warn(errorStr)
 		c.JSON(http.StatusBadRequest, newResponseErrorFromString(errorStr))
 		return
+	} else if wbhPayload.Ref != "refs/heads/master" {
+		c.JSON(http.StatusBadRequest, newResponseErrorFromString("not a runnable reference"))
+		return
 	}
 
 	pathConfig := wbhPayload.PathConfig
@@ -104,5 +107,5 @@ func (s *Server) webhookHandler(c *gin.Context) {
 		Started bool   `json:"started"`
 		UUID    string `json:"uuid"`
 	}
-	c.JSON(http.StatusOK, webhookResponse{Started: true, UUID: e.UUID.String()})
+	c.JSON(http.StatusCreated, webhookResponse{Started: true, UUID: e.UUID.String()})
 }


### PR DESCRIPTION
Signed-off-by: Florent Poinsard <florent.poinsard@outlook.fr>

## Description

As the `git_ref` value given to `Exec` is not dynamic yet, new webhook executions will be limited to push events having a `refs/heads/master` ref. This will greatly reduce the number of Equinix Metal instances that we spin up until we are able to re-use instances in a more sustainable manner.