### PR TITLE
Patched release tags ordering

### DIFF
--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -20,9 +20,8 @@ package server
 
 import (
 	"fmt"
-	"net/http"
-
 	"github.com/vitessio/arewefastyet/go/exec"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/vitessio/arewefastyet/go/tools/git"
@@ -160,10 +159,11 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 		handleRenderErrors(c, err)
 		return
 	}
-	allReleases = append(allReleases, &git.Release{
+	masterRelease := []*git.Release{{
 		Name:       "master",
 		CommitHash: lastrunCronSHA,
-	})
+	}}
+	allReleases = append(masterRelease, allReleases...)
 
 	// initialize left tag and the corresponding sha
 	leftTag := c.Query("ltag")
@@ -268,10 +268,11 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 		handleRenderErrors(c, err)
 		return
 	}
-	allReleases = append(allReleases, &git.Release{
+	masterRelease := []*git.Release{{
 		Name:       "master",
 		CommitHash: lastrunCronSHA,
-	})
+	}}
+	allReleases = append(masterRelease, allReleases...)
 
 	// initialize left tag and the corresponding sha
 	leftTag := c.Query("ltag")

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -87,6 +88,13 @@ func GetAllVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 			return nil, err
 		}
 	}
+	sort.Slice(res, func(i, j int) bool {
+		cmp, err := compareReleaseNumbers(res[i].Name, res[j].Name)
+		if err != nil {
+			return true
+		}
+		return cmp == 1
+	})
 	return res, nil
 }
 


### PR DESCRIPTION
## Description

This pull request fixes the way we order git release tags.

The order before:

- 10.0.0
- 10.0.0-rc1
- 10.0.1
- 7.0.0
- 7.0.1
- ...
- 9.0.1
- master

The order now:

- master
- 10.0.1
- 10.0.0
- 10.0.0-rc1
- 9.0.1
- ...
- 7.0.1
- 7.0.0
