### PR TITLE
Use recent and RC tags for macro/micro comparison

### DIFF
--- a/go/tools/git/git_test.go
+++ b/go/tools/git/git_test.go
@@ -54,14 +54,6 @@ func TestGetAllVitessReleaseCommitHash(t *testing.T) {
 	s, err := GetAllVitessReleaseCommitHash(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "5.0.1",
-		CommitHash: "5165f851ecce1e58d12461ce17e401c2b7788139",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "5.0.1",
-		CommitHash: "5165f851ecce1e58d12461ce17e401c2b7788139",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "7.0.3",
 		CommitHash: "5f293938aa637e073231e24fe97448f3b6f2579a",
 	})
@@ -78,68 +70,28 @@ func TestGetAllVitessReleaseCommitHash(t *testing.T) {
 		CommitHash: "aea21dcbfab3d01fedf2ad4b42f9c7727bc47128",
 	})
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "5.0.0",
-		CommitHash: "1b384b8a7c96b1c0ca4fdec62af7295004df9eab",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "4.0.0",
-		CommitHash: "cc07de2a374699e645fd1273c48b0948bdd38fca",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "7.0.0",
 		CommitHash: "a3a52322d4d24bac4f020ec6fd95418f88276662",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "0.7.0",
-		CommitHash: "a3a52322d4d24bac4f020ec6fd95418f88276662",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "2.1.0",
-		CommitHash: "6c06e70a5d7828ad9f79488a704359661bdb996b",
 	})
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "10.0.0",
 		CommitHash: "48dccf56282dc79903c0ab0b1d0177617f927403",
 	})
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "2.1.1",
-		CommitHash: "89cc312b4da3004d3b5382cf2b37d70e901b1c36",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "10.0.1",
 		CommitHash: "f7304cd1893accfefee0525910098a8e0e68deec",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "0.8.0",
-		CommitHash: "7e09d0c20ca1e535b9b3f2d96ff2b1ab907d96e8",
 	})
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "8.0.0",
 		CommitHash: "7e09d0c20ca1e535b9b3f2d96ff2b1ab907d96e8",
 	})
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "4.0.1",
-		CommitHash: "0629f0da20ab3a78459951137a8482ed804da8b9",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "2.0.0",
-		CommitHash: "d429f4015ace1f1366acb28e996172dc6693515c",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "7.0.1",
 		CommitHash: "19c92a5eabefe4556ae23154e1fee12f977ed1ec",
 	})
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "0.9.0",
-		CommitHash: "daa60859822ff85ce18e2d10c61a27b7797ec6b8",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "3.0",
-		CommitHash: "4f192d1003d128e6d399f0a3b37747d9b970d70c",
-	})
-	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
-		Name:       "2.2",
-		CommitHash: "66e84fadcc1a7e956e7ffcebcaaba0b04132ca1f",
+		Name:       "9.0.0-rc1",
+		CommitHash: "0472d4728ff4b5a0b91834331ff16ab9b0057da8",
 	})
 }
 
@@ -159,6 +111,9 @@ func TestGetVersionNumbersFromString(t *testing.T) {
 	}, {
 		versionString:   "101.132.14.6",
 		expectedVersion: []int{101, 132, 14, 6},
+	}, {
+		versionString:   "10.0.0-rc1",
+		expectedVersion: []int{10, 0, 0, 1},
 	}}
 
 	for _, s := range testcase {
@@ -194,6 +149,10 @@ func TestCompareReleaseNumbers(t *testing.T) {
 	}, {
 		versionString1:     "9.1.1",
 		versionString2:     "9.4.1",
+		expectedComparison: -1,
+	}, {
+		versionString1:     "9.0.0-rc1",
+		versionString2:     "9.0.0",
 		expectedComparison: -1,
 	}}
 


### PR DESCRIPTION
## Description

This pull request shows only RC and recent tags in comparison dropdowns. Only tags above or equal to Vitess's version 7.0 will be shown.

## Related issues

Resolves #202.