### PR TITLE
Golang memory allocs metrics support

### DIFF
--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -24,6 +24,18 @@ import (
 	awftmath "github.com/vitessio/arewefastyet/go/tools/math"
 )
 
+const (
+	cpuSecondsPerComponent = `from(bucket:"%s")
+			|> range(start: %s, stop: %s)
+			|> filter(fn:(r) => r._measurement == "process_cpu_seconds_total" and r.exec_uuid == "%s" and r.component == "%s")
+			|> max()`
+
+	memAllocBytesPerComponent = `from(bucket:"%s")
+			|> range(start: %s, stop: %s)
+			|> filter(fn:(r) => r._measurement == "go_memstats_alloc_bytes_total" and r.exec_uuid == "%s" and r.component == "%s")
+			|> max()`
+)
+
 var (
 	components = []string{
 		"vtgate",
@@ -41,6 +53,15 @@ type (
 		// Map of string/float that contains the name of the component as a key
 		// and the time taken by that component as a value.
 		ComponentsCPUTime map[string]float64
+
+		// TotalComponentsMemStatsAllocBytes represents the total number of bytes
+		// allocated even if freed, by all the components of the execution.
+		// The underlying go metrics used is go_memstats_alloc_bytes_total.
+		TotalComponentsMemStatsAllocBytes float64
+
+		// ComponentsMemStatsAllocBytes represents the number of bytes allocated
+		// and freed that each component used. The go metrics used is go_memstats_alloc_bytes_total.
+		ComponentsMemStatsAllocBytes map[string]float64
 	}
 
 	// ExecutionMetricsArray is a slice of ExecutionMetrics, it has a Median method
@@ -53,15 +74,22 @@ type (
 func GetExecutionMetrics(client influxdb.Client, execUUID string) (ExecutionMetrics, error) {
 	execMetrics := ExecutionMetrics{
 		ComponentsCPUTime: map[string]float64{},
+		ComponentsMemStatsAllocBytes: map[string]float64{},
 	}
 
+	var err error
 	for _, component := range components {
-		cpuTimeForComponent, err := getCPUTimeForComponent(client, "0", "now()", execUUID, component)
+		execMetrics.ComponentsCPUTime[component], err = getSumFloatValueForQuery(client, fmt.Sprintf(cpuSecondsPerComponent, client.Config.Database, "0", "now()", execUUID, component))
 		if err != nil {
 			return ExecutionMetrics{}, err
 		}
-		execMetrics.ComponentsCPUTime[component] = cpuTimeForComponent
-		execMetrics.TotalComponentsCPUTime += cpuTimeForComponent
+		execMetrics.TotalComponentsCPUTime += execMetrics.ComponentsCPUTime[component]
+
+		execMetrics.ComponentsMemStatsAllocBytes[component], err = getSumFloatValueForQuery(client, fmt.Sprintf(memAllocBytesPerComponent, client.Config.Database, "0", "now()", execUUID, component))
+		if err != nil {
+			return ExecutionMetrics{}, err
+		}
+		execMetrics.TotalComponentsMemStatsAllocBytes += execMetrics.ComponentsMemStatsAllocBytes[component]
 	}
 	return execMetrics, nil
 }
@@ -69,21 +97,17 @@ func GetExecutionMetrics(client influxdb.Client, execUUID string) (ExecutionMetr
 // getCPUTimeForComponent return the CPU Time taken by a component (vtgate, vttablet, ...)
 // for the given execUUID. The range of the select is defined through the start and end
 // arguments, to select the whole span one can use: "start:0, end:now()".
-func getCPUTimeForComponent(client influxdb.Client, start, end, execUUID, component string) (float64, error) {
-	result, err := client.Select(fmt.Sprintf(`from(bucket:"%s")
-			|> range(start: %s, stop: %s)
-			|> filter(fn:(r) => r._measurement == "process_cpu_seconds_total" and r.exec_uuid == "%s" and r.component == "%s")
-			|> max()`,
-		client.Config.Database, start, end, execUUID, component))
+func getSumFloatValueForQuery(client influxdb.Client, query string) (float64, error) {
+	result, err := client.Select(query)
 	if err != nil {
 		return 0, err
 	}
 
-	time := 0.0
+	res := 0.0
 	for _, value := range result {
-		time += value["_value"].(float64)
+		res += value["_value"].(float64)
 	}
-	return time, nil
+	return res, nil
 }
 
 // Median computes the median of the ExecutionMetricsArray.
@@ -92,9 +116,15 @@ func (metricsArray ExecutionMetricsArray) Median() ExecutionMetrics {
 	interResults := struct {
 		totalComponentsCPUTime []float64
 		componentsCPUTime      map[string][]float64
+
+		totalComponentsMemStatsAllocBytes []float64
+		componentsMemStatsAllocBytes      map[string][]float64
 	}{
 		totalComponentsCPUTime: []float64{},
 		componentsCPUTime:      map[string][]float64{},
+
+		totalComponentsMemStatsAllocBytes: []float64{},
+		componentsMemStatsAllocBytes:      map[string][]float64{},
 	}
 
 	// Append all the metrics into interResults
@@ -108,13 +138,24 @@ func (metricsArray ExecutionMetricsArray) Median() ExecutionMetrics {
 		for component, value := range metrics.ComponentsCPUTime {
 			interResults.componentsCPUTime[component] = append(interResults.componentsCPUTime[component], value)
 		}
+
+		interResults.totalComponentsMemStatsAllocBytes = append(interResults.totalComponentsMemStatsAllocBytes, metrics.TotalComponentsMemStatsAllocBytes)
+		for component, value := range metrics.ComponentsMemStatsAllocBytes {
+			interResults.componentsMemStatsAllocBytes[component] = append(interResults.componentsMemStatsAllocBytes[component], value)
+		}
 	}
 	result := ExecutionMetrics{
 		ComponentsCPUTime: map[string]float64{},
+		ComponentsMemStatsAllocBytes: map[string]float64{},
 	}
 	result.TotalComponentsCPUTime = awftmath.MedianFloat(interResults.totalComponentsCPUTime)
 	for component, value := range interResults.componentsCPUTime {
 		result.ComponentsCPUTime[component] = awftmath.MedianFloat(value)
+	}
+
+	result.TotalComponentsMemStatsAllocBytes = awftmath.MedianFloat(interResults.totalComponentsMemStatsAllocBytes)
+	for component, value := range interResults.componentsMemStatsAllocBytes {
+		result.ComponentsMemStatsAllocBytes[component] = awftmath.MedianFloat(value)
 	}
 	return result
 }
@@ -125,24 +166,35 @@ func (metricsArray ExecutionMetricsArray) Median() ExecutionMetrics {
 func CompareTwo(left, right ExecutionMetrics) ExecutionMetrics {
 	result := ExecutionMetrics{
 		ComponentsCPUTime: map[string]float64{},
+		ComponentsMemStatsAllocBytes: map[string]float64{},
 	}
-	if left.TotalComponentsCPUTime != 0 {
-		result.TotalComponentsCPUTime = (left.TotalComponentsCPUTime - right.TotalComponentsCPUTime) / left.TotalComponentsCPUTime * 100
-	} else if right.TotalComponentsCPUTime > 0 {
-		result.TotalComponentsCPUTime = -100
-	}
-	for component, value := range left.ComponentsCPUTime {
-		result.ComponentsCPUTime[component] = 0
-		if _, ok := right.ComponentsCPUTime[component]; !ok {
+	result.TotalComponentsCPUTime = compareSafe(left.TotalComponentsCPUTime, right.TotalComponentsCPUTime)
+	result.TotalComponentsMemStatsAllocBytes = compareSafe(left.TotalComponentsMemStatsAllocBytes, right.TotalComponentsMemStatsAllocBytes)
+	result.ComponentsCPUTime = compareSafeComponentMap(left.ComponentsCPUTime, right.ComponentsCPUTime)
+	result.ComponentsMemStatsAllocBytes = compareSafeComponentMap(left.ComponentsMemStatsAllocBytes, right.ComponentsMemStatsAllocBytes)
+	return result
+}
+
+func compareSafeComponentMap(left, right map[string]float64) map[string]float64 {
+	result := map[string]float64{}
+	for component, _ := range left {
+		result[component] = 0
+		if _, ok := right[component]; !ok {
 			continue
 		}
-		if value != 0 {
-			result.ComponentsCPUTime[component] = (value - right.ComponentsCPUTime[component]) / value * 100
-		} else if right.ComponentsCPUTime[component] > 0 {
-			result.ComponentsCPUTime[component] = -100
-		}
+		result[component] = compareSafe(left[component], right[component])
 	}
-	awftmath.CheckForNaN(&result, 0)
-	awftmath.CheckForInf(&result, 0)
 	return result
+}
+
+// Compare the decrease between left and right.
+// The more decrease, the higher result will be.
+// Ex: left=100, right=50, we decreased by 1/2, thus result=50
+func compareSafe(left, right float64) (result float64) {
+	if left != 0 {
+		result = (left - right) / left * 100
+	} else if right > 0 {
+		result = -100
+	}
+	return
 }

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -177,7 +177,7 @@ func CompareTwo(left, right ExecutionMetrics) ExecutionMetrics {
 
 func compareSafeComponentMap(left, right map[string]float64) map[string]float64 {
 	result := map[string]float64{}
-	for component, _ := range left {
+	for component := range left {
 		result[component] = 0
 		if _, ok := right[component]; !ok {
 			continue

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -94,9 +94,8 @@ func GetExecutionMetrics(client influxdb.Client, execUUID string) (ExecutionMetr
 	return execMetrics, nil
 }
 
-// getCPUTimeForComponent return the CPU Time taken by a component (vtgate, vttablet, ...)
-// for the given execUUID. The range of the select is defined through the start and end
-// arguments, to select the whole span one can use: "start:0, end:now()".
+// getSumFloatValueForQuery return the sum of a float value based on the given query, for
+// each row.
 func getSumFloatValueForQuery(client influxdb.Client, query string) (float64, error) {
 	result, err := client.Select(query)
 	if err != nil {

--- a/go/exec/metrics/metrics_test.go
+++ b/go/exec/metrics/metrics_test.go
@@ -26,6 +26,7 @@ import (
 func emptyExecMetrics() ExecutionMetrics {
 	return ExecutionMetrics{
 		ComponentsCPUTime: map[string]float64{},
+		ComponentsMemStatsAllocBytes: map[string]float64{},
 	}
 }
 
@@ -36,6 +37,11 @@ func simpleExecMetrics(vtgate, vttablet float64) ExecutionMetrics {
 			"vtgate":   vtgate,
 			"vttablet": vttablet,
 		},
+		TotalComponentsMemStatsAllocBytes: vtgate + vttablet,
+		ComponentsMemStatsAllocBytes: map[string]float64{
+			"vtgate":   vtgate,
+			"vttablet": vttablet,
+		},
 	}
 }
 
@@ -43,6 +49,11 @@ func complexExecMetrics(vtgate, vttablet, all float64) ExecutionMetrics {
 	return ExecutionMetrics{
 		TotalComponentsCPUTime: all,
 		ComponentsCPUTime: map[string]float64{
+			"vtgate":   vtgate,
+			"vttablet": vttablet,
+		},
+		TotalComponentsMemStatsAllocBytes: all,
+		ComponentsMemStatsAllocBytes: map[string]float64{
 			"vtgate":   vtgate,
 			"vttablet": vttablet,
 		},

--- a/go/exec/metrics/metrics_test.go
+++ b/go/exec/metrics/metrics_test.go
@@ -32,8 +32,8 @@ func emptyExecMetrics() ExecutionMetrics {
 func simpleExecMetrics(vtgate, vttablet float64) ExecutionMetrics {
 	return ExecutionMetrics{
 		TotalComponentsCPUTime: vtgate + vttablet,
-		ComponentsCPUTime:      map[string]float64{
-			"vtgate": vtgate,
+		ComponentsCPUTime: map[string]float64{
+			"vtgate":   vtgate,
 			"vttablet": vttablet,
 		},
 	}
@@ -42,8 +42,8 @@ func simpleExecMetrics(vtgate, vttablet float64) ExecutionMetrics {
 func complexExecMetrics(vtgate, vttablet, all float64) ExecutionMetrics {
 	return ExecutionMetrics{
 		TotalComponentsCPUTime: all,
-		ComponentsCPUTime:      map[string]float64{
-			"vtgate": vtgate,
+		ComponentsCPUTime: map[string]float64{
+			"vtgate":   vtgate,
 			"vttablet": vttablet,
 		},
 	}
@@ -74,6 +74,48 @@ func TestCompareTwo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 			got := CompareTwo(tt.left, tt.right)
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func Test_compareSafe(t *testing.T) {
+	tests := []struct {
+		name       string
+		left       float64
+		right      float64
+		wantResult float64
+	}{
+		{name: "50% performance increase", left: 100, right: 50, wantResult: 50},
+		{name: "100% performance decrease", left: 50, right: 100, wantResult: -100},
+		{name: "200% performance decrease", left: 50, right: 150, wantResult: -200},
+		{name: "left zero", left: 0, right: 100, wantResult: -100},
+		{name: "right zero", left: 100, right: 0, wantResult: 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := compareSafe(tt.left, tt.right)
+			c.Assert(got, qt.Equals, tt.wantResult)
+		})
+	}
+}
+
+func Test_compareSafeComponentMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  map[string]float64
+		right map[string]float64
+		want  map[string]float64
+	}{
+		{name: "Same component", left: map[string]float64{"vtgate": 10}, right: map[string]float64{"vtgate": 10}, want: map[string]float64{"vtgate": 0}},
+		{name: "Same component with performance increase", left: map[string]float64{"vtgate": 10}, right: map[string]float64{"vtgate": 5}, want: map[string]float64{"vtgate": 50}},
+		{name: "Compare multiple components", left: map[string]float64{"vtgate": 10, "vttablet": 10}, right: map[string]float64{"vtgate": 5, "vttablet": 20}, want: map[string]float64{"vtgate": 50, "vttablet": -100}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := compareSafeComponentMap(tt.left, tt.right)
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})
 	}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -152,6 +152,7 @@ func (s *Server) Run() error {
 	s.router = gin.Default()
 	s.router.SetFuncMap(template.FuncMap{
 		"formatFloat": func(f float64) string { return humanize.FormatFloat("#,###.##", f) },
+		"formatBytes": func(f float64) string { return humanize.Bytes(uint64(f)) },
 	})
 
 	s.router.Static("/static", s.staticPath)

--- a/go/server/templates/compare.tmpl
+++ b/go/server/templates/compare.tmpl
@@ -136,6 +136,20 @@ limitations under the License.
                                     <td class="text-center">{{ formatFloat (index $elem.DiffMetrics.ComponentsCPUTime $componentCPUName) }}</td>
                                 </tr>
                             {{ end }}
+                            <tr>
+                                <th scope="row" class="text-center">Total Allocs bytes</th>
+                                <td class="text-center">{{ formatBytes $elem.Compare.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                                <td class="text-center">{{ formatBytes $elem.Reference.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                                <td class="text-center">{{ formatFloat $elem.DiffMetrics.TotalComponentsMemStatsAllocBytes }}</td>
+                            </tr>
+                            {{ range $componentAllocsName, $componentAllocsValue := $elem.Compare.Metrics.ComponentsMemStatsAllocBytes }}
+                            <tr>
+                                <th scope="row" class="text-center">Allocs bytes {{$componentAllocsName}}</th>
+                                <td class="text-center">{{ formatBytes (index $elem.Compare.Metrics.ComponentsMemStatsAllocBytes $componentAllocsName) }}</td>
+                                <td class="text-center">{{ formatBytes (index $elem.Reference.Metrics.ComponentsMemStatsAllocBytes $componentAllocsName) }}</td>
+                                <td class="text-center">{{ formatFloat (index $elem.DiffMetrics.ComponentsMemStatsAllocBytes $componentAllocsName) }}</td>
+                            </tr>
+                            {{ end }}
                         {{ end }}
                         </tbody>
                     </table>

--- a/go/server/templates/macrobench.tmpl
+++ b/go/server/templates/macrobench.tmpl
@@ -155,6 +155,20 @@ limitations under the License.
                                     <td class="text-center">{{ formatFloat (index $elem.DiffMetrics.ComponentsCPUTime $componentCPUName) }}</td>
                                 </tr>
                             {{ end }}
+                            <tr>
+                                <th scope="row" class="text-center">Total Allocs bytes</th>
+                                <td class="text-center">{{ formatBytes $elem.Compare.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                                <td class="text-center">{{ formatBytes $elem.Reference.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                                <td class="text-center">{{ formatFloat $elem.DiffMetrics.TotalComponentsMemStatsAllocBytes }}</td>
+                            </tr>
+                            {{ range $componentAllocsName, $componentAllocsValue := $elem.Compare.Metrics.ComponentsMemStatsAllocBytes }}
+                            <tr>
+                                <th scope="row" class="text-center">Allocs bytes {{$componentAllocsName}}</th>
+                                <td class="text-center">{{ formatBytes (index $elem.Compare.Metrics.ComponentsMemStatsAllocBytes $componentAllocsName) }}</td>
+                                <td class="text-center">{{ formatBytes (index $elem.Reference.Metrics.ComponentsMemStatsAllocBytes $componentAllocsName) }}</td>
+                                <td class="text-center">{{ formatFloat (index $elem.DiffMetrics.ComponentsMemStatsAllocBytes $componentAllocsName) }}</td>
+                            </tr>
+                            {{ end }}
                         {{ end }}
                         </tbody>
                     </table>

--- a/go/server/templates/search.tmpl
+++ b/go/server/templates/search.tmpl
@@ -108,6 +108,28 @@ limitations under the License.
                             {{ end }}
                             </tbody>
                         </table>
+                        <table class="table table-striped table-hover table-sm table-bordered">
+                            <thead>
+                            <tr>
+                                <th scope="col" class="text-center">Total Allocs bytes</th>
+                                {{ range $elem := $val }}
+                                    {{ range $componentAllocsName, $componentAllocsValue := $elem.Metrics.ComponentsMemStatsAllocBytes }}
+                                    <th scope="col" class="text-center">Allocs bytes {{$componentAllocsName}}</th>
+                                    {{ end }}
+                                {{ end }}
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{ range $elem := $val }}
+                            <tr>
+                                <td class="text-right">{{ formatBytes $elem.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                                {{ range $componentAllocsName, $componentAllocsValue := $elem.Metrics.ComponentsMemStatsAllocBytes }}
+                                    <td class="text-right">{{ formatBytes (index $elem.Metrics.ComponentsMemStatsAllocBytes $componentAllocsName ) }}</td>
+                                {{ end }}
+                            </tr>
+                            {{ end }}
+                            </tbody>
+                        </table>
                     {{ end }}
                 {{ else if not .macrobenchmark }}
                     <div class="alert alert-warning" role="alert">

--- a/go/tools/macrobench/results_test.go
+++ b/go/tools/macrobench/results_test.go
@@ -69,20 +69,20 @@ func TestMacroBenchmarkDetailsArray_ReduceSimpleMedian(t *testing.T) {
 		wantReduceMabd DetailsArray
 	}{
 		{name: "Few elements with same git ref", mabd: []Details{
-			*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-			*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+			*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+			*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 		}, wantReduceMabd: []Details{
-			*newDetails(BenchmarkID{}, "11bbAAA", resultOfOneHalf, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+			*newDetails(BenchmarkID{}, "11bbAAA", resultOfOneHalf, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes:      map[string]float64{}}),
 		}},
 
 		{name: "Few elements with different git refs", mabd: []Details{
-			*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-			*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-			*newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-			*newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+			*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+			*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+			*newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+			*newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 		}, wantReduceMabd: []Details{
-			*newDetails(BenchmarkID{}, "11bbAAA", resultOfOneHalf, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-			*newDetails(BenchmarkID{}, "f78gh1p", resultOfOneHalf, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+			*newDetails(BenchmarkID{}, "11bbAAA", resultOfOneHalf, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+			*newDetails(BenchmarkID{}, "f78gh1p", resultOfOneHalf, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 		}},
 	}
 	for _, tt := range tests {
@@ -164,41 +164,41 @@ func TestCompareDetailsArrays(t *testing.T) {
 	}{
 		{name: "Simple comparison array", args: args{
 			references: DetailsArray{
-				*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+				*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 			},
 			compares: DetailsArray{
-				*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+				*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 			},
 		}, wantCompared: ComparisonArray{
 			Comparison{
-				Reference: *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				Compare:   *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				Diff:      resultOfFifty,
-				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}},
+				Reference:   *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Compare:     *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Diff:        resultOfFifty,
+				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},
 		}},
 
 		{name: "Simple comparison array with multiple sources", args: args{
 			references: DetailsArray{
-				*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				*newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+				*newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				*newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 			},
 			compares: DetailsArray{
-				*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				*newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
+				*newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				*newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 			},
 		}, wantCompared: ComparisonArray{
 			Comparison{
-				Reference: *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				Compare:   *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				Diff:      resultOfFifty,
-				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}},
+				Reference:   *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Compare:     *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Diff:        resultOfFifty,
+				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},
 			Comparison{
-				Reference: *newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				Compare:   *newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}}),
-				Diff:      *newResult(*newQPS(50, 50, 50, 50), 50, -100, 50, 50, 50, 50),
-				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}},
+				Reference:   *newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Compare:     *newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Diff:        *newResult(*newQPS(50, 50, 50, 50), 50, -100, 50, 50, 50, 50),
+				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},
 		}},
 	}


### PR DESCRIPTION
## Description

This pull request provides initial support for golang's memory metrics. The metrics we're fetching and analyzing are `go_memstats_alloc_bytes_total`. In the future, it would be preferable to have a very flexible way of adding and modifying the golang metrics we want to fetch & compute.

The metrics are fetched in the execution metrics package and appended to macrobenchmark's comparison and details. The metric is stored for both VTGate and VTTablet, the sum of the two is also stored.

## Related issue(s)

Resolves #216.

