### PR TITLE
Deleted unused api-key parameter in the server

### DIFF
--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -34,7 +34,6 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
       --influx-password string              Password used to connect to InfluxDB.
       --influx-port string                  Port on which to InfluxDB listens. (default "8086")
       --influx-username string              Username used to connect to InfluxDB.
-      --web-api-key string                  API key used to authenticate requests
       --web-cron-schedule string            Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON. (default "@midnight")
       --web-macrobench-oltp-config string   Path to the configuration file used to execute OLTP macrobenchmark.
       --web-macrobench-tpcc-config string   Path to the configuration file used to execute TPCC macrobenchmark.

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -37,7 +37,6 @@ const (
 	flagTemplatePath             = "web-template-path"
 	flagStaticPath               = "web-static-path"
 	flagVitessPath               = "web-vitess-path"
-	flagAPIKey                   = "web-api-key"
 	flagMode                     = "web-mode"
 	flagMicroBenchConfigFile     = "web-microbench-config"
 	flagMacroBenchConfigFileOLTP = "web-macrobench-oltp-config"
@@ -51,7 +50,6 @@ type Server struct {
 	templatePath    string
 	staticPath      string
 	localVitessPath string
-	apiKey          string
 	router          *gin.Engine
 
 	dbCfg    *mysql.ConfigDB
@@ -76,7 +74,6 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.templatePath, flagTemplatePath, "", "Path to the template directory")
 	cmd.Flags().StringVar(&s.staticPath, flagStaticPath, "", "Path to the static directory")
 	cmd.Flags().StringVar(&s.localVitessPath, flagVitessPath, "/", "Absolute path where the vitess directory is located or where it should be cloned")
-	cmd.Flags().StringVar(&s.apiKey, flagAPIKey, "", "API key used to authenticate requests")
 	cmd.Flags().Var(&s.Mode, flagMode, "Specify the mode on which the server will run")
 
 	// execution configuration flags
@@ -93,7 +90,6 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagTemplatePath, cmd.Flags().Lookup(flagTemplatePath))
 	_ = viper.BindPFlag(flagStaticPath, cmd.Flags().Lookup(flagStaticPath))
 	_ = viper.BindPFlag(flagVitessPath, cmd.Flags().Lookup(flagVitessPath))
-	_ = viper.BindPFlag(flagAPIKey, cmd.Flags().Lookup(flagAPIKey))
 	_ = viper.BindPFlag(flagMode, cmd.Flags().Lookup(flagMode))
 	_ = viper.BindPFlag(flagMicroBenchConfigFile, cmd.Flags().Lookup(flagMicroBenchConfigFile))
 	_ = viper.BindPFlag(flagMacroBenchConfigFileOLTP, cmd.Flags().Lookup(flagMacroBenchConfigFileOLTP))
@@ -113,7 +109,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 }
 
 func (s Server) isReady() bool {
-	return s.port != "" && s.templatePath != "" && s.staticPath != "" && s.apiKey != "" &&
+	return s.port != "" && s.templatePath != "" && s.staticPath != "" &&
 		s.microbenchConfigPath != "" && s.macrobenchConfigPathOLTP != "" && s.macrobenchConfigPathTPCC != "" && s.localVitessPath != ""
 }
 
@@ -181,13 +177,12 @@ func (s *Server) Run() error {
 	return s.router.Run(":" + s.port)
 }
 
