### PR TITLE
Addition of link for comparison in slack message

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -239,7 +239,7 @@ func (e Exec) SendNotificationForRegression() error {
 	header := `*Observed a regression.*
 Comparing: recent commit <https://github.com/vitessio/vitess/commit/` + e.GitRef + `|` + git.ShortenSHA(e.GitRef) + `> with old commit <https://github.com/vitessio/vitess/commit/` + previousGitRef + `|` + git.ShortenSHA(previousGitRef) + `>.
 Benchmark UUIDs, recent: ` + e.UUID.String()[:7] + ` old: ` + previousExec[:7] + `.
-
+Comparison can be seen at : ` + getComparisonLink(e.GitRef, previousGitRef) + `
 
 `
 

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -289,6 +289,10 @@ Benchmark UUIDs, recent: ` + e.UUID.String()[:7] + ` old: ` + previousExec[:7] +
 	return nil
 }
 
+func getComparisonLink(leftSHA, rightSHA string) string {
+	return "https://benchmark.vitess.io/compare?r=" + leftSHA + "&c=" + rightSHA
+}
+
 func (e Exec) sendSlackMessage(regression, header string) error {
 	content := header + regression
 	msg := slack.TextMessage{Content: content}

--- a/go/exec/exec_test.go
+++ b/go/exec/exec_test.go
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package exec
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestGetComparisonLink(t *testing.T) {
+	testcases := []struct {
+		leftSHA  string
+		rightSHA string
+		link     string
+	}{
+		{
+			leftSHA:  "71126fe3286a2f0c25f0ab1be1f19ae4664e5571",
+			rightSHA: "daa60859822ff85ce18e2d10c61a27b7797ec6b8",
+			link:     "https://benchmark.vitess.io/compare?r=71126fe3286a2f0c25f0ab1be1f19ae4664e5571&c=daa60859822ff85ce18e2d10c61a27b7797ec6b8",
+		}, {
+			leftSHA:  "aea21dcbfab3d01fedf2ad4b42f9c7727bc47128",
+			rightSHA: "cc07de2a374699e645fd1273c48b0948bdd38fca",
+			link:     "https://benchmark.vitess.io/compare?r=aea21dcbfab3d01fedf2ad4b42f9c7727bc47128&c=cc07de2a374699e645fd1273c48b0948bdd38fca",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.link, func(t *testing.T) {
+			out := getComparisonLink(testcase.leftSHA, testcase.rightSHA)
+			qt.Assert(t, out, qt.Equals, testcase.link)
+		})
+	}
+}


### PR DESCRIPTION
## Description

In the regression slack message that we send, instead of just having the results, we would also want to add the link to the website where the comparison can be graphically seen. This PR adds this functionality

## Linked Issues
Fixes #193 