### PR TITLE
Add tags and proper name to Equinix Metal instances

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/infra/construct"
 	"github.com/vitessio/arewefastyet/go/infra/equinix"
 	"github.com/vitessio/arewefastyet/go/storage/mysql"
+	"github.com/vitessio/arewefastyet/go/tools/git"
 	"io"
 	"os"
 	"path"
@@ -137,6 +138,11 @@ func (e *Exec) Prepare() error {
 		return err
 	}
 
+	e.Infra.SetTags(map[string]string{
+		"execution_git_ref": git.ShortenSHA(e.GitRef),
+		"execution_source": e.Source,
+	})
+
 	err = e.prepareDirectories()
 	if err != nil {
 		return err
@@ -169,7 +175,7 @@ func (e *Exec) Execute() (err error) {
 		return err
 	}
 
-	IPs, err := provision(e.Infra)
+	IPs, err := e.provision()
 	if err != nil {
 		return err
 	}
@@ -231,6 +237,7 @@ func NewExec() (*Exec, error) {
 
 	// ex.AnsibleConfig.SetOutputs(ex.stdout, ex.stderr)
 	ex.Infra.SetConfig(&ex.InfraConfig)
+	ex.Infra.SetExecUUID(ex.UUID)
 
 	return &ex, nil
 }

--- a/go/exec/provision.go
+++ b/go/exec/provision.go
@@ -20,11 +20,10 @@ package exec
 
 import (
 	"encoding/json"
-	"github.com/vitessio/arewefastyet/go/infra"
 )
 
-func provision(infra infra.Infra) (IPs []string, err error) {
-	out, err := infra.Create("device_public_ip")
+func (e Exec) provision() (IPs []string, err error) {
+	out, err := e.Infra.Create("device_public_ip")
 	if err != nil {
 		return nil, err
 	}

--- a/go/infra/infra.go
+++ b/go/infra/infra.go
@@ -21,6 +21,7 @@ package infra
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfinstall"
 	"github.com/spf13/cobra"
@@ -44,6 +45,8 @@ type Infra interface {
 	TerraformVarArray() (vars []*tfexec.VarOption)
 	Run(ansible *ansible.Config) error
 	SetConfig(config *Config)
+	SetTags(tags map[string]string)
+	SetExecUUID(uuid uuid.UUID)
 }
 
 func getTerraformExecPath(installPath string) (string, error) {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -20,4 +20,5 @@ resource "metal_device" "node" {
   operating_system = var.operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id
+  tags             = [var.execution_source, var.execution_git_ref]
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -40,3 +40,13 @@ variable "facilities" {
   description = "Equinix Metal facility used to run the server"
   default = ["ams1"]
 }
+
+variable "execution_source" {
+  description = "The source or trigger of the execution"
+  default = ""
+}
+
+variable "execution_git_ref" {
+  description = "The git reference on which we execute benchmarks"
+  default = ""
+}


### PR DESCRIPTION
## Description

Addition of tags and unique names for our Equinix Metal instances with Terraform. The hostname is the UUID of the execution. The updated terraform state with the new hostname and tags is shown below:

```tf
# metal_device.node:
resource "metal_device" "node" {
    ...
    created                          = "2021-05-10T21:02:35Z"
    deployed_facility                = "ams1"
    facilities                       = [
        "ams1",
    ]
    hostname                         = "1d99b690-d81d-4cd6-bc3d-62975954c756"
    ...
    operating_system                 = "centos_8"
    plan                             = "m2.xlarge.x86"
    ...
    tags                             = [
        "local_test",
        "918ce3d",
    ]
    ...
}
```

## Related issues

Resolves #141 