-func Run(port, templatePath, staticPath, localVitessPath, apiKey string) error {
+func Run(port, templatePath, staticPath, localVitessPath string) error {
 	s := Server{
 		port:                     port,
 		templatePath:             templatePath,
 		staticPath:               staticPath,
 		localVitessPath:          localVitessPath,
-		apiKey:                   apiKey,
 		microbenchConfigPath:     "/",
 		macrobenchConfigPathOLTP: "/",
 		macrobenchConfigPathTPCC: "/",

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -30,7 +30,6 @@ func TestRun(t *testing.T) {
 		templatePath    string
 		staticPath      string
 		localVitessPath string
-		apiKey          string
 	}
 	tests := []struct {
 		name    string
@@ -38,17 +37,16 @@ func TestRun(t *testing.T) {
 		wantErr bool
 		err     string
 	}{
-		{name: "Missing port", args: args{templatePath: "./", staticPath: "./", localVitessPath: "~/", apiKey: "api_key"}, wantErr: true, err: ErrorIncorrectConfiguration},
-		{name: "Missing template path", args: args{port: "8888", staticPath: "./", localVitessPath: "~/", apiKey: "424242-848484-ABC"}, wantErr: true, err: ErrorIncorrectConfiguration},
-		{name: "Missing static path", args: args{port: "9999", templatePath: "./", localVitessPath: "~/", apiKey: "my key"}, wantErr: true, err: ErrorIncorrectConfiguration},
-		{name: "Missing api key", args: args{port: "8080", templatePath: "./", staticPath: "./static", localVitessPath: "~/"}, wantErr: true, err: ErrorIncorrectConfiguration},
-		{name: "Missing local vitess path", args: args{port: "8080", templatePath: "./", staticPath: "./static", apiKey: "api-key"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing port", args: args{templatePath: "./", staticPath: "./", localVitessPath: "~/"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing template path", args: args{port: "8888", staticPath: "./", localVitessPath: "~/"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing static path", args: args{port: "9999", templatePath: "./", localVitessPath: "~/"}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Missing local vitess path", args: args{port: "8080", templatePath: "./", staticPath: "./static"}, wantErr: true, err: ErrorIncorrectConfiguration},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			gotErr := Run(tt.args.port, tt.args.templatePath, tt.args.staticPath, tt.args.localVitessPath, tt.args.apiKey)
+			gotErr := Run(tt.args.port, tt.args.templatePath, tt.args.staticPath, tt.args.localVitessPath)
 			if tt.wantErr == true {
 				c.Assert(gotErr, qt.Not(qt.IsNil))
 				c.Assert(gotErr, qt.ErrorMatches, tt.err)
@@ -87,15 +85,15 @@ func TestServer_isReady(t *testing.T) {
 		s    Server
 		want bool
 	}{
-		{name: "Server fully ready", s: Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/", apiKey: "api_key", microbenchConfigPath: "micro/config.yaml", macrobenchConfigPathOLTP: "oltp/config.yaml", macrobenchConfigPathTPCC: "tpcc/config.yaml"}, want: true},
-		{name: "Missing port", s: Server{templatePath: "./", staticPath: "./", localVitessPath: "~/", apiKey: "api_key"}},
-		{name: "Missing template path", s: Server{port: "8888", staticPath: "./", localVitessPath: "~/", apiKey: "424242-848484-ABC"}},
-		{name: "Missing static path", s: Server{port: "9999", templatePath: "./", localVitessPath: "~/", apiKey: "my key"}},
+		{name: "Server fully ready", s: Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/", microbenchConfigPath: "micro/config.yaml", macrobenchConfigPathOLTP: "oltp/config.yaml", macrobenchConfigPathTPCC: "tpcc/config.yaml"}, want: true},
+		{name: "Missing port", s: Server{templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Missing template path", s: Server{port: "8888", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Missing static path", s: Server{port: "9999", templatePath: "./", localVitessPath: "~/"}},
 		{name: "Missing api key", s: Server{port: "8080", templatePath: "./", staticPath: "./static", localVitessPath: "~/"}},
-		{name: "Missing local vitess path", s: Server{port: "8080", templatePath: "./", staticPath: "./static", apiKey: "api_key"}},
-		{name: "Missing multiple elements (1)", s: Server{port: "8080", staticPath: "", localVitessPath: "~/", apiKey: ""}},
-		{name: "Missing multiple elements (2)", s: Server{templatePath: "", staticPath: "./", localVitessPath: "~/", apiKey: "428484242-4284842-IUN81B5465"}},
-		{name: "Missing execution configuration paths", s: Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/", apiKey: "api_key"}},
+		{name: "Missing local vitess path", s: Server{port: "8080", templatePath: "./", staticPath: "./static"}},
+		{name: "Missing multiple elements (1)", s: Server{port: "8080", staticPath: "", localVitessPath: "~/"}},
+		{name: "Missing multiple elements (2)", s: Server{templatePath: "", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Missing execution configuration paths", s: Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Remove the API key parameter in the server and CLI documentation. Webhooks and API are deprecated since #162.

## Related issues

Resolves #177.