### PR TITLE
Addition of vitess-mixin dashboards in Grafana

### DIFF
--- a/infra/monitoring/files/dashboards/cluster_overview.json
+++ b/infra/monitoring/files/dashboards/cluster_overview.json
@@ -1,20 +1,29 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
    "annotations": {
-      "list": [ ]
+      "list": [
+         {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+         }
+      ]
    },
    "description": "Vitess cluster overview",
    "editable": true,
    "gnetId": null,
    "graphTooltip": 1,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "id": 15,
+   "iteration": 1621323987568,
+   "links": [],
    "panels": [
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
@@ -22,7 +31,7 @@
             "y": 0
          },
          "id": 2,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -42,6 +51,10 @@
          ],
          "datasource": "Prometheus",
          "decimals": 4,
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "format": "percentunit",
          "gauge": {
             "maxValue": 100,
@@ -58,7 +71,7 @@
          },
          "id": 3,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -116,89 +129,6 @@
       },
       {
          "cacheTimeout": null,
-         "colorBackground": true,
-         "colorValue": false,
-         "colors": [
-            "#d44a3a",
-            "rgba(237, 129, 40, 0.89)",
-            "#299c46"
-         ],
-         "datasource": "Prometheus",
-         "decimals": 4,
-         "format": "percentunit",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-         },
-         "gridPos": {
-            "h": 2,
-            "w": 4,
-            "x": 0,
-            "y": 3
-         },
-         "id": 4,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
-         "targets": [
-            {
-               "expr": "1 - (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\"}[$interval])) / (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\"}[$interval])) + sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\"}[$interval]))))",
-               "format": "time_series",
-               "instant": true,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": "0.99,0.999",
-         "title": "Query success - vttablet",
-         "type": "singlestat",
-         "valueFontSize": "70%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "current"
-      },
-      {
-         "cacheTimeout": null,
          "colorBackground": false,
          "colorValue": false,
          "colors": [
@@ -207,6 +137,10 @@
             "#d44a3a"
          ],
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "format": "none",
          "gauge": {
             "maxValue": 100,
@@ -223,7 +157,7 @@
          },
          "id": 5,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -289,88 +223,10 @@
             "#d44a3a"
          ],
          "datasource": "Prometheus",
-         "format": "none",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
          },
-         "gridPos": {
-            "h": 2,
-            "w": 4,
-            "x": 4,
-            "y": 3
-         },
-         "id": 6,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-         },
-         "tableColumn": "",
-         "targets": [
-            {
-               "expr": "sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\"}[$interval]))",
-               "format": "time_series",
-               "instant": false,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": "",
-         "title": "QPS - vttablet",
-         "type": "singlestat",
-         "valueFontSize": "70%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "current"
-      },
-      {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "Prometheus",
          "format": "none",
          "gauge": {
             "maxValue": 100,
@@ -387,7 +243,7 @@
          },
          "id": 7,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -453,170 +309,10 @@
             "#d44a3a"
          ],
          "datasource": "Prometheus",
-         "format": "none",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
          },
-         "gridPos": {
-            "h": 2,
-            "w": 2,
-            "x": 8,
-            "y": 3
-         },
-         "id": 8,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
-         "targets": [
-            {
-               "expr": "count(count(vttablet_tablet_state{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace))",
-               "format": "time_series",
-               "instant": true,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": "",
-         "title": "keyspace",
-         "type": "singlestat",
-         "valueFontSize": "50%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "avg"
-      },
-      {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "Prometheus",
-         "format": "none",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-         },
-         "gridPos": {
-            "h": 2,
-            "w": 2,
-            "x": 10,
-            "y": 3
-         },
-         "id": 9,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
-         "targets": [
-            {
-               "expr": "count(count(vttablet_tablet_state{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace, shard))",
-               "format": "time_series",
-               "instant": true,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": "",
-         "title": "shard",
-         "type": "singlestat",
-         "valueFontSize": "50%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "avg"
-      },
-      {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "Prometheus",
          "format": "none",
          "gauge": {
             "maxValue": 100,
@@ -633,7 +329,7 @@
          },
          "id": 10,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -699,6 +395,10 @@
             "#d44a3a"
          ],
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "format": "none",
          "gauge": {
             "maxValue": 100,
@@ -715,7 +415,7 @@
          },
          "id": 11,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -773,6 +473,93 @@
       },
       {
          "cacheTimeout": null,
+         "colorBackground": true,
+         "colorValue": false,
+         "colors": [
+            "#d44a3a",
+            "rgba(237, 129, 40, 0.89)",
+            "#299c46"
+         ],
+         "datasource": "Prometheus",
+         "decimals": 4,
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
+         "format": "percentunit",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 0,
+            "y": 3
+         },
+         "id": 4,
+         "interval": null,
+         "links": [],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "1 - (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\"}[$interval])) / (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\"}[$interval])) + sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\"}[$interval]))))",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "0.99,0.999",
+         "title": "Query success - vttablet",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
          "colorBackground": false,
          "colorValue": false,
          "colors": [
@@ -781,6 +568,268 @@
             "#d44a3a"
          ],
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 4,
+            "y": 3
+         },
+         "id": 6,
+         "interval": null,
+         "links": [],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\"}[$interval]))",
+               "format": "time_series",
+               "instant": false,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "QPS - vttablet",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 8,
+            "y": 3
+         },
+         "id": 8,
+         "interval": null,
+         "links": [],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "count(count(vttablet_tablet_state{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace))",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "keyspace",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 10,
+            "y": 3
+         },
+         "id": 9,
+         "interval": null,
+         "links": [],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "count(count(vttablet_tablet_state{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace, shard))",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "shard",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "format": "none",
          "gauge": {
             "maxValue": 100,
@@ -797,7 +846,7 @@
          },
          "id": 12,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -863,6 +912,10 @@
             "#d44a3a"
          ],
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "format": "none",
          "gauge": {
             "maxValue": 100,
@@ -879,7 +932,7 @@
          },
          "id": 13,
          "interval": null,
