### PR TITLE
Remove old execution directories

### DIFF
--- a/infra/cron/cron.sh
+++ b/infra/cron/cron.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# Copyright 2021 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+crontab ./cron.txt

--- a/infra/cron/cron.txt
+++ b/infra/cron/cron.txt
@@ -1,0 +1,1 @@
+0 0 * * * find /exec/* -mtime +365 -exec rm -Rf {} \;


### PR DESCRIPTION
## Description

Addition of a cron to remove old execution directories. Each directory that's 1 year old will be removed.

To add the corn to crontab:

```sh
cd ./infra/cron
./cron.sh
```

## Related issues

Fixes #171.