### PR TITLE
Adds check for master cron job to check if there are existing runs for the same sha

### DIFF
--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -45,10 +45,10 @@ func (s *Server) createNewCron() error {
 }
 
 func (s *Server) cronMasterHandler() {
-	configs := []string{
-		s.microbenchConfigPath,
-		s.macrobenchConfigPathOLTP,
-		s.macrobenchConfigPathTPCC,
+	configs := map[string]string{
+		"micro": s.microbenchConfigPath,
+		"oltp":  s.macrobenchConfigPathOLTP,
+		"tpcc":  s.macrobenchConfigPathTPCC,
 	}
 
 	err := s.pullLocalVitess()
@@ -62,7 +62,20 @@ func (s *Server) cronMasterHandler() {
 		slog.Warn(err.Error())
 		return
 	}
-	s.cronExecution(configs, ref, "cron")
+
+	var configFiles []string
+	for configType, configFile := range configs {
+		exist, err := exec.Exists(s.dbClient, ref, "cron", configType, exec.StatusFinished)
+		if err != nil {
+			slog.Error(err)
+			continue
+		}
+		if !exist {
+			configFiles = append(configFiles, configFile)
+		}
+	}
+
+	s.cronExecution(configFiles, ref, "cron")
 }
 
 func (s Server) cronPRLabels() {
@@ -105,7 +118,7 @@ func (s *Server) cronExecution(configs []string, ref, source string) {
 			return
 		}
 		slog.Info("Created new execution: ", e.UUID.String())
-		e.Source = "cron"
+		e.Source = source
 		e.GitRef = ref
 
 		go func() {


### PR DESCRIPTION
## Description
Master cron job does not check if there are existing runs for the same sha. This would happen when there were no commits on Vitess on a given day. In this case, we would not want to run the cron jobs for the same sha. This PR adds a check for it.

## Related Issues
Fixes #190 