### PR TITLE
Add pull request information in execution and Ansible ExtraVars

### DIFF
--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -19,7 +19,7 @@
         repo: "{{ arewefastyet_git_repo }}"
         dest: /go/src/github.com/vitessio/arewefastyet
         version: "{{ arewefastyet_git_version }}"
-        refspec: "{{ arewefastyet_git_version_fetch_pr if arewefastyet_git_version_pr_nb is defined | default('') }}"
+        refspec: "{{ arewefastyet_git_version_fetch_pr if arewefastyet_git_version_pr_nb is defined else '' | default('') }}"
         force: true
 
     - name: Build arewefastyet CLI

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -34,6 +34,7 @@ arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --db-
       --equinix-project-id string         Project ID to use for Equinix Metal
       --equinix-token string              Auth Token for Equinix Metal
       --exec-git-ref string               Git reference on which the benchmarks will run.
+      --exec-pull-nb int                  Defines the number of the pull request against which to execute.
       --exec-root-dir string              Path to the root directory of exec.
       --exec-source string                Name of the source that triggered the execution.
       --exec-type string                  Defines the execution type (oltp, tpcc, micro).

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -28,6 +28,7 @@ const (
 	flagGitRefExec = "exec-git-ref"
 	flagSourceExec = "exec-source"
 	flagExecType   = "exec-type"
+	flagExecPullNB = "exec-pull-nb"
 )
 
 func (e *Exec) AddToViper(v *viper.Viper) (err error) {
@@ -35,6 +36,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	_ = v.UnmarshalKey(flagGitRefExec, &e.GitRef)
 	_ = v.UnmarshalKey(flagSourceExec, &e.Source)
 	_ = v.UnmarshalKey(flagExecType, &e.typeOf)
+	_ = v.UnmarshalKey(flagExecPullNB, &e.pullNB)
 
 	e.AnsibleConfig.AddToViper(v)
 	e.InfraConfig.AddToViper(v)
@@ -50,11 +52,13 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&e.GitRef, flagGitRefExec, "", "Git reference on which the benchmarks will run.")
 	cmd.Flags().StringVar(&e.Source, flagSourceExec, "", "Name of the source that triggered the execution.")
 	cmd.Flags().StringVar(&e.typeOf, flagExecType, "", "Defines the execution type (oltp, tpcc, micro).")
+	cmd.Flags().IntVar(&e.pullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
 
 	_ = viper.BindPFlag(flagRootExec, cmd.Flags().Lookup(flagRootExec))
 	_ = viper.BindPFlag(flagGitRefExec, cmd.Flags().Lookup(flagGitRefExec))
 	_ = viper.BindPFlag(flagSourceExec, cmd.Flags().Lookup(flagSourceExec))
 	_ = viper.BindPFlag(flagExecType, cmd.Flags().Lookup(flagExecType))
+	_ = viper.BindPFlag(flagExecPullNB, cmd.Flags().Lookup(flagExecPullNB))
 
 	e.AnsibleConfig.AddToPersistentCommand(cmd)
 	e.InfraConfig.AddToPersistentCommand(cmd)

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
@@ -69,6 +70,9 @@ type Exec struct {
 
 	// Defines the type of execution (oltp, tpcc, micro, ...)
 	typeOf string
+
+	// Defines the pull request number linked to this execution.
+	pullNB int
 
 	// Configuration used to interact with the SQL database.
 	configDB *mysql.ConfigDB
@@ -170,6 +174,11 @@ func (e *Exec) Prepare() error {
 	}
 	e.AnsibleConfig.ExtraVars = map[string]interface{}{}
 	e.statsRemoteDBConfig.AddToAnsible(&e.AnsibleConfig)
+	if e.pullNB != 0 {
+		e.AnsibleConfig.ExtraVars["vitess_git_version_fetch_pr"] = "refs/pull/" + strconv.Itoa(e.pullNB) + "/head"
+		e.AnsibleConfig.ExtraVars["vitess_git_version_pr_nb"] = e.pullNB
+	}
+
 	e.prepared = true
 	return nil
 }

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -151,7 +151,7 @@ func (e *Exec) Prepare() error {
 	}
 
 	// insert new exec in SQL
-	if _, err = e.clientDB.Insert("INSERT INTO execution(uuid, status, source, git_ref, type) VALUES(?, ?, ?, ?, ?)", e.UUID.String(), StatusCreated, e.Source, e.GitRef, e.typeOf); err != nil {
+	if _, err = e.clientDB.Insert("INSERT INTO execution(uuid, status, source, git_ref, type, pull_nb) VALUES(?, ?, ?, ?, ?, ?)", e.UUID.String(), StatusCreated, e.Source, e.GitRef, e.typeOf, e.pullNB); err != nil {
 		return err
 	}
 

--- a/sql/migration/004_add_pull_request_to_execution.sql
+++ b/sql/migration/004_add_pull_request_to_execution.sql
@@ -1,0 +1,19 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+alter table execution add column pull_nb INT(11) DEFAULT 0;

--- a/sql/migration/test_migration.sh
+++ b/sql/migration/test_migration.sh
@@ -17,3 +17,4 @@ mysql -u root < ./000_old_schema.sql
 mysql -u root < ./001_New_parent_table_for_executions_125.sql
 mysql -u root < ./002_add_foreign_key_to_microbenchmark_details.sql
 mysql -u root < ./003_add_type_to_execution.sql
+mysql -u root < ./004_add_pull_request_to_execution.sql

--- a/sql/vitess-benchmark.sql
+++ b/sql/vitess-benchmark.sql
@@ -67,6 +67,7 @@ CREATE TABLE `execution` (
                              `source` varchar(100) DEFAULT NULL,
                              `git_ref` varchar(100) DEFAULT NULL,
                              `type` varchar(100) DEFAULT '',
+                             `pull_nb` int(11) DEFAULT 0,
                              PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
## Description

Our ansible scripts supports the execution of macro and micro benchmarks on pull request, since pull request commits are outside of the regular tree, they need to be fetched using specific git fetch syntax like: `git fetch origin refs/pull/PR_NUMBER/head`.

Link between Execution's golang code and Ansible is added through this pull request, we define if the execution is linked to a pull request or not through a new integer CLI flag, its value is the pull request number. If we declare that the execution is linked to a pull request, then the proper git fetch ref spec is added to Ansible's ExtraVars.

## Related issues

Fixes #178.