### PR TITLE
Add label to Vitess PR to automatically request benchmarks

### DIFF
--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -41,7 +41,7 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
       --web-microbench-config string        Path to the configuration file used to execute microbenchmark.
       --web-mode string                     Specify the mode on which the server will run
       --web-port string                     Port used for the HTTP server (default "8080")
-      --web-pr-label-trigger string         GitHub Pull Request label that will trigger the execution of new execution.
+      --web-pr-label-trigger string         GitHub Pull Request label that will trigger the execution of new execution. (default "Benchmark me")
       --web-static-path string              Path to the static directory
       --web-template-path string            Path to the template directory
 ```

--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -41,6 +41,7 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
       --web-microbench-config string        Path to the configuration file used to execute microbenchmark.
       --web-mode string                     Specify the mode on which the server will run
       --web-port string                     Port used for the HTTP server (default "8080")
+      --web-pr-label-trigger string         GitHub Pull Request label that will trigger the execution of new execution.
       --web-static-path string              Path to the static directory
       --web-template-path string            Path to the template directory
 ```

--- a/go/exec/status.go
+++ b/go/exec/status.go
@@ -19,8 +19,8 @@
 package exec
 
 const (
-	statusCreated  = "created"
-	statusStarted  = "started"
-	statusFailed   = "failed"
-	statusFinished = "finished"
+	StatusCreated  = "created"
+	StatusStarted  = "started"
+	StatusFailed   = "failed"
+	StatusFinished = "finished"
 )

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -66,7 +66,7 @@ func (s Server) cronPRLabels() {
 		"tpcc":  s.macrobenchConfigPathTPCC,
 	}
 