-         "links": [ ],
+         "links": [],
          "mappingType": 1,
          "mappingTypes": [
             {
@@ -938,6 +991,7 @@
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
@@ -945,7 +999,7 @@
             "y": 5
          },
          "id": 14,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -955,11 +1009,15 @@
          "type": "row"
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -968,6 +1026,7 @@
             "x": 0,
             "y": 6
          },
+         "hiddenSeries": false,
          "id": 15,
          "legend": {
             "alignAsTable": true,
@@ -985,14 +1044,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1006,8 +1069,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Requests",
          "tooltip": {
@@ -1021,7 +1085,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1040,7 +1104,11 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "aliasColors": {
@@ -1050,6 +1118,10 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -1058,6 +1130,7 @@
             "x": 8,
             "y": 6
          },
+         "hiddenSeries": false,
          "id": 16,
          "legend": {
             "alignAsTable": true,
@@ -1075,14 +1148,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1096,8 +1173,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Error rate",
          "tooltip": {
@@ -1111,7 +1189,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1130,7 +1208,11 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "aliasColors": {
@@ -1140,6 +1222,10 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -1148,6 +1234,7 @@
             "x": 16,
             "y": 6
          },
+         "hiddenSeries": false,
          "id": 17,
          "legend": {
             "alignAsTable": true,
@@ -1165,14 +1252,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1186,8 +1277,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Duration 99th quantile",
          "tooltip": {
@@ -1201,7 +1293,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1220,14 +1312,29 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {
+               "links": [
+                  {
+                     "title": "Go to \"Keyspace Overview\"",
+                     "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__field.labels.keyspace}&time=${__url_time_range}"
+                  }
+               ]
+            },
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -1236,6 +1343,7 @@
             "x": 0,
             "y": 12
          },
+         "hiddenSeries": false,
          "id": 18,
          "legend": {
             "alignAsTable": true,
@@ -1253,22 +1361,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [
-               {
-                  "title": "Go to \"Keyspace Overview\"",
-                  "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__series.labels.keyspace}&time=${__url_time_range}"
-               }
-            ]
+            "alertThreshold": true
          },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1282,8 +1386,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Requests (by keyspace)",
          "tooltip": {
@@ -1297,7 +1402,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1316,14 +1421,29 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {
+               "links": [
+                  {
+                     "title": "Go to \"Keyspace Overview\"",
+                     "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__field.labels.keyspace}&time=${__url_time_range}"
+                  }
+               ]
+            },
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -1332,6 +1452,7 @@
             "x": 8,
             "y": 12
          },
+         "hiddenSeries": false,
          "id": 19,
          "legend": {
             "alignAsTable": true,
@@ -1349,22 +1470,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [
-               {
-                  "title": "Go to \"Keyspace Overview\"",
-                  "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__series.labels.keyspace}&time=${__url_time_range}"
-               }
-            ]
+            "alertThreshold": true
          },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1378,8 +1495,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Error rate (by keyspace)",
          "tooltip": {
@@ -1393,7 +1511,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1412,14 +1530,29 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {
+               "links": [
+                  {
+                     "title": "Go to \"Keyspace Overview\"",
+                     "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__field.labels.keyspace}&time=${__url_time_range}"
+                  }
+               ]
+            },
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -1428,6 +1561,7 @@
             "x": 16,
             "y": 12
          },
+         "hiddenSeries": false,
          "id": 20,
          "legend": {
             "alignAsTable": true,
@@ -1445,22 +1579,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [
-               {
-                  "title": "Go to \"Keyspace Overview\"",
-                  "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__series.labels.keyspace}&time=${__url_time_range}"
-               }
-            ]
+            "alertThreshold": true
          },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1474,8 +1604,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Duration 99th quantile (by keyspace)",
          "tooltip": {
@@ -1489,7 +1620,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1508,19 +1639,24 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 13
+            "y": 20
          },
          "id": 21,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -1530,19 +1666,24 @@
          "type": "row"
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 14
+            "y": 21
          },
+         "hiddenSeries": false,
          "id": 22,
          "legend": {
             "alignAsTable": true,
@@ -1560,14 +1701,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1581,8 +1726,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query pool: min connections available (by keyspace)",
          "tooltip": {
@@ -1596,7 +1742,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1615,22 +1761,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 14
+            "y": 21
          },
+         "hiddenSeries": false,
          "id": 23,
          "legend": {
             "alignAsTable": true,
@@ -1648,14 +1803,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1669,8 +1828,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Transaction pool: min connections available (by keyspace)",
          "tooltip": {
@@ -1684,7 +1844,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1703,22 +1863,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 14
+            "y": 21
          },
+         "hiddenSeries": false,
          "id": 24,
          "legend": {
             "alignAsTable": true,
@@ -1736,14 +1905,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1757,8 +1930,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Count of serving tablets (by keyspace)",
          "tooltip": {
@@ -1772,7 +1946,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1791,19 +1965,24 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 27
          },
          "id": 25,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -1813,19 +1992,24 @@
          "type": "row"
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 16
+            "y": 28
          },
+         "hiddenSeries": false,
          "id": 26,
          "legend": {
             "alignAsTable": true,
@@ -1843,14 +2027,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null as zero",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1864,8 +2052,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Slow queries > 0 (by keyspace)",
          "tooltip": {
@@ -1879,7 +2068,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1898,22 +2087,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 16
+            "y": 28
          },
+         "hiddenSeries": false,
          "id": 27,
          "legend": {
             "alignAsTable": true,
@@ -1931,14 +2129,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1952,8 +2154,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Replication lag > 0 (by keyspace)",
          "tooltip": {
@@ -1967,7 +2170,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1986,22 +2189,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
          "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 16
+            "y": 28
          },
+         "hiddenSeries": false,
          "id": 28,
          "legend": {
             "alignAsTable": true,
@@ -2019,14 +2231,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -2040,8 +2256,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Semi-sync replication avg wait time (by keyspace)",
          "tooltip": {
@@ -2055,7 +2272,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -2074,12 +2291,15 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       }
    ],
-   "refresh": "",
-   "rows": [ ],
-   "schemaVersion": 14,
+   "refresh": false,
+   "schemaVersion": 27,
    "style": "dark",
    "tags": [
       "vitess-mixin",
@@ -2090,11 +2310,17 @@
       "list": [
          {
             "allValue": null,
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "10s",
             "current": {
-               "text": "5m",
-               "value": "5m"
+               "selected": true,
+               "text": "1m",
+               "value": "1m"
             },
             "datasource": "$datasource",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Interval",
@@ -2102,12 +2328,12 @@
             "name": "interval",
             "options": [
                {
-                  "selected": false,
+                  "selected": true,
                   "text": "1m",
                   "value": "1m"
                },
                {
-                  "selected": true,
+                  "selected": false,
                   "text": "5m",
                   "value": "5m"
                },
@@ -2138,40 +2364,63 @@
                }
             ],
             "query": "1m,5m,10m,30m,1h,6h,12h",
+            "queryValue": "",
             "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [ ],
+            "tags": [],
             "tagsQuery": "",
             "type": "interval",
             "useTags": false
          },
          {
             "allValue": null,
-            "current": { },
+            "current": {
+               "selected": false,
+               "text": "local",
+               "value": "local"
+            },
             "datasource": "Prometheus",
+            "definition": "",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Region",
             "multi": false,
             "name": "region",
-            "options": [ ],
-            "query": "label_values(vtctld_build_number{job=\"vitess-vtctld\"}, region)",
+            "options": [],
+            "query": {
+               "query": "label_values(vtctld_build_number{job=\"vitess-vtctld\"}, region)",
+               "refId": "Prometheus-region-Variable-Query"
+            },
             "refresh": 2,
             "regex": "",
+            "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [ ],
+            "tags": [],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
+         },
+         {
+            "datasource": null,
+            "description": null,
+            "error": null,
+            "filters": [],
+            "hide": 0,
+            "label": null,
+            "name": "filter",
+            "skipUrlSync": false,
+            "type": "adhoc"
          }
       ]
    },
    "time": {
-      "from": "now-30m",
+      "from": "now-7d",
       "to": "now"
    },
    "timepicker": {
@@ -2202,5 +2451,5 @@
    "timezone": "browser",
    "title": "Vitess / Cluster Overview (auto-generated)",
    "uid": "0d0778047f5a64ff2ea084ec3e",
-   "version": 0
+   "version": 5
 }

--- a/infra/monitoring/files/dashboards/cluster_overview.json
+++ b/infra/monitoring/files/dashboards/cluster_overview.json
@@ -1,0 +1,2206 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "description": "Vitess cluster overview",
+   "editable": true,
+   "gnetId": null,
+   "graphTooltip": 1,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Top level",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": true,
+         "colorValue": false,
+         "colors": [
+            "#d44a3a",
+            "rgba(237, 129, 40, 0.89)",
+            "#299c46"
+         ],
+         "datasource": "Prometheus",
+         "decimals": 4,
+         "format": "percentunit",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 0,
+            "y": 1
+         },
+         "id": 3,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "1 - sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) / (sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) + sum(rate(vtgate_api_count{region=\"$region\", job=\"vitess-vtgate\"}[$interval])))\n",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "0.99,0.999",
+         "title": "Query success - vtgate",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": true,
+         "colorValue": false,
+         "colors": [
+            "#d44a3a",
+            "rgba(237, 129, 40, 0.89)",
+            "#299c46"
+         ],
+         "datasource": "Prometheus",
+         "decimals": 4,
+         "format": "percentunit",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 0,
+            "y": 3
+         },
+         "id": 4,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "1 - (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\"}[$interval])) / (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\"}[$interval])) + sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\"}[$interval]))))",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "0.99,0.999",
+         "title": "Query success - vttablet",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 4,
+            "y": 1
+         },
+         "id": 5,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(rate(vtgate_api_count{region=\"$region\", job=\"vitess-vtgate\"}[$interval]))",
+               "format": "time_series",
+               "instant": false,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "QPS - vtgate",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 4,
+            "y": 3
+         },
+         "id": 6,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\"}[$interval]))",
+               "format": "time_series",
+               "instant": false,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "QPS - vttablet",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 8,
+            "y": 1
+         },
+         "id": 7,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(rate(mysql_global_status_queries{region=\"$region\", job=\"mysql\"}[$interval])) ",
+               "format": "time_series",
+               "instant": false,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "QPS - MySQL",
+         "type": "singlestat",
+         "valueFontSize": "70%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 8,
+            "y": 3
+         },
+         "id": 8,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "count(count(vttablet_tablet_state{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace))",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "keyspace",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 10,
+            "y": 3
+         },
+         "id": 9,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "count(count(vttablet_tablet_state{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace, shard))",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "shard",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 12,
+            "y": 1
+         },
+         "id": 10,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(up{region=\"$region\", job=\"vitess-vtgate\"})",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "vtgate",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 14,
+            "y": 1
+         },
+         "id": 11,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(up{region=\"$region\", job=\"vitess-vttablet\"})",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "vttablet",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 12,
+            "y": 3
+         },
+         "id": 12,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(up{region=\"$region\", job=\"vitess-vtctld\"})",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "vtctld",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 14,
+            "y": 3
+         },
+         "id": 13,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "sum(up{region=\"$region\", job=\"vitess-vtworker\"})",
+               "format": "time_series",
+               "instant": true,
+               "intervalFactor": 1,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "vtworker",
+         "type": "singlestat",
+         "valueFontSize": "50%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "avg"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+         },
+         "id": 14,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "RED (Requests / Error rate / Duration)",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 6
+         },
+         "id": 15,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(vtgate_queries_processed_by_table{region=\"$region\", job=\"vitess-vtgate\"}[$interval]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Requests",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Requests",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": {
+            "Error rate": "#F2495C"
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 6
+         },
+         "id": 16,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) /  sum(rate(vtgate_api_count{region=\"$region\", job=\"vitess-vtgate\"}[$interval]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Error rate",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Error rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": {
+            "Duration": "#5794F2"
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 6
+         },
+         "id": 17,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.99, sum(rate(vtgate_api_bucket{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Duration",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Duration 99th quantile",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 12
+         },
+         "id": 18,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "options": {
+            "dataLinks": [
+               {
+                  "title": "Go to \"Keyspace Overview\"",
+                  "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__series.labels.keyspace}&time=${__url_time_range}"
+               }
+            ]
+         },
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(vtgate_queries_processed_by_table{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) by (keyspace)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Requests (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 12
+         },
+         "id": 19,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "options": {
+            "dataLinks": [
+               {
+                  "title": "Go to \"Keyspace Overview\"",
+                  "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__series.labels.keyspace}&time=${__url_time_range}"
+               }
+            ]
+         },
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) by (keyspace) /  sum(rate(vtgate_api_count{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) by (keyspace)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Error rate (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 12
+         },
+         "id": 20,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "options": {
+            "dataLinks": [
+               {
+                  "title": "Go to \"Keyspace Overview\"",
+                  "url": "/d/ff33eceed7d2b1267dd286a099/?var-interval=${interval}&var-region=${region}&var-keyspace=${__series.labels.keyspace}&time=${__url_time_range}"
+               }
+            ]
+         },
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.99, sum(rate(vtgate_api_bucket{region=\"$region\", job=\"vitess-vtgate\"}[$interval])) by (keyspace, le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Duration 99th quantile (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 13
+         },
+         "id": 21,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "vttablet",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 14
+         },
+         "id": 22,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "min(vttablet_conn_pool_available{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query pool: min connections available (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 14
+         },
+         "id": 23,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "min(vttablet_transaction_pool_available{region=\"$region\", job=\"vitess-vttablet\"}) by (keyspace)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Transaction pool: min connections available (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 14
+         },
+         "id": 24,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "count(vttablet_tablet_server_state{region=\"$region\", job=\"vitess-vttablet\", name=\"SERVING\"}) by (keyspace)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Count of serving tablets (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+         },
+         "id": 25,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "MySQL",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 16
+         },
+         "id": 26,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(mysql_global_status_slow_queries{region=\"$region\", job=\"mysql\"}[$interval])) by (keyspace) > 0",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Slow queries > 0 (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 16
+         },
+         "id": 27,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(mysql_slave_status_seconds_behind_master{region=\"$region\", job=\"mysql\"}) by (keyspace) > 0",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Replication lag > 0 (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 16
+         },
+         "id": 28,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(mysql_global_status_rpl_semi_sync_master_tx_avg_wait_time{region=\"$region\", job=\"mysql\"}[$interval])) by (keyspace)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{keyspace}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Semi-sync replication avg wait time (by keyspace)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      }
+   ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "vitess-mixin",
+      "overview",
+      "cluster"
+   ],
+   "templating": {
+      "list": [
+         {
+            "allValue": null,
+            "current": {
+               "text": "5m",
+               "value": "5m"
+            },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Interval",
+            "multi": false,
+            "name": "interval",
+            "options": [
+               {
+                  "selected": false,
+                  "text": "1m",
+                  "value": "1m"
+               },
+               {
+                  "selected": true,
+                  "text": "5m",
+                  "value": "5m"
+               },
+               {
+                  "selected": false,
+                  "text": "10m",
+                  "value": "10m"
+               },
+               {
+                  "selected": false,
+                  "text": "30m",
+                  "value": "30m"
+               },
+               {
+                  "selected": false,
+                  "text": "1h",
+                  "value": "1h"
+               },
+               {
+                  "selected": false,
+                  "text": "6h",
+                  "value": "6h"
+               },
+               {
+                  "selected": false,
+                  "text": "12h",
+                  "value": "12h"
+               }
+            ],
+            "query": "1m,5m,10m,30m,1h,6h,12h",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "interval",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "Prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Region",
+            "multi": false,
+            "name": "region",
+            "options": [ ],
+            "query": "label_values(vtctld_build_number{job=\"vitess-vtctld\"}, region)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-30m",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Vitess / Cluster Overview (auto-generated)",
+   "uid": "0d0778047f5a64ff2ea084ec3e",
+   "version": 0
+}

--- a/infra/monitoring/files/dashboards/keyspace_overview.json
+++ b/infra/monitoring/files/dashboards/keyspace_overview.json
@@ -1,0 +1,1593 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "description": "General keyspace overview",
+   "editable": true,
+   "gnetId": null,
+   "graphTooltip": 1,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "vtgate",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 1
+         },
+         "id": 3,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(vtgate_queries_processed_by_table{region=\"$region\", job=\"vitess-vtgate\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) by (table)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{table}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "QPS (by table)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 1
+         },
+         "id": 4,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(vtgate_queries_processed_by_table{region=\"$region\", job=\"vitess-vtgate\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) by (plan)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{plan}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "QPS (by plan type)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 1
+         },
+         "id": 5,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "100 - sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) / (sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) + sum(rate(vtgate_api_count{region=\"$region\", job=\"vitess-vtgate\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval]))) * 100",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Success rate",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(rate(vtgate_api_error_counts{region=\"$region\", job=\"vitess-vtgate\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Error count",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query success rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": 100,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": 100,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 8
+         },
+         "id": 6,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "vttablet",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 9
+         },
+         "id": 7,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) by (table)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{table}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "QPS (by table)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 9
+         },
+         "id": 8,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) by (plan)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{plan}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "QPS (by plan type)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "rps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 9
+         },
+         "id": 9,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "100 - (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) / (sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])) + sum(rate(vttablet_query_counts{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval])))) * 100",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Success rate",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(rate(vttablet_errors{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\", table=~\"$table\"}[$interval]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Error count",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query success rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": 100,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "percent",
+               "label": null,
+               "logBase": 1,
+               "max": 100,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+         },
+         "id": 10,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Query/Transaction timings (table filter doesn't apply)",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 16
+         },
+         "id": 11,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum (rate(vttablet_queries_sum{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) /\nsum (rate(vttablet_queries_count{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "avg",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query time (avg)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 16
+         },
+         "id": 12,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.50, sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p50",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query time (p50)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 16
+         },
+         "id": 13,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.95, sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query time (p95)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 16
+         },
+         "id": 14,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.999, sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p999",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Query time (p999)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 23
+         },
+         "id": 15,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum (rate(vttablet_transactions_sum{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) /\nsum (rate(vttablet_transactions_count{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "avg",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Transaction time (avg)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 23
+         },
+         "id": 16,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.50, sum(rate(vttablet_transactions_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p50",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Transaction time (p50)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 23
+         },
+         "id": 17,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.95, sum(rate(vttablet_transactions_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Transaction time (p95)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus_Vitess",
+         "fill": 0,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 23
+         },
+         "id": 18,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.999, sum(rate(vttablet_transactions_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p999",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Transaction time (p999)",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "cards": {
+            "cardPadding": null,
+            "cardRound": null
+         },
+         "color": {
+            "cardColor": "#FF9830",
+            "colorScale": "sqrt",
+            "exponent": 0.29999999999999999,
+            "mode": "opacity"
+         },
+         "dataFormat": "tsbuckets",
+         "datasource": "Prometheus_Vitess",
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+         },
+         "heatmap": { },
+         "hideZeroBuckets": false,
+         "highlightCards": true,
+         "id": 19,
+         "legend": {
+            "show": false
+         },
+         "targets": [
+            {
+               "expr": "sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le)",
+               "format": "heatmap",
+               "intervalFactor": 2,
+               "legendFormat": "{{le}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Query timings heatmap",
+         "tooltip": {
+            "show": true,
+            "showHistogram": false
+         },
+         "type": "heatmap",
+         "xAxis": {
+            "show": true
+         },
+         "xBucketNumber": null,
+         "xBucketSize": null,
+         "yAxis": {
+            "decimals": 0,
+            "format": "s",
+            "show": true,
+            "splitFactor": null
+         },
+         "yBucketBound": "auto"
+      },
+      {
+         "cards": {
+            "cardPadding": null,
+            "cardRound": null
+         },
+         "color": {
+            "cardColor": "#FF9830",
+            "colorScale": "sqrt",
+            "exponent": 0.29999999999999999,
+            "mode": "opacity"
+         },
+         "dataFormat": "tsbuckets",
+         "datasource": "Prometheus_Vitess",
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+         },
+         "heatmap": { },
+         "hideZeroBuckets": false,
+         "highlightCards": true,
+         "id": 20,
+         "legend": {
+            "show": false
+         },
+         "targets": [
+            {
+               "expr": "sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le)",
+               "format": "heatmap",
+               "intervalFactor": 2,
+               "legendFormat": "{{le}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Transaction timings heatmap",
+         "tooltip": {
+            "show": true,
+            "showHistogram": false
+         },
+         "type": "heatmap",
+         "xAxis": {
+            "show": true
+         },
+         "xBucketNumber": null,
+         "xBucketSize": null,
+         "yAxis": {
+            "decimals": 0,
+            "format": "s",
+            "show": true,
+            "splitFactor": null
+         },
+         "yBucketBound": "auto"
+      }
+   ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "vitess-mixin",
+      "overview",
+      "keyspace"
+   ],
+   "templating": {
+      "list": [
+         {
+            "allValue": null,
+            "current": {
+               "text": "5m",
+               "value": "5m"
+            },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Interval",
+            "multi": false,
+            "name": "interval",
+            "options": [
+               {
+                  "selected": false,
+                  "text": "1m",
+                  "value": "1m"
+               },
+               {
+                  "selected": true,
+                  "text": "5m",
+                  "value": "5m"
+               },
+               {
+                  "selected": false,
+                  "text": "10m",
+                  "value": "10m"
+               },
+               {
+                  "selected": false,
+                  "text": "30m",
+                  "value": "30m"
+               },
+               {
+                  "selected": false,
+                  "text": "1h",
+                  "value": "1h"
+               },
+               {
+                  "selected": false,
+                  "text": "6h",
+                  "value": "6h"
+               },
+               {
+                  "selected": false,
+                  "text": "12h",
+                  "value": "12h"
+               }
+            ],
+            "query": "1m,5m,10m,30m,1h,6h,12h",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "interval",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "Prometheus_Vitess",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Region",
+            "multi": false,
+            "name": "region",
+            "options": [ ],
+            "query": "label_values(vtctld_build_number{job=\"vitess-vtctld\"}, region)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "Prometheus_Vitess",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Keyspace",
+            "multi": false,
+            "name": "keyspace",
+            "options": [ ],
+            "query": "label_values(vttablet_build_number{job=\"vitess-vttablet\", region=\"$region\"}, keyspace)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": ".*",
+            "current": { },
+            "datasource": "Prometheus_Vitess",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Table",
+            "multi": false,
+            "name": "table",
+            "options": [ ],
+            "query": "label_values(vtgate_queries_processed_by_table{job=\"vitess-vtgate\", region=\"$region\", keyspace=\"$keyspace\"}, table)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-30m",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Vitess / Keyspace Overview (auto-generated)",
+   "uid": "ff33eceed7d2b1267dd286a099",
+   "version": 0
+}

--- a/infra/monitoring/files/dashboards/keyspace_overview.json
+++ b/infra/monitoring/files/dashboards/keyspace_overview.json
@@ -1,20 +1,29 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
    "annotations": {
-      "list": [ ]
+      "list": [
+         {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+         }
+      ]
    },
    "description": "General keyspace overview",
    "editable": true,
    "gnetId": null,
    "graphTooltip": 1,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "id": 16,
+   "iteration": 1621324320710,
+   "links": [],
    "panels": [
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
@@ -22,7 +31,7 @@
             "y": 0
          },
          "id": 2,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -32,11 +41,15 @@
          "type": "row"
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -45,6 +58,7 @@
             "x": 0,
             "y": 1
          },
+         "hiddenSeries": false,
          "id": 3,
          "legend": {
             "alignAsTable": true,
@@ -62,14 +76,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -83,8 +101,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "QPS (by table)",
          "tooltip": {
@@ -98,7 +117,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -117,14 +136,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -133,6 +160,7 @@
             "x": 8,
             "y": 1
          },
+         "hiddenSeries": false,
          "id": 4,
          "legend": {
             "alignAsTable": true,
@@ -150,14 +178,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -171,8 +203,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "QPS (by plan type)",
          "tooltip": {
@@ -186,7 +219,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -205,14 +238,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -221,6 +262,7 @@
             "x": 16,
             "y": 1
          },
+         "hiddenSeries": false,
          "id": 5,
          "legend": {
             "alignAsTable": true,
@@ -238,14 +280,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -266,8 +312,9 @@
                "refId": "B"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query success rate",
          "tooltip": {
@@ -281,7 +328,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -300,11 +347,16 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
@@ -312,7 +364,7 @@
             "y": 8
          },
          "id": 6,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -322,11 +374,15 @@
          "type": "row"
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -335,6 +391,7 @@
             "x": 0,
             "y": 9
          },
+         "hiddenSeries": false,
          "id": 7,
          "legend": {
             "alignAsTable": true,
@@ -352,14 +409,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -373,8 +434,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "QPS (by table)",
          "tooltip": {
@@ -388,7 +450,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -407,14 +469,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -423,6 +493,7 @@
             "x": 8,
             "y": 9
          },
+         "hiddenSeries": false,
          "id": 8,
          "legend": {
             "alignAsTable": true,
@@ -440,14 +511,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -461,8 +536,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "QPS (by plan type)",
          "tooltip": {
@@ -476,7 +552,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -495,14 +571,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -511,6 +595,7 @@
             "x": 16,
             "y": 9
          },
+         "hiddenSeries": false,
          "id": 9,
          "legend": {
             "alignAsTable": true,
@@ -528,14 +613,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -556,8 +645,9 @@
                "refId": "B"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query success rate",
          "tooltip": {
@@ -571,7 +661,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -590,19 +680,24 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "collapse": false,
          "collapsed": false,
+         "datasource": null,
          "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 16
          },
          "id": 10,
-         "panels": [ ],
+         "panels": [],
          "repeat": null,
          "repeatIteration": null,
          "repeatRowId": null,
@@ -612,19 +707,24 @@
          "type": "row"
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 16
+            "y": 17
          },
+         "hiddenSeries": false,
          "id": 11,
          "legend": {
             "alignAsTable": true,
@@ -642,29 +742,36 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum (rate(vttablet_queries_sum{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) /\nsum (rate(vttablet_queries_count{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval]))",
+               "exemplar": true,
+               "expr": "sum (rate(vttablet_queries_sum{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) /\nsum(rate(vttablet_queries_count{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval]))",
                "format": "time_series",
+               "interval": "",
                "intervalFactor": 2,
                "legendFormat": "avg",
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query time (avg)",
          "tooltip": {
@@ -678,7 +785,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -697,22 +804,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 16
+            "y": 17
          },
+         "hiddenSeries": false,
          "id": 12,
          "legend": {
             "alignAsTable": true,
@@ -730,14 +846,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -751,8 +871,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query time (p50)",
          "tooltip": {
@@ -766,7 +887,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -785,22 +906,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 6,
             "x": 12,
-            "y": 16
+            "y": 17
          },
+         "hiddenSeries": false,
          "id": 13,
          "legend": {
             "alignAsTable": true,
@@ -818,14 +948,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -839,8 +973,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query time (p95)",
          "tooltip": {
@@ -854,7 +989,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -873,22 +1008,31 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
             "h": 6,
             "w": 6,
             "x": 18,
-            "y": 16
+            "y": 17
          },
+         "hiddenSeries": false,
          "id": 14,
          "legend": {
             "alignAsTable": true,
@@ -906,14 +1050,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -927,8 +1075,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Query time (p999)",
          "tooltip": {
@@ -942,7 +1091,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -961,14 +1110,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -977,6 +1134,7 @@
             "x": 0,
             "y": 23
          },
+         "hiddenSeries": false,
          "id": 15,
          "legend": {
             "alignAsTable": true,
@@ -994,14 +1152,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1015,8 +1177,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Transaction time (avg)",
          "tooltip": {
@@ -1030,7 +1193,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1049,14 +1212,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -1065,6 +1236,7 @@
             "x": 6,
             "y": 23
          },
+         "hiddenSeries": false,
          "id": 16,
          "legend": {
             "alignAsTable": true,
@@ -1082,14 +1254,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1103,8 +1279,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Transaction time (p50)",
          "tooltip": {
@@ -1118,7 +1295,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1137,14 +1314,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -1153,6 +1338,7 @@
             "x": 12,
             "y": 23
          },
+         "hiddenSeries": false,
          "id": 17,
          "legend": {
             "alignAsTable": true,
@@ -1170,14 +1356,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1191,8 +1381,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Transaction time (p95)",
          "tooltip": {
@@ -1206,7 +1397,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1225,14 +1416,22 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
-         "aliasColors": { },
+         "aliasColors": {},
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "fill": 0,
          "fillGradient": 0,
          "gridPos": {
@@ -1241,6 +1440,7 @@
             "x": 18,
             "y": 23
          },
+         "hiddenSeries": false,
          "id": 18,
          "legend": {
             "alignAsTable": true,
@@ -1258,14 +1458,18 @@
          },
          "lines": true,
          "linewidth": 1,
-         "links": [ ],
+         "links": [],
          "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true
+         },
          "percentage": false,
+         "pluginVersion": "7.5.6",
          "pointradius": 5,
          "points": false,
          "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
+         "seriesOverrides": [],
          "spaceLength": 10,
          "span": 4,
          "stack": false,
@@ -1279,8 +1483,9 @@
                "refId": "A"
             }
          ],
-         "thresholds": [ ],
+         "thresholds": [],
          "timeFrom": null,
+         "timeRegions": [],
          "timeShift": null,
          "title": "Transaction time (p999)",
          "tooltip": {
@@ -1294,7 +1499,7 @@
             "mode": "time",
             "name": null,
             "show": true,
-            "values": [ ]
+            "values": []
          },
          "yaxes": [
             {
@@ -1313,7 +1518,11 @@
                "min": 0,
                "show": true
             }
-         ]
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       },
       {
          "cards": {
@@ -1323,24 +1532,30 @@
          "color": {
             "cardColor": "#FF9830",
             "colorScale": "sqrt",
-            "exponent": 0.29999999999999999,
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.3,
             "mode": "opacity"
          },
          "dataFormat": "tsbuckets",
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 29
          },
-         "heatmap": { },
+         "heatmap": {},
          "hideZeroBuckets": false,
          "highlightCards": true,
          "id": 19,
          "legend": {
             "show": false
          },
+         "reverseYBuckets": false,
          "targets": [
             {
                "expr": "sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le)",
@@ -1364,10 +1579,15 @@
          "yAxis": {
             "decimals": 0,
             "format": "s",
+            "logBase": 1,
+            "max": null,
+            "min": null,
             "show": true,
             "splitFactor": null
          },
-         "yBucketBound": "auto"
+         "yBucketBound": "auto",
+         "yBucketNumber": null,
+         "yBucketSize": null
       },
       {
          "cards": {
@@ -1377,24 +1597,30 @@
          "color": {
             "cardColor": "#FF9830",
             "colorScale": "sqrt",
-            "exponent": 0.29999999999999999,
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.3,
             "mode": "opacity"
          },
          "dataFormat": "tsbuckets",
-         "datasource": "Prometheus_Vitess",
+         "datasource": "Prometheus",
+         "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+         },
          "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
             "y": 29
          },
-         "heatmap": { },
+         "heatmap": {},
          "hideZeroBuckets": false,
          "highlightCards": true,
          "id": 20,
          "legend": {
             "show": false
          },
+         "reverseYBuckets": false,
          "targets": [
             {
                "expr": "sum(rate(vttablet_queries_bucket{region=\"$region\", job=\"vitess-vttablet\", keyspace=\"$keyspace\"}[$interval])) by (le)",
@@ -1418,15 +1644,19 @@
          "yAxis": {
             "decimals": 0,
             "format": "s",
+            "logBase": 1,
+            "max": null,
+            "min": null,
             "show": true,
             "splitFactor": null
          },
-         "yBucketBound": "auto"
+         "yBucketBound": "auto",
+         "yBucketNumber": null,
+         "yBucketSize": null
       }
    ],
-   "refresh": "",
-   "rows": [ ],
-   "schemaVersion": 14,
+   "refresh": false,
+   "schemaVersion": 27,
    "style": "dark",
    "tags": [
       "vitess-mixin",
@@ -1437,11 +1667,17 @@
       "list": [
          {
             "allValue": null,
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "10s",
             "current": {
-               "text": "5m",
-               "value": "5m"
+               "selected": false,
+               "text": "1m",
+               "value": "1m"
             },
             "datasource": "$datasource",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Interval",
@@ -1449,12 +1685,12 @@
             "name": "interval",
             "options": [
                {
-                  "selected": false,
+                  "selected": true,
                   "text": "1m",
                   "value": "1m"
                },
                {
-                  "selected": true,
+                  "selected": false,
                   "text": "5m",
                   "value": "5m"
                },
@@ -1485,80 +1721,125 @@
                }
             ],
             "query": "1m,5m,10m,30m,1h,6h,12h",
+            "queryValue": "",
             "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [ ],
+            "tags": [],
             "tagsQuery": "",
             "type": "interval",
             "useTags": false
          },
          {
             "allValue": null,
-            "current": { },
-            "datasource": "Prometheus_Vitess",
+            "current": {
+               "selected": false,
+               "text": "local",
+               "value": "local"
+            },
+            "datasource": "Prometheus",
+            "definition": "",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Region",
             "multi": false,
             "name": "region",
-            "options": [ ],
-            "query": "label_values(vtctld_build_number{job=\"vitess-vtctld\"}, region)",
+            "options": [],
+            "query": {
+               "query": "label_values(vtctld_build_number{job=\"vitess-vtctld\"}, region)",
+               "refId": "Prometheus-region-Variable-Query"
+            },
             "refresh": 2,
             "regex": "",
+            "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [ ],
+            "tags": [],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
          },
          {
             "allValue": null,
-            "current": { },
-            "datasource": "Prometheus_Vitess",
+            "current": {
+               "selected": false,
+               "text": "main",
+               "value": "main"
+            },
+            "datasource": "Prometheus",
+            "definition": "",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Keyspace",
             "multi": false,
             "name": "keyspace",
-            "options": [ ],
-            "query": "label_values(vttablet_build_number{job=\"vitess-vttablet\", region=\"$region\"}, keyspace)",
+            "options": [],
+            "query": {
+               "query": "label_values(vttablet_build_number{job=\"vitess-vttablet\", region=\"$region\"}, keyspace)",
+               "refId": "Prometheus-keyspace-Variable-Query"
+            },
             "refresh": 1,
             "regex": "",
+            "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [ ],
+            "tags": [],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
          },
          {
             "allValue": ".*",
-            "current": { },
-            "datasource": "Prometheus_Vitess",
+            "current": {
+               "selected": false,
+               "text": "All",
+               "value": "$__all"
+            },
+            "datasource": "Prometheus",
+            "definition": "",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": true,
             "label": "Table",
             "multi": false,
             "name": "table",
-            "options": [ ],
-            "query": "label_values(vtgate_queries_processed_by_table{job=\"vitess-vtgate\", region=\"$region\", keyspace=\"$keyspace\"}, table)",
+            "options": [],
+            "query": {
+               "query": "label_values(vtgate_queries_processed_by_table{job=\"vitess-vtgate\", region=\"$region\", keyspace=\"$keyspace\"}, table)",
+               "refId": "Prometheus-table-Variable-Query"
+            },
             "refresh": 1,
             "regex": "",
+            "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [ ],
+            "tags": [],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
+         },
+         {
+            "datasource": null,
+            "description": null,
+            "error": null,
+            "filters": [],
+            "hide": 0,
+            "label": null,
+            "name": "filter",
+            "skipUrlSync": false,
+            "type": "adhoc"
          }
       ]
    },
    "time": {
-      "from": "now-30m",
+      "from": "now-7d",
       "to": "now"
    },
    "timepicker": {
@@ -1589,5 +1870,5 @@
    "timezone": "browser",
    "title": "Vitess / Keyspace Overview (auto-generated)",
    "uid": "ff33eceed7d2b1267dd286a099",
-   "version": 0
+   "version": 6
 }

--- a/infra/monitoring/files/provisioning/ansible.yaml
+++ b/infra/monitoring/files/provisioning/ansible.yaml
@@ -18,3 +18,11 @@ providers:
     allowUiUpdates: true
     options:
       path: "/var/lib/grafana/dashboards"
+
+  - name: 'vitess-mixin'
+    orgId: 1
+    folder: ''
+    type: file
+    allowUiUpdates: true
+    options:
+      path: "/go/src/vitess.io/vitess/vitess-mixin/dashboards_out"

--- a/infra/monitoring/playbook.yaml
+++ b/infra/monitoring/playbook.yaml
@@ -34,6 +34,12 @@
 
 - hosts: frontend
   tasks:
+    - name: create grafana directories
+      file:
+        path: /etc/grafana/provisioning/dashboards
+        state: directory
+        recurse: 1
+
     - name: copy dashboard provision configuration
       copy:
         src: "provisioning/ansible.yaml"


### PR DESCRIPTION
## Description

This pull request adds two new dashboards to the Grafana server. The new dashboards originate from [vitess-mixin](https://github.com/vitessio/vitess/tree/master/vitess-mixin), on both of them, a new variable is added to allow ad-hoc filtering, so that results can be filtered by `exec_uuid`. Below is a representation of what the two dashboards look like.

**Keyspace overview:**

![image](https://user-images.githubusercontent.com/35779988/118615561-260eb000-b7c1-11eb-9501-a3763dbdfc1b.png)


**Cluster overview:**

![image](https://user-images.githubusercontent.com/35779988/118615601-3161db80-b7c1-11eb-9ad0-787a2b2c2436.png)

## Related issues

Resolves #185.
