### PR TITLE
Support for oltp/tpcc vschema and improved equinix tags

### DIFF
--- a/ansible/macrobench.yml
+++ b/ansible/macrobench.yml
@@ -158,21 +158,23 @@
         done
       changed_when: false
 
-    - name: Get schema
+    - name: Get VSchema for OLTP
       ansible.builtin.copy:
-        src: "{{ macrobenchmark_vschema }}"
+        src: "{{ macrobenchmark_vschema_oltp }}"
         dest: /tmp/vschema_sysbench.json
         mode: '0644'
+      when: arewefastyet_execution_type == 'oltp'
+
+    - name: Get VSchema for TPCC
+      ansible.builtin.copy:
+        src: "{{ macrobenchmark_vschema_tpcc }}"
+        dest: /tmp/vschema_sysbench.json
+        mode: '0644'
+      when: arewefastyet_execution_type == 'tpcc'
 
     - name: Ensure VSchmea
       shell: |
         vtctlclient -server {{ groups['vtctld'][0] }}:15999 ApplyVSchema -vschema="$(cat /tmp/vschema_sysbench.json)" main
-      when: tpcc is not defined
-
-    - name: Ensure VSchmea
-      shell: |
-        vtctlclient -server {{ groups['vtctld'][0] }}:15999 ApplyVSchema -vschema="$(cat /tmp/vschema_sysbench.json)" main
-      when: tpcc is defined
 
 - hosts: macrobench
   roles:

--- a/ansible/macrobench_sharded_inventory.yml
+++ b/ansible/macrobench_sharded_inventory.yml
@@ -19,7 +19,8 @@ all:
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
     arewefastyet_git_version: "HEAD"
-    macrobenchmark_vschema: "./vitess-benchmark/sysbench.json"
+    macrobenchmark_vschema_oltp: "./vitess-benchmark/sysbench.json"
+    macrobenchmark_vschema_tpcc: "./vitess-benchmark/tpcc_vschema.json"
     macrobenchmarks_local_config: "LOCAL_CONFIG_PATH_0"
     cell: local
     keyspace: main

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -54,6 +54,8 @@ const (
 	// or SHA on which benchmarks will be executed.
 	keyVitessVersion = "vitess_git_version"
 
+	keyExecutionType = "arewefastyet_execution_type"
+
 	stderrFile = "exec-stderr.log"
 	stdoutFile = "exec-stdout.log"
 
@@ -167,6 +169,7 @@ func (e *Exec) Prepare() error {
 	e.Infra.SetTags(map[string]string{
 		"execution_git_ref": git.ShortenSHA(e.GitRef),
 		"execution_source":  e.Source,
+		"execution_type": e.typeOf,
 	})
 
 	err = e.prepareDirectories()
@@ -221,6 +224,7 @@ func (e *Exec) Execute() (err error) {
 	e.AnsibleConfig.ExtraVars[keyExecUUID] = e.UUID.String()
 	e.AnsibleConfig.ExtraVars[keyVitessVersion] = e.GitRef
 	e.AnsibleConfig.ExtraVars[keyExecSource] = e.Source
+	e.AnsibleConfig.ExtraVars[keyExecutionType] = e.typeOf
 
 	// Infra will run the given config.
 	err = e.Infra.Run(&e.AnsibleConfig)

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -20,5 +20,5 @@ resource "metal_device" "node" {
   operating_system = var.operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id
-  tags             = [var.execution_source, var.execution_git_ref]
+  tags             = [var.execution_source, var.execution_git_ref, var.execution_type]
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -50,3 +50,8 @@ variable "execution_git_ref" {
   description = "The git reference on which we execute benchmarks"
   default = ""
 }
+
+variable "execution_type" {
+  description = "The type of execution (can be micro, oltp, tpcc)"
+  default = ""
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible==2.9.12
 molecule[ansible, docker]
 supervisor
 ansible_runner
+jmespath


### PR DESCRIPTION
## Description

This pull request fixes an issue with TPCC's vschema, in short, TPCC vschema was not properly set and was using OLTP's vschema instead. This issue is fixed by introducing two Ansible variables (`macrobenchmark_vschema_oltp` and `macrobenchmark_vschema_tpcc`) that define which vschema file needs to be used.

Additionally, the execution type (oltp, tpcc, micro) is added to Equinix instances' tags.

## Related issues

Resolves #218.