### PR TITLE
Changed redundant methods and fields naming in the microbench package

### DIFF
--- a/go/cmd/microbench/run.go
+++ b/go/cmd/microbench/run.go
@@ -23,7 +23,7 @@ import (
 )
 
 func run() *cobra.Command {
-	var mbcfg microbench.MicroBenchConfig
+	var mbcfg microbench.Config
 	mbcfg.DatabaseConfig = &mysql.ConfigDB{}
 
 	cmd := &cobra.Command{
@@ -44,7 +44,7 @@ The output can also be outputted to <output file>.`,
 			mbcfg.Package = args[idx]
 			mbcfg.Output = args[idx+1]
 
-			err := microbench.MicroBenchmark(mbcfg)
+			err := microbench.Run(mbcfg)
 			if err != nil {
 				return err
 			}

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -235,7 +235,7 @@ Benchmark UUIDs, recent: ` + e.UUID.String()[:7] + ` old: ` + previousExec[:7] +
 `
 
 	if e.typeOf == "micro" {
-		microBenchmarks, err := microbench.CompareMicroBenchmarks(e.clientDB, e.GitRef, previousGitRef)
+		microBenchmarks, err := microbench.Compare(e.clientDB, e.GitRef, previousGitRef)
 		if err != nil {
 			return err
 		}

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -95,7 +95,7 @@ func (s *Server) compareHandler(c *gin.Context) {
 	}
 
 	// Compare Microbenchmarks for the two given SHAs.
-	microsMatrix, err := microbench.CompareMicroBenchmarks(s.dbClient, reference, compare)
+	microsMatrix, err := microbench.Compare(s.dbClient, reference, compare)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -215,7 +215,7 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	}
 	rightMbd = rightMbd.ReduceSimpleMedianByName()
 
-	matrix := microbench.MergeMicroBenchmarkDetails(leftMbd, rightMbd)
+	matrix := microbench.MergeDetails(leftMbd, rightMbd)
 	sort.SliceStable(matrix, func(i, j int) bool {
 		return !(matrix[i].Current.NSPerOp < matrix[j].Current.NSPerOp)
 	})

--- a/go/tools/microbench/compare_test.go
+++ b/go/tools/microbench/compare_test.go
@@ -26,10 +26,10 @@ import (
 func TestMicroBenchmarkComparisonArray_Regression(t *testing.T) {
 	tests := []struct {
 		name         string
-		microsMatrix MicroBenchmarkComparisonArray
+		microsMatrix ComparisonArray
 		wantReason   string
 	}{
-		{name: "No regression", microsMatrix: MicroBenchmarkComparisonArray{
+		{name: "No regression", microsMatrix: ComparisonArray{
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, CurrLastDiff: 1},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, CurrLastDiff: 1},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, CurrLastDiff: 1},
@@ -38,13 +38,13 @@ func TestMicroBenchmarkComparisonArray_Regression(t *testing.T) {
 			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, CurrLastDiff: 1},
 		}, wantReason: ""},
 
-		{name: "Few regressions", microsMatrix: MicroBenchmarkComparisonArray{
+		{name: "Few regressions", microsMatrix: ComparisonArray{
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, CurrLastDiff: 0.5},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, CurrLastDiff: 0.89},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, CurrLastDiff: 0.25},
 		}, wantReason: "- pkg1/bench3-pkg1 decreased by 50.00%\n- pkg1/bench1-pkg1 decreased by 11.00%\n- pkg1/bench2-pkg1 decreased by 75.00%\n"},
 
-		{name: "Close call regressions", microsMatrix: MicroBenchmarkComparisonArray{
+		{name: "Close call regressions", microsMatrix: ComparisonArray{
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, CurrLastDiff: 0.90},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, CurrLastDiff: 0.91},
 			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, CurrLastDiff: 0.899},

--- a/go/tools/microbench/config.go
+++ b/go/tools/microbench/config.go
@@ -26,7 +26,7 @@ const (
 	flagExecUUID = "microbench-exec-uuid"
 )
 
-type MicroBenchConfig struct {
+type Config struct {
 	// RootDir is the root path from where micro benchmarks will
 	// be executed.
 	RootDir        string
@@ -48,7 +48,7 @@ type MicroBenchConfig struct {
 	execUUID string
 }
 
-func (mbc *MicroBenchConfig) AddToCommand(cmd *cobra.Command) {
+func (mbc *Config) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&mbc.execUUID, flagExecUUID, "", "UUID of the parent execution, an empty string will set to NULL.")
 
 	_ = viper.BindPFlag(flagExecUUID, cmd.Flags().Lookup(flagExecUUID))

--- a/go/tools/microbench/line_test.go
+++ b/go/tools/microbench/line_test.go
@@ -26,7 +26,7 @@ import (
 func Test_benchmarkRunLine_applyRegularExpr_checkBenchType(t *testing.T) {
 	tests := []struct {
 		name            string
-		benchTypeWanted BenchType
+		benchTypeWanted microType
 		stringToParse   string
 	}{
 		// regular benchmarks
@@ -75,7 +75,7 @@ func Test_benchmarkRunLine_applyRegularExpr_checkBenchType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			line := &benchmarkRunLine{Output: tt.stringToParse}
+			line := &lineRun{Output: tt.stringToParse}
 			line.applyRegularExpr()
 			gotBenchType := line.benchType
 			c.Assert(gotBenchType, qt.Equals, tt.benchTypeWanted)
@@ -85,7 +85,7 @@ func Test_benchmarkRunLine_applyRegularExpr_checkBenchType(t *testing.T) {
 
 func BenchmarkApplyRegularExprRegularBenchmark(b *testing.B) {
 	b.ReportAllocs()
-	line := &benchmarkRunLine{Output: "BenchmarkEmpty-16 1000000000 0.2439 ns/op\n"}
+	line := &lineRun{Output: "BenchmarkEmpty-16 1000000000 0.2439 ns/op\n"}
 
 	for i := 0; i < b.N; i++ {
 		line.applyRegularExpr()
@@ -97,7 +97,7 @@ func BenchmarkApplyRegularExprRegularBenchmark(b *testing.B) {
 
 func BenchmarkApplyRegularExprAllocsBenchmark(b *testing.B) {
 	b.ReportAllocs()
-	line := &benchmarkRunLine{Output: "BenchmarkAllocs-16 1000000000 0.2439 ns/op \t90 B/op \t1 allocs/op\n"}
+	line := &lineRun{Output: "BenchmarkAllocs-16 1000000000 0.2439 ns/op \t90 B/op \t1 allocs/op\n"}
 
 	for i := 0; i < b.N; i++ {
 		line.applyRegularExpr()
@@ -109,7 +109,7 @@ func BenchmarkApplyRegularExprAllocsBenchmark(b *testing.B) {
 
 func BenchmarkApplyRegularExprBytesBenchmark(b *testing.B) {
 	b.ReportAllocs()
-	line := &benchmarkRunLine{Output: "BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n"}
+	line := &lineRun{Output: "BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n"}
 
 	for i := 0; i < b.N; i++ {
 		line.applyRegularExpr()
@@ -121,7 +121,7 @@ func BenchmarkApplyRegularExprBytesBenchmark(b *testing.B) {
 
 func BenchmarkApplyRegularExprMixedBenchmark(b *testing.B) {
 	b.ReportAllocs()
-	line := &benchmarkRunLine{Output: "BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s \t90 B/op \t1 allocs/op\n"}
+	line := &lineRun{Output: "BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s \t90 B/op \t1 allocs/op\n"}
 
 	for i := 0; i < b.N; i++ {
 		line.applyRegularExpr()
@@ -148,7 +148,7 @@ func Test_benchmarkRunLine_parseGeneralBenchmarkInvalidSubmatchLen(t *testing.T)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			line := &benchmarkRunLine{submatch: tt.submatch}
+			line := &lineRun{submatch: tt.submatch}
 			err := line.parseGeneralBenchmark()
 			c.Assert(err != nil, qt.Equals, tt.wantErr)
 		})
@@ -160,19 +160,19 @@ func Test_benchmarkRunLine_parseGeneralBenchmark(t *testing.T) {
 		name        string
 		submatch    []string
 		wantErr     bool
-		wantResults benchmarkResult
+		wantResults lineResult
 	}{
-		{name: "regular benchmark (1)", submatch: []string{"BenchmarkEmpty-16 1000000000 0.2439 ns/op", "BenchmarkEmpty-16", "1000000000", "0.2439", "", "", ""}, wantResults: benchmarkResult{Op: 1000000000, NanosecondPerOp: 0.2439}},
-		{name: "regular benchmark (2)", submatch: []string{"BenchmarkEmpty-16 19836 178.2396 ns/op", "BenchmarkEmpty-16", "19836", "178.2396", "", "", ""}, wantResults: benchmarkResult{Op: 19836, NanosecondPerOp: 178.2396}},
+		{name: "regular benchmark (1)", submatch: []string{"BenchmarkEmpty-16 1000000000 0.2439 ns/op", "BenchmarkEmpty-16", "1000000000", "0.2439", "", "", ""}, wantResults: lineResult{Op: 1000000000, NanosecondPerOp: 0.2439}},
+		{name: "regular benchmark (2)", submatch: []string{"BenchmarkEmpty-16 19836 178.2396 ns/op", "BenchmarkEmpty-16", "19836", "178.2396", "", "", ""}, wantResults: lineResult{Op: 19836, NanosecondPerOp: 178.2396}},
 
-		{name: "allocs benchmark (1)", submatch: []string{"BenchmarkAllocs-16 1000000000 0.2439 ns/op \t90 B/op \t1 allocs/op\n", "BenchmarkAllocs-16", "1000000000", "0.2439", "", "90", "1"}, wantResults: benchmarkResult{Op: 1000000000, NanosecondPerOp: 0.2439, BytesPerOp: 90, AllocsPerOp: 1}},
-		{name: "allocs benchmark (2)", submatch: []string{"BenchmarkAllocs-16 19836 178.2396 ns/op \t40489 B/op \t190 allocs/op\n", "BenchmarkAllocs-16", "19836", "178.2396", "", "40489", "190"}, wantResults: benchmarkResult{Op: 19836, NanosecondPerOp: 178.2396, BytesPerOp: 40489, AllocsPerOp: 190}},
+		{name: "allocs benchmark (1)", submatch: []string{"BenchmarkAllocs-16 1000000000 0.2439 ns/op \t90 B/op \t1 allocs/op\n", "BenchmarkAllocs-16", "1000000000", "0.2439", "", "90", "1"}, wantResults: lineResult{Op: 1000000000, NanosecondPerOp: 0.2439, BytesPerOp: 90, AllocsPerOp: 1}},
+		{name: "allocs benchmark (2)", submatch: []string{"BenchmarkAllocs-16 19836 178.2396 ns/op \t40489 B/op \t190 allocs/op\n", "BenchmarkAllocs-16", "19836", "178.2396", "", "40489", "190"}, wantResults: lineResult{Op: 19836, NanosecondPerOp: 178.2396, BytesPerOp: 40489, AllocsPerOp: 190}},
 
-		{name: "bytes benchmark (1)", submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "", ""}, wantResults: benchmarkResult{Op: 1000000000, NanosecondPerOp: 0.2439, MBs: 3837911248885.89}},
-		{name: "bytes benchmark (2)", submatch: []string{"BenchmarkBytes-16 19836 178.2396 ns/op \t985291124.89213 MB/s\n", "BenchmarkBytes-16", "19836", "178.2396", "985291124.89213", "", ""}, wantResults: benchmarkResult{Op: 19836, NanosecondPerOp: 178.2396, MBs: 985291124.89213}},
+		{name: "bytes benchmark (1)", submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "", ""}, wantResults: lineResult{Op: 1000000000, NanosecondPerOp: 0.2439, MBs: 3837911248885.89}},
+		{name: "bytes benchmark (2)", submatch: []string{"BenchmarkBytes-16 19836 178.2396 ns/op \t985291124.89213 MB/s\n", "BenchmarkBytes-16", "19836", "178.2396", "985291124.89213", "", ""}, wantResults: lineResult{Op: 19836, NanosecondPerOp: 178.2396, MBs: 985291124.89213}},
 
-		{name: "mixed benchmark (1)", submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "95", "2"}, wantResults: benchmarkResult{Op: 1000000000, NanosecondPerOp: 0.2439, MBs: 3837911248885.89, BytesPerOp: 95, AllocsPerOp: 2}},
-		{name: "mixed benchmark (2)", submatch: []string{"BenchmarkBytes-16 19836 178.2396 ns/op \t985291124.89213 MB/s\n", "BenchmarkBytes-16", "19836", "178.2396", "985291124.89213", "173", "9"}, wantResults: benchmarkResult{Op: 19836, NanosecondPerOp: 178.2396, MBs: 985291124.89213, BytesPerOp: 173, AllocsPerOp: 9}},
+		{name: "mixed benchmark (1)", submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "95", "2"}, wantResults: lineResult{Op: 1000000000, NanosecondPerOp: 0.2439, MBs: 3837911248885.89, BytesPerOp: 95, AllocsPerOp: 2}},
+		{name: "mixed benchmark (2)", submatch: []string{"BenchmarkBytes-16 19836 178.2396 ns/op \t985291124.89213 MB/s\n", "BenchmarkBytes-16", "19836", "178.2396", "985291124.89213", "173", "9"}, wantResults: lineResult{Op: 19836, NanosecondPerOp: 178.2396, MBs: 985291124.89213, BytesPerOp: 173, AllocsPerOp: 9}},
 
 		{name: "invalid number of ops", submatch: []string{"BenchmarkAllocs-16 wrong 0.2439 ns/op \t90 B/op \t1 allocs/op\n", "BenchmarkAllocs-16", "wrong", "0.2439", "", "90", "1"}, wantErr: true},
 		{name: "invalid ns/op", submatch: []string{"BenchmarkAllocs-16 19836 178.wrong ns/op \t40489 B/op \t190 allocs/op\n", "BenchmarkAllocs-16", "19836", "178.wrong", "", "40489", "190"}, wantErr: true},
@@ -183,7 +183,7 @@ func Test_benchmarkRunLine_parseGeneralBenchmark(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			line := &benchmarkRunLine{submatch: tt.submatch}
+			line := &lineRun{submatch: tt.submatch}
 			err := line.parseGeneralBenchmark()
 
 			c.Assert(err != nil, qt.Equals, tt.wantErr)
@@ -204,7 +204,7 @@ func Test_benchmarkRunLine_parseGeneralBenchmark(t *testing.T) {
 
 func BenchmarkParseSimpleGeneralBenchmark(b *testing.B) {
 	var err error
-	line := benchmarkRunLine{submatch: []string{"BenchmarkEmpty-16 1000000000 0.2439 ns/op", "BenchmarkEmpty-16", "1000000000", "0.2439", "", "", ""}}
+	line := lineRun{submatch: []string{"BenchmarkEmpty-16 1000000000 0.2439 ns/op", "BenchmarkEmpty-16", "1000000000", "0.2439", "", "", ""}}
 
 	for i := 0; i < b.N; i++ {
 		err = line.parseGeneralBenchmark()
@@ -216,7 +216,7 @@ func BenchmarkParseSimpleGeneralBenchmark(b *testing.B) {
 
 func BenchmarkParseAllocsGeneralBenchmark(b *testing.B) {
 	var err error
-	line := benchmarkRunLine{submatch: []string{"BenchmarkAllocs-16 1000000000 0.2439 ns/op \t90 B/op \t1 allocs/op\n", "BenchmarkAllocs-16", "1000000000", "0.2439", "", "90", "1"}}
+	line := lineRun{submatch: []string{"BenchmarkAllocs-16 1000000000 0.2439 ns/op \t90 B/op \t1 allocs/op\n", "BenchmarkAllocs-16", "1000000000", "0.2439", "", "90", "1"}}
 
 	for i := 0; i < b.N; i++ {
 		err = line.parseGeneralBenchmark()
@@ -228,7 +228,7 @@ func BenchmarkParseAllocsGeneralBenchmark(b *testing.B) {
 
 func BenchmarkParseBytesGeneralBenchmark(b *testing.B) {
 	var err error
-	line := benchmarkRunLine{submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "", ""}}
+	line := lineRun{submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "", ""}}
 
 	for i := 0; i < b.N; i++ {
 		err = line.parseGeneralBenchmark()
@@ -240,7 +240,7 @@ func BenchmarkParseBytesGeneralBenchmark(b *testing.B) {
 
 func BenchmarkParseMixedGeneralBenchmark(b *testing.B) {
 	var err error
-	line := benchmarkRunLine{submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "645", "14"}}
+	line := lineRun{submatch: []string{"BenchmarkBytes-16 1000000000 0.2439 ns/op \t3837911248885.89 MB/s\n", "BenchmarkBytes-16", "1000000000", "0.2439", "3837911248885.89", "645", "14"}}
 
 	for i := 0; i < b.N; i++ {
 		err = line.parseGeneralBenchmark()

--- a/go/tools/microbench/microbench.go
+++ b/go/tools/microbench/microbench.go
@@ -76,7 +76,7 @@ func (b *benchmark) execute(rootDir string, w *os.File) error {
 
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
-		var benchLine benchmarkRunLine
+		var benchLine lineRun
 		err := json.Unmarshal([]byte(line), &benchLine)
 		if err != nil || benchLine.Output == "" {
 			continue
@@ -118,10 +118,10 @@ func (b benchmark) executeProfile(rootDir, profileType string, w *os.File) error
 	return nil
 }
 
-// MicroBenchmark runs "go test bench" on the given package (pkg) and outputs
+// Run runs "go test bench" on the given package (pkg) and outputs
 // the results to outputPath.
 // Profiling files will be written to the current working directory.
-func MicroBenchmark(cfg MicroBenchConfig) error {
+func Run(cfg Config) error {
 	var sqlClient *mysql.Client
 	var err error
 

--- a/go/tools/microbench/microbench_test.go
+++ b/go/tools/microbench/microbench_test.go
@@ -26,17 +26,17 @@ import (
 func TestMicroBenchmark(t *testing.T) {
 	tests := []struct {
 		name        string
-		cfg         MicroBenchConfig
+		cfg         Config
 		wantErr     bool
 		errContains string
 	}{
-		{name: "Invalid package path", cfg: MicroBenchConfig{Package: "invalid", Output: "test.txt"}, wantErr: true, errContains: errorInvalidPackageParsing},
+		{name: "Invalid package path", cfg: Config{Package: "invalid", Output: "test.txt"}, wantErr: true, errContains: errorInvalidPackageParsing},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			gotErr := MicroBenchmark(tt.cfg)
+			gotErr := Run(tt.cfg)
 			if tt.wantErr {
 				c.Assert(gotErr, qt.Not(qt.IsNil))
 

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -27,81 +27,81 @@ import (
 func TestMicroBenchmarkResults_ReduceSimpleMedianByName(t *testing.T) {
 	tests := []struct {
 		name string
-		mbd  MicroBenchmarkDetailsArray
-		want MicroBenchmarkDetailsArray
+		mbd  DetailsArray
+		want DetailsArray
 	}{
 		// tc1
-		{name: "Few simple values in same package but different benchmark names", mbd: MicroBenchmarkDetailsArray{
+		{name: "Few simple values in same package but different benchmark names", mbd: DetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(100, 1.00, 1.00, 1, 9)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(100, 1.00, 2.00, 50, 18)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(100, 1.00, 3.00, 100, 27)),
 
 			// input bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
-		}, want: MicroBenchmarkDetailsArray{
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(150, 2.00, 3.00, 55.00, 42)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(300, 2.00, 4.00, 55.00, 84)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(450, 2.00, 5.00, 55.00, 126)),
+		}, want: DetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(100, 1.00, 2, 50.00, 18)),
 
 			// want bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(300, 2.00, 4, 55.00, 84)),
 		}},
 
 		// tc2
-		{name: "Few values in different packages and different benchmark names", mbd: MicroBenchmarkDetailsArray{
+		{name: "Few values in different packages and different benchmark names", mbd: DetailsArray{
 			// input bench 1 in pkg 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewResult(0, 1.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewResult(0, 5.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewResult(0, 10.00, 0, 0, 0)),
 
 			// input bench 1 in pkg 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
-		}, want: MicroBenchmarkDetailsArray{
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewResult(0, 2.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewResult(0, 2.50, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewResult(0, 3.00, 0, 0, 0)),
+		}, want: DetailsArray{
 			// want bench 1 from pkg1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewResult(0, 5.00, 0, 0, 0)),
 
 			// want bench 1 from pkg2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewResult(0, 2.50, 0, 0, 0)),
 		}},
 
 		// tc3
-		{name: "More unordered values with single package and benchmark name", mbd: MicroBenchmarkDetailsArray{
+		{name: "More unordered values with single package and benchmark name", mbd: DetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
-		}, want: MicroBenchmarkDetailsArray{
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 30.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 5.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 15.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 10.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 40.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 25.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 20.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 0.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 35.00, 0, 0, 0)),
+		}, want: DetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 20.00, 0, 0, 0)),
 		}},
 
 		// tc4
-		{name: "Few values in different packages and different benchmark names", mbd: MicroBenchmarkDetailsArray{
+		{name: "Few values in different packages and different benchmark names", mbd: DetailsArray{
 			// input bench 1 in pkg 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewResult(0, 2.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewResult(0, 2.50, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewResult(0, 3.00, 0, 0, 0)),
 
 			// input bench 1 in pkg 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
-		}, want: MicroBenchmarkDetailsArray{
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewResult(0, 1.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewResult(0, 5.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewResult(0, 10.00, 0, 0, 0)),
+		}, want: DetailsArray{
 			// want bench 1 from pkg1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewResult(0, 5.00, 0, 0, 0)),
 
 			// want bench 1 from pkg2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewResult(0, 2.50, 0, 0, 0)),
 		}},
 	}
 	for _, tt := range tests {
@@ -117,43 +117,43 @@ func TestMicroBenchmarkResults_ReduceSimpleMedianByName(t *testing.T) {
 func TestMicroBenchmarkResults_ReduceSimpleMedianByGitRef(t *testing.T) {
 	tests := []struct {
 		name string
-		mbd  MicroBenchmarkDetailsArray
-		want MicroBenchmarkDetailsArray
+		mbd  DetailsArray
+		want DetailsArray
 	}{
 		// tc1
-		{name: "Few simple values in same package with different git refs", mbd: MicroBenchmarkDetailsArray{
+		{name: "Few simple values in same package with different git refs", mbd: DetailsArray{
 			// input for git ref `abcd`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(100, 1.00, 1.00, 1, 9)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(100, 1.00, 2.00, 50, 18)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(100, 1.00, 3.00, 100, 27)),
 
 			// input for git ref `efgh`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
-		}, want: MicroBenchmarkDetailsArray{
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewResult(150, 2.00, 3.00, 55.00, 42)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewResult(300, 2.00, 4.00, 55.00, 84)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewResult(450, 2.00, 5.00, 55.00, 126)),
+		}, want: DetailsArray{
 			// want git ref `abcd`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(100, 1.00, 2, 50.00, 18)),
 
 			// want git ref `efgh`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewResult(300, 2.00, 4, 55.00, 84)),
 		}},
 
 		// tc2
-		{name: "More unordered values with same git ref", mbd: MicroBenchmarkDetailsArray{
+		{name: "More unordered values with same git ref", mbd: DetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
-		}, want: MicroBenchmarkDetailsArray{
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 30.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 5.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 15.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 10.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 40.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 25.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 20.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 0.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 35.00, 0, 0, 0)),
+		}, want: DetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewResult(0, 20.00, 0, 0, 0)),
 		}},
 	}
 	for _, tt := range tests {
@@ -167,13 +167,13 @@ func TestMicroBenchmarkResults_ReduceSimpleMedianByGitRef(t *testing.T) {
 }
 
 func BenchmarkReduceSimpleMedianByName(b *testing.B) {
-	mbd := MicroBenchmarkDetailsArray{
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+	mbd := DetailsArray{
+		*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 1.00, 0, 0, 0)),
+		*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 1.00, 0, 0, 0)),
+		*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 1.00, 0, 0, 0)),
+		*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(0, 2.00, 0, 0, 0)),
+		*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(0, 2.00, 0, 0, 0)),
+		*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(0, 2.00, 0, 0, 0)),
 	}
 
 	b.ReportAllocs()
@@ -192,116 +192,116 @@ func BenchmarkReduceSimpleMedianByName(b *testing.B) {
 
 func TestMergeMicroBenchmarkDetails(t *testing.T) {
 	type args struct {
-		currentMbd     MicroBenchmarkDetailsArray
-		lastReleaseMbd MicroBenchmarkDetailsArray
+		currentMbd     DetailsArray
+		lastReleaseMbd DetailsArray
 	}
 	tests := []struct {
 		name string
 		args args
-		want MicroBenchmarkComparisonArray
+		want ComparisonArray
 	}{
 		// tc1
 		{name: "Simple compare with ordered array of one elements", args: args{
-			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			currentMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 1.00, 0, 0, 0)),
 			},
-			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			lastReleaseMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 5.00, 0, 0, 0)),
 			},
-		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}, CurrLastDiff: 5},
+		}, want: ComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: Result{NSPerOp: 1.00}, Last: Result{NSPerOp: 5.00}, CurrLastDiff: 5},
 		}},
 
 		// tc2
 		{name: "Simple compare with ordered array of two elements", args: args{
-			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+			currentMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 1.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(0, 98.00, 0, 0, 0)),
 			},
-			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+			lastReleaseMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewResult(0, 5.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewResult(0, 89.00, 0, 0, 0)),
 			},
-		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+		}, want: ComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
 		}},
 
 		// tc3
 		{name: "Compare with unordered array", args: args{
-			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+			currentMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewResult(0, 58.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewResult(0, 1.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewResult(0, 98.00, 0, 0, 0)),
 			},
-			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
+			lastReleaseMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewResult(0, 89.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewResult(0, 5.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewResult(0, 56.00, 0, 0, 0)),
 			},
-		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+		}, want: ComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewResult(0, 58.00, 0, 0, 0), Last: *NewResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
 		}},
 
 		// tc4
 		{name: "Compare with unordered array from multiple package", args: args{
-			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
+			currentMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewResult(0, 58.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewResult(0, 1.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewResult(0, 98.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewResult(0, 3.50, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewResult(0, 5.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewResult(0, 2385.00, 0, 0, 0)),
 			},
-			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
+			lastReleaseMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewResult(0, 89.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewResult(0, 2560.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewResult(0, 56.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewResult(0, 6.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewResult(0, 5.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewResult(0, 4.20, 0, 0, 0)),
 			},
-		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0), CurrLastDiff: 1.7142857142857142},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0), CurrLastDiff: 1.0733752620545074},
+		}, want: ComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewResult(0, 58.00, 0, 0, 0), Last: *NewResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewResult(0, 3.50, 0, 0, 0), Last: *NewResult(0, 6.00, 0, 0, 0), CurrLastDiff: 1.7142857142857142},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewResult(0, 5.00, 0, 0, 0), Last: *NewResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewResult(0, 2385.00, 0, 0, 0), Last: *NewResult(0, 2560.00, 0, 0, 0), CurrLastDiff: 1.0733752620545074},
 		}},
 
 		// tc5
 		{name: "Compare with unordered and different size array from multiple package", args: args{
-			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
+			currentMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewResult(0, 58.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewResult(0, 1.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewResult(0, 98.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewResult(0, 3.50, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewResult(0, 5.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewResult(0, 2385.00, 0, 0, 0)),
 			},
-			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
+			lastReleaseMbd: DetailsArray{
+				*NewDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewResult(0, 89.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewResult(0, 56.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewResult(0, 5.00, 0, 0, 0)),
+				*NewDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewResult(0, 4.20, 0, 0, 0)),
 			},
-		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0, 0, 0, 0), CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0), CurrLastDiff: 1},
+		}, want: ComparisonArray{
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewResult(0, 58.00, 0, 0, 0), Last: *NewResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewResult(0, 3.50, 0, 0, 0), Last: *NewResult(0, 0, 0, 0, 0), CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewResult(0, 5.00, 0, 0, 0), Last: *NewResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewResult(0, 2385.00, 0, 0, 0), Last: *NewResult(0, 0.00, 0, 0, 0), CurrLastDiff: 1},
 		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			got := MergeMicroBenchmarkDetails(tt.args.currentMbd, tt.args.lastReleaseMbd)
+			got := MergeDetails(tt.args.currentMbd, tt.args.lastReleaseMbd)
 			c.Assert(got, qt.HasLen, len(tt.want))
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})
@@ -310,7 +310,7 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 
 func TestHumanReadableStrings(t *testing.T) {
 	c := qt.New(t)
-	r := MicroBenchmarkResult{
+	r := Result{
 		Ops:         876543,
 		NSPerOp:     141650883.50,
 		MBPerSec:    45030859.00,
@@ -324,7 +324,7 @@ func TestHumanReadableStrings(t *testing.T) {
 	c.Assert(r.OpsStr(), qt.Equals, "876,543")
 	c.Assert(r.BytesPerOpStr(), qt.Equals, "4.5 kB/op")
 
-	r = MicroBenchmarkResult{
+	r = Result{
 		NSPerOp: 2.5149999999999997,
 	}
 	c.Assert(r.NSPerOpStr(), qt.Equals, "2.5")

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -79,7 +79,7 @@ func GenerateCompareReport(client *mysql.Client, metricsClient *influxdb.Client,
 	}
 
 	// Compare microbenchmark results for the 2 SHAs
-	microsMatrix, err := microbench.CompareMicroBenchmarks(client, fromSHA, toSHA)
+	microsMatrix, err := microbench.Compare(client, fromSHA, toSHA)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Changed the naming throughout `microbench` package, removed redundant names such as: `microbench.MicroBench()` and `microbench.CompareMicroBenchmarks`.

## Related issues

Fixes #138.