### PR TITLE
Add release branches to the website

### DIFF
--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -165,6 +165,13 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 		CommitHash: lastrunCronSHA,
 	}}
 	allReleases = append(masterRelease, allReleases...)
+	// get all the latest release branches as well
+	allReleaseBranches, err := git.GetLatestVitessReleaseBranchCommitHash(s.getVitessPath())
+	if err != nil {
+		handleRenderErrors(c, err)
+		return
+	}
+	allReleases = append(allReleases, allReleaseBranches...)
 
 	// initialize left tag and the corresponding sha
 	leftTag := c.Query("ltag")
@@ -274,6 +281,13 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 		CommitHash: lastrunCronSHA,
 	}}
 	allReleases = append(masterRelease, allReleases...)
+	// get all the latest release branches as well
+	allReleaseBranches, err := git.GetLatestVitessReleaseBranchCommitHash(s.getVitessPath())
+	if err != nil {
+		handleRenderErrors(c, err)
+		return
+	}
+	allReleases = append(allReleases, allReleaseBranches...)
 
 	// initialize left tag and the corresponding sha
 	leftTag := c.Query("ltag")


### PR DESCRIPTION
## Description

This PR adds the release branches to the website as well so that the results of the ran cron jobs can be seen.

## Related Issues

Fixes #211