### PR TITLE
Fixing clean up defer statement with new Success method

### DIFF
--- a/go/cmd/exec/exec.go
+++ b/go/cmd/exec/exec.go
@@ -45,6 +45,7 @@ It handles the creation, configuration, and cleanup of the infrastructure.`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer func() {
 				errCleanUp := ex.CleanUp()
+				ex.Success()
 				if errCleanUp == nil {
 					return
 				}

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -233,6 +233,7 @@ func (s *Server) cronExecution(eI execInfo) {
 				return
 			}
 		}
+		e.Success()
 		mtx.Lock()
 		currentCountExec--
 		mtx.Unlock()


### PR DESCRIPTION
## Description

The clean-up phase of the execution was overriding the status of execution in the database, the new defer statement and the Success method fix that issue.