### PR TITLE
Fix migration 001 to fit MySQL 5.7.9 syntax

### DIFF
--- a/sql/migration/001_New_parent_table_for_executions_125.sql
+++ b/sql/migration/001_New_parent_table_for_executions_125.sql
@@ -30,12 +30,12 @@ CREATE TABLE IF NOT EXISTS execution (
 
 alter table benchmark rename to macrobenchmark;
 
-alter table macrobenchmark rename column test_no to macrobenchmark_id;
+alter table macrobenchmark change column test_no macrobenchmark_id int(11) NOT NULL AUTO_INCREMENT;
 alter table macrobenchmark add column exec_uuid VARCHAR(100) DEFAULT NULL;
 alter table macrobenchmark add constraint  macrobenchmark_ibfk_1 FOREIGN KEY (exec_uuid) REFERENCES execution (uuid);
 
-alter table OLTP rename column test_no to macrobenchmark_id;
-alter table TPCC rename column test_no to macrobenchmark_id;
+alter table OLTP change column test_no macrobenchmark_id int(11) DEFAULT NULL;
+alter table TPCC change column test_no macrobenchmark_id int(11) DEFAULT NULL;
 
 alter table microbenchmark add column exec_uuid VARCHAR(100) DEFAULT NULL;
 alter table microbenchmark add constraint  microbenchmark_ibfk_1 FOREIGN KEY (exec_uuid) REFERENCES execution (uuid);


### PR DESCRIPTION
## Description

Changed the MySQL syntax to fit the currently used MySQL version used: `5.7.9-vitess-10.0.0-SNAPSHOT`. The `rename column old_name to new_name` was causing an issue, this pull request replaces them by `change column old_name new_name definition`.