### PR TITLE
Adds support to track microbenchmarks as distinct sub-benchmarks

### DIFF
--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -21,7 +21,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"sort"
 
 	"github.com/vitessio/arewefastyet/go/exec"
 
@@ -216,9 +215,6 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	rightMbd = rightMbd.ReduceSimpleMedianByName()
 
 	matrix := microbench.MergeMicroBenchmarkDetails(leftMbd, rightMbd)
-	sort.SliceStable(matrix, func(i, j int) bool {
-		return !(matrix[i].Current.NSPerOp < matrix[j].Current.NSPerOp)
-	})
 	c.HTML(http.StatusOK, "microbench.tmpl", gin.H{
 		"title":        "Vitess benchmark - microbenchmark",
 		"leftSHA":      leftSHA,

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -237,8 +237,9 @@ func findSHA(releases []*git.Release, tag string) (string, error) {
 
 func (s *Server) microbenchmarkSingleResultsHandler(c *gin.Context) {
 	name := c.Param("name")
+	subBenchmarkName := c.Query("subBenchmarkName")
 
-	results, err := microbench.GetLatestResultsFor(name, 10, s.dbClient)
+	results, err := microbench.GetLatestResultsFor(name, subBenchmarkName, 10, s.dbClient)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -246,8 +247,9 @@ func (s *Server) microbenchmarkSingleResultsHandler(c *gin.Context) {
 	results = results.ReduceSimpleMedianByGitRef()
 
 	c.HTML(http.StatusOK, "microbench_single.tmpl", gin.H{
-		"title":   "Vitess benchmark - microbenchmark - " + name,
-		"name":    name,
-		"results": results,
+		"title":            "Vitess benchmark - microbenchmark - " + name,
+		"name":             name,
+		"subBenchmarkName": subBenchmarkName,
+		"results":          results,
 	})
 }

--- a/go/server/templates/compare.tmpl
+++ b/go/server/templates/compare.tmpl
@@ -172,7 +172,7 @@ limitations under the License.
                         {{range $val := .microbenchmark}}
                         <tr>
                             <td>{{ $val.PkgName }}</td>
-                            <td><a href="/microbench/{{ $val.Name }}">{{ $val.SubBenchmarkName }}</a></td>
+                            <td><a href="/microbench/{{ $val.Name }}?subBenchmarkName={{ $val.SubBenchmarkName }}">{{ $val.SubBenchmarkName }}</a></td>
                             <td class="text-right {{if le $val.CurrLastDiff 0.90 }} bg-danger {{ else if ge $val.CurrLastDiff 1.10 }} bg-success {{ end }}">{{ $val.CurrLastDiffStr }}</td>
                             <td class="text-right">{{ $val.Current.OpsStr }}</td>
                             <td class="text-right">{{ $val.Last.OpsStr }}</td>

--- a/go/server/templates/compare.tmpl
+++ b/go/server/templates/compare.tmpl
@@ -172,7 +172,7 @@ limitations under the License.
                         {{range $val := .microbenchmark}}
                         <tr>
                             <td>{{ $val.PkgName }}</td>
-                            <td><a href="https://github.com/vitessio/vitess/search?q={{ $val.Name }}&type=code" target="_blank">{{ $val.Name }}</a></td>
+                            <td><a href="/microbench/{{ $val.Name }}">{{ $val.SubBenchmarkName }}</a></td>
                             <td class="text-right {{if le $val.CurrLastDiff 0.90 }} bg-danger {{ else if ge $val.CurrLastDiff 1.10 }} bg-success {{ end }}">{{ $val.CurrLastDiffStr }}</td>
                             <td class="text-right">{{ $val.Current.OpsStr }}</td>
                             <td class="text-right">{{ $val.Last.OpsStr }}</td>

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -98,7 +98,7 @@ limitations under the License.
                 {{range $val := .resultMatrix}}
                     <tr>
                         <td>{{ $val.PkgName }}</td>
-                        <td><a href="/microbench/{{ $val.Name }}">{{ $val.Name }}</a></td>
+                        <td><a href="/microbench/{{ $val.Name }}">{{ $val.SubBenchmarkName }}</a></td>
                         <td class="text-right">{{ $val.Current.OpsStr }}</td>
                         <td class="text-right">{{ $val.Last.OpsStr }}</td>
 

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -98,7 +98,7 @@ limitations under the License.
                 {{range $val := .resultMatrix}}
                     <tr>
                         <td>{{ $val.PkgName }}</td>
-                        <td><a href="/microbench/{{ $val.Name }}">{{ $val.SubBenchmarkName }}</a></td>
+                        <td><a href="/microbench/{{ $val.Name }}?subBenchmarkName={{ $val.SubBenchmarkName }}">{{ $val.SubBenchmarkName }}</a></td>
                         <td class="text-right">{{ $val.Current.OpsStr }}</td>
                         <td class="text-right">{{ $val.Last.OpsStr }}</td>
 

--- a/go/server/templates/microbench_single.tmpl
+++ b/go/server/templates/microbench_single.tmpl
@@ -28,7 +28,7 @@ limitations under the License.
 <section class="py-5">
     <div class="container">
         <h1>Microbenchmarks</h1>
-        <p class="lead">Displaying last 10 runs results for microbenchmark <a href="https://github.com/vitessio/vitess/search?q={{ .name }}&type=code" target="_blank">{{ .name }}</a></p>
+        <p class="lead">Displaying last 10 runs results for microbenchmark <a href="https://github.com/vitessio/vitess/search?q={{ .name }}&type=code" target="_blank">{{ .subBenchmarkName }}</a></p>
     </div>
 
     <div class="container-xl">

--- a/go/server/templates/search.tmpl
+++ b/go/server/templates/search.tmpl
@@ -134,7 +134,7 @@ limitations under the License.
                         {{range $val := .microbenchmark}}
                         <tr>
                             <td>{{ $val.PkgName }}</td>
-                            <td><a href="/microbench/{{ $val.Name }}">{{ $val.SubBenchmarkName }}</a></td>
+                            <td><a href="/microbench/{{ $val.Name }}?subBenchmarkName={{ $val.SubBenchmarkName }}">{{ $val.SubBenchmarkName }}</a></td>
                             <td class="text-right">{{ $val.Result.OpsStr }}</td>
                             <td class="text-right">{{ $val.Result.NSPerOpToDurationStr }}</td>
                             <td class="text-right">{{ $val.Result.MBPerSecStr }}</td>

--- a/go/server/templates/search.tmpl
+++ b/go/server/templates/search.tmpl
@@ -134,7 +134,7 @@ limitations under the License.
                         {{range $val := .microbenchmark}}
                         <tr>
                             <td>{{ $val.PkgName }}</td>
-                            <td><a href="/microbench/{{ $val.Name }}">{{ $val.Name }}</a></td>
+                            <td><a href="/microbench/{{ $val.Name }}">{{ $val.SubBenchmarkName }}</a></td>
                             <td class="text-right">{{ $val.Result.OpsStr }}</td>
                             <td class="text-right">{{ $val.Result.NSPerOpToDurationStr }}</td>
                             <td class="text-right">{{ $val.Result.MBPerSecStr }}</td>

--- a/go/tools/microbench/compare.go
+++ b/go/tools/microbench/compare.go
@@ -20,7 +20,6 @@ package microbench
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/vitessio/arewefastyet/go/storage/mysql"
 )
@@ -39,9 +38,7 @@ func CompareMicroBenchmarks(dbClient *mysql.Client, reference string, compare st
 		micros[sha] = micro.ReduceSimpleMedianByName()
 	}
 	microsMatrix := MergeMicroBenchmarkDetails(micros[reference], micros[compare])
-	sort.SliceStable(microsMatrix, func(i, j int) bool {
-		return !(microsMatrix[i].Current.NSPerOp < microsMatrix[j].Current.NSPerOp)
-	})
+	// The result of the merge will be sorted by the package name and then the benchmark name
 	return microsMatrix, nil
 }
 
@@ -54,7 +51,7 @@ func CompareMicroBenchmarks(dbClient *mysql.Client, reference string, compare st
 func (microsMatrix MicroBenchmarkComparisonArray) Regression() (reason string) {
 	for _, micro := range microsMatrix {
 		if micro.CurrLastDiff < 0.90 {
-			reason += fmt.Sprintf("- %s/%s decreased by %.2f%%\n", micro.PkgName, micro.Name, (1 - micro.CurrLastDiff) * 100)
+			reason += fmt.Sprintf("- %s/%s decreased by %.2f%%\n", micro.PkgName, micro.SubBenchmarkName, (1-micro.CurrLastDiff)*100)
 		}
 	}
 	return

--- a/go/tools/microbench/compare_test.go
+++ b/go/tools/microbench/compare_test.go
@@ -19,8 +19,9 @@
 package microbench
 
 import (
-	qt "github.com/frankban/quicktest"
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 func TestMicroBenchmarkComparisonArray_Regression(t *testing.T) {
@@ -30,24 +31,24 @@ func TestMicroBenchmarkComparisonArray_Regression(t *testing.T) {
 		wantReason   string
 	}{
 		{name: "No regression", microsMatrix: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, CurrLastDiff: 1},
 		}, wantReason: ""},
 
 		{name: "Few regressions", microsMatrix: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, CurrLastDiff: 0.5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, CurrLastDiff: 0.89},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, CurrLastDiff: 0.25},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, CurrLastDiff: 0.5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, CurrLastDiff: 0.89},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, CurrLastDiff: 0.25},
 		}, wantReason: "- pkg1/bench3-pkg1 decreased by 50.00%\n- pkg1/bench1-pkg1 decreased by 11.00%\n- pkg1/bench2-pkg1 decreased by 75.00%\n"},
 
 		{name: "Close call regressions", microsMatrix: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, CurrLastDiff: 0.90},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, CurrLastDiff: 0.91},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, CurrLastDiff: 0.899},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, CurrLastDiff: 0.90},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, CurrLastDiff: 0.91},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, CurrLastDiff: 0.899},
 		}, wantReason: "- pkg1/bench2-pkg1 decreased by 10.10%\n"},
 	}
 	for _, tt := range tests {

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -208,12 +208,12 @@ func GetResultsForGitRef(ref string, client *mysql.Client) (mrs MicroBenchmarkDe
 
 // GetLatestResultsFor will fetch and return a MicroBenchmarkDetailsArray
 // containing all the MicroBenchmarkDetails linked to latest runs of the given benchmark name.
-func GetLatestResultsFor(name string, count int, client *mysql.Client) (mrs MicroBenchmarkDetailsArray, err error) {
+func GetLatestResultsFor(name, subBenchmarkName string, count int, client *mysql.Client) (mrs MicroBenchmarkDetailsArray, err error) {
 	query := "select m.pkg_name, m.name, md.name, m.git_ref , md.n, md.ns_per_op, md.bytes_per_op," +
 		" md.allocs_per_op, md.mb_per_sec, m.started_at  from (select microbenchmark_no, pkg_name, name, microbenchmark.git_ref, started_at" +
 		" from microbenchmark join execution on exec_uuid = uuid where name = ? and source = \"cron\" and status = \"finished\" order by started_at desc limit ?) m, " +
-		"microbenchmark_details md where md.microbenchmark_no = m.microbenchmark_no"
-	rows, err := client.Select(query, name, count)
+		"microbenchmark_details md where md.microbenchmark_no = m.microbenchmark_no and md.name = ?"
+	rows, err := client.Select(query, name, count, subBenchmarkName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -33,75 +33,75 @@ func TestMicroBenchmarkResults_ReduceSimpleMedianByName(t *testing.T) {
 		// tc1
 		{name: "Few simple values in same package but different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
 
 			// input bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
 
 			// want bench 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
 		}},
 
 		// tc2
 		{name: "Few values in different packages and different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1 in pkg 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
 
 			// input bench 1 in pkg 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1 from pkg1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
 
 			// want bench 1 from pkg2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "", "2021-05-10T13:20:11Z", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
 		}},
 
 		// tc3
 		{name: "More unordered values with single package and benchmark name", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
 		}},
 
 		// tc4
 		{name: "Few values in different packages and different benchmark names", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1 in pkg 2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", ", ", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", ", ", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", ", ", "bench1"), "", "", *NewMicroBenchmarkResult(0, 3.00, 0, 0, 0)),
 
 			// input bench 1 in pkg 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", ", ", "bench2"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", ", ", "bench2"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", ", ", "bench2"), "", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1 from pkg1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", ", ", "bench2"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
 
 			// want bench 1 from pkg2
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", ", ", "bench1"), "", "", *NewMicroBenchmarkResult(0, 2.50, 0, 0, 0)),
 		}},
 	}
 	for _, tt := range tests {
@@ -123,37 +123,37 @@ func TestMicroBenchmarkResults_ReduceSimpleMedianByGitRef(t *testing.T) {
 		// tc1
 		{name: "Few simple values in same package with different git refs", mbd: MicroBenchmarkDetailsArray{
 			// input for git ref `abcd`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 1.00, 1, 9)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 2.00, 50, 18)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 3.00, 100, 27)),
 
 			// input for git ref `efgh`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(150, 2.00, 3.00, 55.00, 42)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(300, 2.00, 4.00, 55.00, 84)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(450, 2.00, 5.00, 55.00, 126)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want git ref `abcd`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(100, 1.00, 2, 50.00, 18)),
 
 			// want git ref `efgh`
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "efgh", "", *NewMicroBenchmarkResult(300, 2.00, 4, 55.00, 84)),
 		}},
 
 		// tc2
 		{name: "More unordered values with same git ref", mbd: MicroBenchmarkDetailsArray{
 			// input bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 30.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 15.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 10.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 40.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 25.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 35.00, 0, 0, 0)),
 		}, want: MicroBenchmarkDetailsArray{
 			// want bench 1
-			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
+			*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "abcd", "", *NewMicroBenchmarkResult(0, 20.00, 0, 0, 0)),
 		}},
 	}
 	for _, tt := range tests {
@@ -168,12 +168,12 @@ func TestMicroBenchmarkResults_ReduceSimpleMedianByGitRef(t *testing.T) {
 
 func BenchmarkReduceSimpleMedianByName(b *testing.B) {
 	mbd := MicroBenchmarkDetailsArray{
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
-		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
+		*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 2.00, 0, 0, 0)),
 	}
 
 	b.ReportAllocs()
@@ -203,98 +203,98 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 		// tc1
 		{name: "Simple compare with ordered array of one elements", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}, CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: MicroBenchmarkResult{NSPerOp: 1.00}, Last: MicroBenchmarkResult{NSPerOp: 5.00}, CurrLastDiff: 5},
 		}},
 
 		// tc2
 		{name: "Simple compare with ordered array of two elements", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
 		}},
 
 		// tc3
 		{name: "Compare with unordered array", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
 		}},
 
 		// tc4
 		{name: "Compare with unordered array from multiple package", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0), CurrLastDiff: 1.7142857142857142},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0), CurrLastDiff: 1.0733752620545074},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 6.00, 0, 0, 0), CurrLastDiff: 1.7142857142857142},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 2560.00, 0, 0, 0), CurrLastDiff: 1.0733752620545074},
 		}},
 
 		// tc5
 		{name: "Compare with unordered and different size array from multiple package", args: args{
 			currentMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "aabb", "", *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench2", "bench2-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg3", "bench1", "bench1-pkg3"), "ppbb", "", *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0)),
 			},
 			lastReleaseMbd: MicroBenchmarkDetailsArray{
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
-				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "ppbb", "", *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0)),
+				*NewMicroBenchmarkDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "ppbb", "", *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: MicroBenchmarkComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0, 0, 0, 0), CurrLastDiff: 1},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0), CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Current: *NewMicroBenchmarkResult(0, 58.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 56.00, 0, 0, 0), CurrLastDiff: 0.9655172413793104},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewMicroBenchmarkResult(0, 1.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), CurrLastDiff: 5},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewMicroBenchmarkResult(0, 98.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 89.00, 0, 0, 0), CurrLastDiff: 0.9081632653061225},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, Current: *NewMicroBenchmarkResult(0, 3.50, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0, 0, 0, 0), CurrLastDiff: 1},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, Current: *NewMicroBenchmarkResult(0, 5.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 4.20, 0, 0, 0), CurrLastDiff: 0.8400000000000001},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, Current: *NewMicroBenchmarkResult(0, 2385.00, 0, 0, 0), Last: *NewMicroBenchmarkResult(0, 0.00, 0, 0, 0), CurrLastDiff: 1},
 		}},
 	}
 	for _, tt := range tests {

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -17,9 +17,10 @@ limitations under the License.
 package report
 
 import (
-	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	"strconv"
 	"strings"
+
+	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 
 	"github.com/vitessio/arewefastyet/go/tools/microbench"
 
@@ -143,7 +144,7 @@ func GenerateCompareReport(client *mysql.Client, metricsClient *influxdb.Client,
 		}
 		// range over all the microbenchmarks
 		for _, microComp := range microsMatrix {
-			microTable = append(microTable, []tableCell{{value: microComp.PkgName + "." + microComp.Name, styleIndex: 2}})
+			microTable = append(microTable, []tableCell{{value: microComp.PkgName + "." + microComp.SubBenchmarkName, styleIndex: 2}})
 			microTable = append(microTable, []tableCell{{value: "Ops", styleIndex: 0}, {value: strconv.Itoa(microComp.Current.Ops), styleIndex: 1}, {value: strconv.Itoa(microComp.Last.Ops), styleIndex: 1}})
 			microTable = append(microTable, []tableCell{{value: "NSPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Current.NSPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Last.NSPerOp), styleIndex: 1}})
 			microTable = append(microTable, []tableCell{{value: "MBPerSec", styleIndex: 0}, {value: convertFloatToString(microComp.Current.MBPerSec), styleIndex: 1}, {value: convertFloatToString(microComp.Last.MBPerSec), styleIndex: 1}})


### PR DESCRIPTION
 ## Description
This PR augments the webserver to display the results of the sub-benchmarks separately and not part of the same microbenchmark.

After this PR, the `microbenchmark` page will look like this - 
![Screenshot 2021-05-13 at 4 41 13 PM](https://user-images.githubusercontent.com/35839558/118118157-32ce8500-b40a-11eb-9ee8-8a3679ec963b.png)

Also, the `microbenchmark/:name` page will now take a `subBenchmarkName` as a query argument and show results for a sub-benchmark
![Screenshot 2021-05-13 at 4 58 29 PM](https://user-images.githubusercontent.com/35839558/118120061-eb95c380-b40c-11eb-8ff2-f4d933dca372.png)


## Related Issues
- Resolves #161 