### PR TITLE
Configuration improvements on the webhook api handler

### DIFF
--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -37,6 +37,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	e.AnsibleConfig.AddToViper(v)
 	e.InfraConfig.AddToViper(v)
 	e.Infra.AddToViper(v)
+	e.configDB.AddToViper(v)
 	return nil
 }
 

--- a/go/mysql/flags.go
+++ b/go/mysql/flags.go
@@ -23,14 +23,29 @@ import (
 	"github.com/spf13/viper"
 )
 
-func (cfg *ConfigDB) AddToCommand(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&cfg.Database, "db-database", "", "Database to use.")
-	cmd.Flags().StringVar(&cfg.Host, "db-host", "", "Hostname of the database")
-	cmd.Flags().StringVar(&cfg.Password, "db-password", "", "Password to authenticate the database.")
-	cmd.Flags().StringVar(&cfg.User, "db-user", "", "User used to connect to the database")
+const (
+	flagDatabaseName     = "db-database"
+	flagDatabaseHost     = "db-host"
+	flagDatabasePassword = "db-password"
+	flagDatabaseUser     = "db-user"
+)
 
-	_ = viper.BindPFlag("db-database", cmd.Flags().Lookup("db-database"))
-	_ = viper.BindPFlag("db-host", cmd.Flags().Lookup("db-host"))
-	_ = viper.BindPFlag("db-password", cmd.Flags().Lookup("db-password"))
-	_ = viper.BindPFlag("db-user", cmd.Flags().Lookup("db-user"))
+func (cfg *ConfigDB) AddToViper(v *viper.Viper) {
+	_ = v.UnmarshalKey(flagDatabaseName, &cfg.Database)
+	_ = v.UnmarshalKey(flagDatabaseHost, &cfg.Host)
+	_ = v.UnmarshalKey(flagDatabasePassword, &cfg.Password)
+	_ = v.UnmarshalKey(flagDatabaseUser, &cfg.User)
+}
+
+func (cfg *ConfigDB) AddToCommand(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&cfg.Database, flagDatabaseName, "", "Database to use.")
+	cmd.Flags().StringVar(&cfg.Host, flagDatabaseHost, "", "Hostname of the database")
+	cmd.Flags().StringVar(&cfg.Password, flagDatabasePassword, "", "Password to authenticate the database.")
+
+	cmd.Flags().StringVar(&cfg.User, flagDatabaseUser, "", "User used to connect to the database")
+
+	_ = viper.BindPFlag(flagDatabaseName, cmd.Flags().Lookup(flagDatabaseName))
+	_ = viper.BindPFlag(flagDatabaseHost, cmd.Flags().Lookup(flagDatabaseHost))
+	_ = viper.BindPFlag(flagDatabasePassword, cmd.Flags().Lookup(flagDatabasePassword))
+	_ = viper.BindPFlag(flagDatabaseUser, cmd.Flags().Lookup(flagDatabaseUser))
 }

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -18,7 +18,29 @@
 
 package git
 
-import "github.com/go-git/go-git/v5"
+import (
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+func GetCommitHashFromClonedRef(ref, repo string) (hash string, err error) {
+	r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+		URL:           repo,
+		ReferenceName: plumbing.ReferenceName(ref),
+		SingleBranch:  true,
+		Depth:         1,
+		Tags:          git.NoTags,
+	})
+	if err != nil {
+		return "", err
+	}
+	head, err := r.Head()
+	if err != nil {
+		return "", err
+	}
+	return head.Hash().String(), nil
+}
 
 func GetCommitHash(repoDir string) (hash string, err error) {
 	r, err := git.PlainOpen(repoDir)


### PR DESCRIPTION
## Description

This pull request adds an `AddToViper` method to `mysql.ConfigDB` allowing execution to use MySQL configurations when triggered from webhooks. The execution source and git ref are also added to the handler. The source defaults to `webhook`, and the git ref is fetched using `go-git` and the reference located in the payload of the webhook query.