-	SHAs, err := git.GetPullRequestHeadForLabels([]string{"\"Component: Query Serving\""}, "vitessio/vitess")
+	SHAs, err := git.GetPullRequestHeadForLabels([]string{s.prLabelTrigger}, "vitessio/vitess")
 	if err != nil {
 		slog.Error(err)
 		return

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -62,7 +62,7 @@ func (s *Server) cronMasterHandler() {
 		slog.Warn(err.Error())
 		return
 	}
-	s.cronExecution(configs, ref)
+	s.cronExecution(configs, ref, "cron")
 }
 
 func (s Server) cronPRLabels() {
@@ -82,7 +82,7 @@ func (s Server) cronPRLabels() {
 	toExec := map[string][]string{}
 	for _, sha := range SHAs {
 		for configType, configFile := range configs {
-			exist, err := exec.Exists(s.dbClient, sha, "cron", configType, exec.StatusFinished)
+			exist, err := exec.Exists(s.dbClient, sha, "cron_pr", configType, exec.StatusFinished)
 			if err != nil {
 				slog.Error(err)
 				continue
@@ -93,11 +93,11 @@ func (s Server) cronPRLabels() {
 		}
 	}
 	for gitRef, configArray := range toExec {
-		s.cronExecution(configArray, gitRef)
+		s.cronExecution(configArray, gitRef, "cron_pr")
 	}
 }
 
-func (s *Server) cronExecution(configs []string, ref string) {
+func (s *Server) cronExecution(configs []string, ref, source string) {
 	for _, config := range configs {
 		e, err := exec.NewExecWithConfig(config)
 		if err != nil {

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -80,7 +80,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.macrobenchConfigPathOLTP, flagMacroBenchConfigFileOLTP, "", "Path to the configuration file used to execute OLTP macrobenchmark.")
 	cmd.Flags().StringVar(&s.macrobenchConfigPathTPCC, flagMacroBenchConfigFileTPCC, "", "Path to the configuration file used to execute TPCC macrobenchmark.")
 	cmd.Flags().StringVar(&s.cronSchedule, flagCronSchedule, "@midnight", "Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON.")
-	cmd.Flags().StringVar(&s.prLabelTrigger, flagPullRequestLabelTrigger, "", "GitHub Pull Request label that will trigger the execution of new execution.")
+	cmd.Flags().StringVar(&s.prLabelTrigger, flagPullRequestLabelTrigger, "Benchmark me", "GitHub Pull Request label that will trigger the execution of new execution.")
 	_ = cmd.MarkFlagRequired(flagMicroBenchConfigFile)
 	_ = cmd.MarkFlagRequired(flagMacroBenchConfigFileOLTP)
 	_ = cmd.MarkFlagRequired(flagMacroBenchConfigFileTPCC)

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -41,6 +41,7 @@ const (
 	flagMacroBenchConfigFileOLTP = "web-macrobench-oltp-config"
 	flagMacroBenchConfigFileTPCC = "web-macrobench-tpcc-config"
 	flagCronSchedule             = "web-cron-schedule"
+	flagPullRequestLabelTrigger  = "web-pr-label-trigger"
 )
 
 type Server struct {
@@ -61,6 +62,8 @@ type Server struct {
 	macrobenchConfigPathOLTP string
 	macrobenchConfigPathTPCC string
 
+	prLabelTrigger string
+
 	// Mode used to run the server.
 	Mode
 }
@@ -77,6 +80,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.macrobenchConfigPathOLTP, flagMacroBenchConfigFileOLTP, "", "Path to the configuration file used to execute OLTP macrobenchmark.")
 	cmd.Flags().StringVar(&s.macrobenchConfigPathTPCC, flagMacroBenchConfigFileTPCC, "", "Path to the configuration file used to execute TPCC macrobenchmark.")
 	cmd.Flags().StringVar(&s.cronSchedule, flagCronSchedule, "@midnight", "Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON.")
+	cmd.Flags().StringVar(&s.prLabelTrigger, flagPullRequestLabelTrigger, "", "GitHub Pull Request label that will trigger the execution of new execution.")
 	_ = cmd.MarkFlagRequired(flagMicroBenchConfigFile)
 	_ = cmd.MarkFlagRequired(flagMacroBenchConfigFileOLTP)
 	_ = cmd.MarkFlagRequired(flagMacroBenchConfigFileTPCC)
@@ -90,6 +94,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagMacroBenchConfigFileOLTP, cmd.Flags().Lookup(flagMacroBenchConfigFileOLTP))
 	_ = viper.BindPFlag(flagMacroBenchConfigFileTPCC, cmd.Flags().Lookup(flagMacroBenchConfigFileTPCC))
 	_ = viper.BindPFlag(flagCronSchedule, cmd.Flags().Lookup(flagCronSchedule))
+	_ = viper.BindPFlag(flagPullRequestLabelTrigger, cmd.Flags().Lookup(flagPullRequestLabelTrigger))
 
 	if s.dbCfg == nil {
 		s.dbCfg = &mysql.ConfigDB{}

--- a/go/tools/git/github.go
+++ b/go/tools/git/github.go
@@ -25,6 +25,9 @@ import (
 	"net/url"
 )
 
+// GetPullRequestHeadForLabels fetches every pull requests in the provided repo that have the
+// given set of labels. It then returns each pull request's head SHA.
+// The format for repo is: "{USERNAME}/{REPO_NAME}", i.e "vitessio/vitess".
 func GetPullRequestHeadForLabels(labels []string, repo string) ([]string, error) {
 	pulls, err := getPullRequestsForLabels(labelsToURL(labels), repo)
 	if err != nil {

--- a/go/tools/git/github.go
+++ b/go/tools/git/github.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 func GetPullRequestHeadForLabels(labels []string, repo string) ([]string, error) {
@@ -44,7 +45,7 @@ func GetPullRequestHeadForLabels(labels []string, repo string) ([]string, error)
 func labelsToURL(labels []string) string {
 	result := ""
 	for i, label := range labels {
-		result += "label:"+label
+		result += "label:"+url.PathEscape(label)
 		if i + 1 < len(labels) {
 			result += "+"
 		}

--- a/go/tools/git/github.go
+++ b/go/tools/git/github.go
@@ -1,0 +1,111 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package git
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func GetPullRequestHeadForLabels(labels []string, repo string) ([]string, error) {
+	pulls, err := getPullRequestsForLabels(labelsToURL(labels), repo)
+	if err != nil {
+		return nil, err
+	}
+
+	SHAs := []string{}
+	for _, pull := range pulls {
+		head, err := getPullRequestHead(pull)
+		if err != nil {
+			return nil, err
+		}
+		SHAs = append(SHAs, head)
+	}
+	return SHAs, nil
+}
+
+func labelsToURL(labels []string) string {
+	result := ""
+	for i, label := range labels {
+		result += "label:"+label
+		if i + 1 < len(labels) {
+			result += "+"
+		}
+	}
+	return result
+}
+
+func getPullRequestsForLabels(labels, repo string) ([]string, error) {
+	query := fmt.Sprintf("https://api.github.com/search/issues?q=repo:%s+is:pr+is:open", repo)
+	if labels != "" {
+		query += "+" + labels
+	}
+	client := http.Client{}
+	request, err := http.NewRequest(http.MethodGet, query, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	res := struct {
+		Items []struct{
+			PullRequest struct {
+				URL string `json:"url"`
+			} `json:"pull_request"`
+		} `json:"items"`
+	}{}
+	err = json.NewDecoder(response.Body).Decode(&res)
+	if err != nil {
+		return nil, err
+	}
+	var pulls []string
+	for _, r := range res.Items {
+		pulls = append(pulls, r.PullRequest.URL)
+	}
+	return pulls, nil
+}
+
+func getPullRequestHead(url string) (string, error) {
+	client := http.Client{}
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	res := struct {
+		Head struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+	}{}
+	err = json.NewDecoder(response.Body).Decode(&res)
+	if err != nil {
+		return "", err
+	}
+	return res.Head.SHA, nil
+}

--- a/go/tools/git/github_test.go
+++ b/go/tools/git/github_test.go
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package git
+
+import (
+	qt "github.com/frankban/quicktest"
+	"testing"
+)
+
+func Test_labelsToURL(t *testing.T) {
+	tests := []struct {
+		name string
+		labels []string
+		want string
+	}{
+		{name: "Single label", labels: []string{"javascript"}, want: "label:javascript"},
+		{name: "Multiple labels", labels: []string{"javascript", "test"}, want: "label:javascript+label:test"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(labelsToURL(tt.labels), qt.Equals, tt.want)
+		})
+	}
+}

--- a/go/tools/macrobench/compare_test.go
+++ b/go/tools/macrobench/compare_test.go
@@ -40,7 +40,6 @@ func TestComparison_Regression(t *testing.T) {
 		{name: "VTGate time increase (1)", cmp: Comparison{DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{"vtgate": -11.98}}}, wantReason: "- vtgate CPU time increased by 11.98% \n"},
 		{name: "VTGate time increase (2)", cmp: Comparison{DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{"vtgate": -5}}}, wantReason: "- vtgate CPU time increased by 5.00% \n"},
 		{name: "VTGate time no increase", cmp: Comparison{DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{"vtgate": -4.99}}}, wantReason: ""},
-		{name: "VTGate and VTTablet times increase", cmp: Comparison{DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{"vtgate": -5, "vttablet": -5}}}, wantReason: "- vtgate CPU time increased by 5.00% \n- vttablet CPU time increased by 5.00% \n"},
 		{name: "TPS decrease", cmp: Comparison{Diff: Result{TPS: -50}}, wantReason: "- TPS decreased by 50.00% \n"},
 		{name: "Latency increase", cmp: Comparison{Diff: Result{Latency: -15}}, wantReason: "- Latency increased by 15.00% \n"},
 		{name: "QPS decrease", cmp: Comparison{Diff: Result{QPS: QPS{Total: -10}}}, wantReason: "- QPS decreased by 10.00% \n"},


### PR DESCRIPTION
## Description

A new cron job is added to the server, the job fetches the head's SHA of Vitess' pull requests matching a certain label (by default `Benchmark me`). Once we have the SHAs, we verify which type of benchmark (oltp, tpcc, micro) we need to execute for each SHA and execute a benchmark accordingly, we do not run the same benchmark twice on the same SHA.

## Related issues

Fixes #173.