### PR TITLE
Cron for release branches

### DIFF
--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -20,8 +20,9 @@ package server
 
 import (
 	"fmt"
-	"github.com/vitessio/arewefastyet/go/exec"
 	"net/http"
+
+	"github.com/vitessio/arewefastyet/go/exec"
 
 	"github.com/gin-gonic/gin"
 	"github.com/vitessio/arewefastyet/go/tools/git"
@@ -148,7 +149,7 @@ func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	var err error
 
-	// get all the supported releases and the last cron job for master
+	// get all the latest releases and the last cron job for master
 	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
 	if err != nil {
 		handleRenderErrors(c, err)
@@ -257,7 +258,7 @@ func (s *Server) microbenchmarkSingleResultsHandler(c *gin.Context) {
 func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 	var err error
 
-	// get all the releases and the last cron job for master
+	// get all the latest releases and the last cron job for master
 	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
 	if err != nil {
 		handleRenderErrors(c, err)

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -124,13 +124,13 @@ func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 	if err != nil || len(allReleases) == 0 {
 		return nil, err
 	}
-	var last3Releases []*Release
+	var latestReleases []*Release
 	for _, release := range allReleases {
 		if release.Number[0] > 6 {
-			last3Releases = append(last3Releases, release)
+			latestReleases = append(latestReleases, release)
 		}
 	}
-	return last3Releases, nil
+	return latestReleases, nil
 }
 
 // GetAllVitessReleaseBranchCommitHash gets all the vitess release branches and the commit hashes given the directory of the clone of vitess
@@ -179,6 +179,21 @@ func GetAllVitessReleaseBranchCommitHash(repoDir string) ([]*Release, error) {
 		return compareReleaseNumbers(res[i], res[j]) == 1
 	})
 	return res, nil
+}
+
+// GetLatestVitessReleaseBranchCommitHash gets the latest vitess release branches and the commit hashes given the directory of the clone of vitess
+func GetLatestVitessReleaseBranchCommitHash(repoDir string) ([]*Release, error) {
+	res, err := GetAllVitessReleaseBranchCommitHash(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	var latestReleaseBranches []*Release
+	for _, release := range res {
+		if release.Number[0] > 6 {
+			latestReleaseBranches = append(latestReleaseBranches, release)
+		}
+	}
+	return latestReleaseBranches, nil
 }
 
 // GetLastReleaseAndCommitHash gets the last release number along with the commit hash given the directory of the clone of vitess

--- a/go/tools/git/git_test.go
+++ b/go/tools/git/git_test.go
@@ -264,6 +264,19 @@ func TestGetAllVitessReleaseBranchCommitHash(t *testing.T) {
 	}
 }
 
+func TestGetLatestVitessReleaseBranchCommitHash(t *testing.T) {
+	tmpDir, vitessPath, err := createTemporaryVitessClone()
+	defer os.RemoveAll(tmpDir)
+	qt.Assert(t, err, qt.IsNil)
+	out, err := GetLatestVitessReleaseBranchCommitHash(vitessPath)
+	qt.Assert(t, err, qt.IsNil)
+	for _, release := range out {
+		qt.Assert(t, len(release.CommitHash), qt.Equals, 40)
+		qt.Assert(t, release.Name, qt.Contains, "release-")
+		qt.Assert(t, release.Number[0] >= 7, qt.IsTrue)
+	}
+}
+
 func TestGetLatestVitessReleaseCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
## Description

This PR adds the ability to run CRONs for release branches as well. This will enable us to track any regression in case of bug fixes that go into the release branches.

## Related Issues

Fixes #208 