### PR TITLE
Hotfix invalid MySQL SELECT

### DIFF
--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -84,12 +84,12 @@ func GetResultsForLastDays(macroType MacroBenchmarkType, source string, lastDays
 	}
 
 	upperMacroType := macroType.ToUpper().String()
-	query := "SELECT b.test_no, b.commit, b.source, b.DateTime, " +
+	query := "SELECT b.macrobenchmark_id, b.commit, b.source, b.DateTime, " +
 		"macrotype.tps, macrotype.latency, macrotype.errors, macrotype.reconnects, macrotype.time, macrotype.threads, " +
 		"qps.qps_no, qps.total_qps, qps.reads_qps, qps.writes_qps, qps.other_qps " +
 		"FROM macrobenchmark AS b, $(MBTYPE) AS macrotype, qps AS qps " +
 		"WHERE b.DateTime BETWEEN DATE(NOW()) - INTERVAL ? DAY AND DATE(NOW()) " +
-		"AND b.source = ? AND b.test_no = macrotype.test_no AND macrotype.$(MBTYPE)_no = qps.$(MBTYPE)_no"
+		"AND b.source = ? AND b.macrobenchmark_id = macrotype.macrobenchmark_id AND macrotype.$(MBTYPE)_no = qps.$(MBTYPE)_no"
 
 	query = strings.ReplaceAll(query, "$(MBTYPE)", upperMacroType)
 


### PR DESCRIPTION
## Description of the issue

Shortly after the migration process for [`001`](https://github.com/vitessio/arewefastyet/blob/master/sql/migration/001_New_parent_table_for_executions_125.sql) (PR #125) completed, non-fatal errors appeared on arewefastyet's production server and were causing macro benchmark dashboards unavailability.

## Filtered logs

```
2021-04-23T12:30:38.591Z        WARN    server/handlers.go:49   Error 1054: vtgate: {DB_HOST_NAME}: target: benchmark.-.master, used tablet: {VTTABLET_NAME} ({VTTABLET_IP}): vttablet: rpc error: code 
= NotFound desc = Unknown column 'b.test_no' in 'field list' (errno 1054) (sqlstate 42S22) (CallerID: vitess): Sql: "select b.test_no, b.`
commit`, b.source, b.`DateTime`, macrotype.tps, macrotype.latency, macrotype.errors, macrotype.reconnects, macrotype.`time`, macrotype.thr
eads, qps.qps_no, qps.total_qps, qps.reads_qps, qps.writes_qps, qps.other_qps from macrobenchmark as b, OLTP as macrotype, qps as qps wher
e 1 != 1", BindVars: {v1: ""v2: ""}
github.com/vitessio/arewefastyet/go/server.(*Server).homeHandler
        /root/arewefastyet/go/server/handlers.go:49
github.com/gin-gonic/gin.(*Context).Next
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.RecoveryWithWriter.func1
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/recovery.go:83
github.com/gin-gonic/gin.(*Context).Next
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.LoggerWithConfig.func1
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/logger.go:241
github.com/gin-gonic/gin.(*Context).Next
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:409
github.com/gin-gonic/gin.(*Engine).ServeHTTP
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:367
net/http.serverHandler.ServeHTTP
        /usr/local/go/src/net/http/server.go:2843
net/http.(*conn).serve
        /usr/local/go/src/net/http/server.go:1925
2021-04-23T12:30:38.596Z        WARN    server/handlers.go:54   Error 1054: vtgate: {DB_HOST_NAME}: target: benchmark.-.master, used tablet: {VTTABLET_NAME} ({VTTABLET_IP}): vttablet: rpc error: code 
= NotFound desc = Unknown column 'b.test_no' in 'field list' (errno 1054) (sqlstate 42S22) (CallerID: vitess): Sql: "select b.test_no, b.`
commit`, b.source, b.`DateTime`, macrotype.tps, macrotype.latency, macrotype.errors, macrotype.reconnects, macrotype.`time`, macrotype.thr
eads, qps.qps_no, qps.total_qps, qps.reads_qps, qps.writes_qps, qps.other_qps from macrobenchmark as b, TPCC as macrotype, qps as qps wher
e 1 != 1", BindVars: {v1: ""v2: ""}
github.com/vitessio/arewefastyet/go/server.(*Server).homeHandler
        /root/arewefastyet/go/server/handlers.go:54
github.com/gin-gonic/gin.(*Context).Next
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.RecoveryWithWriter.func1
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/recovery.go:83
github.com/gin-gonic/gin.(*Context).Next
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.LoggerWithConfig.func1
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/logger.go:241
github.com/gin-gonic/gin.(*Context).Next
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:409
github.com/gin-gonic/gin.(*Engine).ServeHTTP
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:367
net/http.serverHandler.ServeHTTP
        /usr/local/go/src/net/http/server.go:2843
net/http.(*conn).serve
        /usr/local/go/src/net/http/server.go:1925
```

## What's done on the server

While waiting for this hotfix to be merged into master, the server will checkout to this pull request git ref.

## What's the fix

A column was renamed from `test_no` to `macrobenchmark_id` in both projection and selection of the MySQL query used to get macrobenchmarks details. 
