### PR TITLE
Planner Version Support in Macrobenchmarks

### DIFF
--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -42,6 +42,6 @@
 
 - name: Run macrobenchmarks
   shell: |
-    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }}
+    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ planner_version }}
   register: arewefastyetcli
   changed_when: False

--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -25,7 +25,7 @@ EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
             -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }},waitSig
         {%- endfor %}
     {% endif %}
-    -planner_version {{ planner_version }}
+    -planner_version {{ planner_version | default("V3") }}
     {{gateway.extra_flags|default("")}} \
     {{extra_vtgate_flags|default("")}} \
 "

--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -25,6 +25,7 @@ EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
             -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }},waitSig
         {%- endfor %}
     {% endif %}
+    -planner_version {{ planner_version }}
     {{gateway.extra_flags|default("")}} \
     {{extra_vtgate_flags|default("")}} \
 "

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -23,30 +23,31 @@ arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --db-
 ### Options
 
 ```
-      --ansible-inventory-files strings   List of inventory files used by Ansible
-      --ansible-playbook-files strings    List of playbook files used by Ansible
-      --ansible-root-directory string     Root directory of Ansible
-      --db-database string                Database to use.
-      --db-host string                    Hostname of the database
-      --db-password string                Password to authenticate the database.
-      --db-user string                    User used to connect to the database
-      --equinix-instance-type string      Instance type to use for the creation of a new node
-      --equinix-project-id string         Project ID to use for Equinix Metal
-      --equinix-token string              Auth Token for Equinix Metal
-      --exec-git-ref string               Git reference on which the benchmarks will run.
-      --exec-pull-nb int                  Defines the number of the pull request against which to execute.
-      --exec-root-dir string              Path to the root directory of exec.
-      --exec-source string                Name of the source that triggered the execution.
-      --exec-type string                  Defines the execution type (oltp, tpcc, micro).
-  -h, --help                              help for exec
-      --infra-path string                 Path to the infra directory
-      --slack-channel string              Slack channel on which to post messages
-      --slack-token string                Token used to authenticate Slack
-      --stats-remote-db-database string   Name of the stats remote database.
-      --stats-remote-db-host string       Hostname of the stats remote database.
-      --stats-remote-db-password string   Password to authenticate the stats remote database.
-      --stats-remote-db-port string       Port of the stats remote database.
-      --stats-remote-db-user string       User used to connect to the stats remote database
+      --ansible-inventory-files strings      List of inventory files used by Ansible
+      --ansible-playbook-files strings       List of playbook files used by Ansible
+      --ansible-root-directory string        Root directory of Ansible
+      --db-database string                   Database to use.
+      --db-host string                       Hostname of the database
+      --db-password string                   Password to authenticate the database.
+      --db-user string                       User used to connect to the database
+      --equinix-instance-type string         Instance type to use for the creation of a new node
+      --equinix-project-id string            Project ID to use for Equinix Metal
+      --equinix-token string                 Auth Token for Equinix Metal
+      --exec-git-ref string                  Git reference on which the benchmarks will run.
+      --exec-pull-nb int                     Defines the number of the pull request against which to execute.
+      --exec-root-dir string                 Path to the root directory of exec.
+      --exec-source string                   Name of the source that triggered the execution.
+      --exec-type string                     Defines the execution type (oltp, tpcc, micro).
+      --exec-vtgate-planner-version string   Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
+  -h, --help                                 help for exec
+      --infra-path string                    Path to the infra directory
+      --slack-channel string                 Slack channel on which to post messages
+      --slack-token string                   Token used to authenticate Slack
+      --stats-remote-db-database string      Name of the stats remote database.
+      --stats-remote-db-host string          Hostname of the stats remote database.
+      --stats-remote-db-password string      Password to authenticate the stats remote database.
+      --stats-remote-db-port string          Port of the stats remote database.
+      --stats-remote-db-user string          User used to connect to the stats remote database
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -19,19 +19,20 @@ arewastyet macrobenchmark run --db-database benchmark --db-host localhost --db-p
 ### Options
 
 ```
-      --db-database string                      Database to use.
-      --db-host string                          Hostname of the database
-      --db-password string                      Password to authenticate the database.
-      --db-user string                          User used to connect to the database
-  -h, --help                                    help for run
-      --macrobench-exec-uuid string             UUID of the parent execution, an empty string will set to NULL.
-      --macrobench-git-ref string               Git SHA referring to the macro benchmark.
-      --macrobench-skip-steps strings           Slice of sysbench steps to skip.
-      --macrobench-source string                The source or origin of the macro benchmark trigger.
-      --macrobench-sysbench-executable string   Path to the sysbench binary.
-      --macrobench-type Type                    Type of macro benchmark.
-      --macrobench-working-directory string     Directory on which to execute sysbench.
-      --macrobench-workload-path string         Path to the workload used by sysbench.
+      --db-database string                         Database to use.
+      --db-host string                             Hostname of the database
+      --db-password string                         Password to authenticate the database.
+      --db-user string                             User used to connect to the database
+  -h, --help                                       help for run
+      --macrobench-exec-uuid string                UUID of the parent execution, an empty string will set to NULL.
+      --macrobench-git-ref string                  Git SHA referring to the macro benchmark.
+      --macrobench-skip-steps strings              Slice of sysbench steps to skip.
+      --macrobench-source string                   The source or origin of the macro benchmark trigger.
+      --macrobench-sysbench-executable string      Path to the sysbench binary.
+      --macrobench-type Type                       Type of macro benchmark.
+      --macrobench-vtgate-planner-version string   Vtgate planner version running on Vitess
+      --macrobench-working-directory string        Directory on which to execute sysbench.
+      --macrobench-workload-path string            Path to the workload used by sysbench.
 ```
 
 ### Options inherited from parent commands

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -37,7 +37,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	_ = v.UnmarshalKey(flagGitRefExec, &e.GitRef)
 	_ = v.UnmarshalKey(flagSourceExec, &e.Source)
 	_ = v.UnmarshalKey(flagExecType, &e.typeOf)
-	_ = v.UnmarshalKey(flagVtgatePlannerVersion, &e.vtgatePlannerVersion)
+	_ = v.UnmarshalKey(flagVtgatePlannerVersion, &e.VtgatePlannerVersion)
 	_ = v.UnmarshalKey(flagExecPullNB, &e.pullNB)
 
 	e.AnsibleConfig.AddToViper(v)
@@ -54,7 +54,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&e.GitRef, flagGitRefExec, "", "Git reference on which the benchmarks will run.")
 	cmd.Flags().StringVar(&e.Source, flagSourceExec, "", "Name of the source that triggered the execution.")
 	cmd.Flags().StringVar(&e.typeOf, flagExecType, "", "Defines the execution type (oltp, tpcc, micro).")
-	cmd.Flags().StringVar(&e.vtgatePlannerVersion, flagVtgatePlannerVersion, "V3", "Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback.")
+	cmd.Flags().StringVar(&e.VtgatePlannerVersion, flagVtgatePlannerVersion, "V3", "Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback.")
 	cmd.Flags().IntVar(&e.pullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
 
 	_ = viper.BindPFlag(flagRootExec, cmd.Flags().Lookup(flagRootExec))

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -24,11 +24,12 @@ import (
 )
 
 const (
-	flagRootExec   = "exec-root-dir"
-	flagGitRefExec = "exec-git-ref"
-	flagSourceExec = "exec-source"
-	flagExecType   = "exec-type"
-	flagExecPullNB = "exec-pull-nb"
+	flagRootExec             = "exec-root-dir"
+	flagGitRefExec           = "exec-git-ref"
+	flagSourceExec           = "exec-source"
+	flagExecType             = "exec-type"
+	flagVtgatePlannerVersion = "exec-vtgate-planner-version"
+	flagExecPullNB           = "exec-pull-nb"
 )
 
 func (e *Exec) AddToViper(v *viper.Viper) (err error) {
@@ -36,6 +37,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	_ = v.UnmarshalKey(flagGitRefExec, &e.GitRef)
 	_ = v.UnmarshalKey(flagSourceExec, &e.Source)
 	_ = v.UnmarshalKey(flagExecType, &e.typeOf)
+	_ = v.UnmarshalKey(flagVtgatePlannerVersion, &e.vtgatePlannerVersion)
 	_ = v.UnmarshalKey(flagExecPullNB, &e.pullNB)
 
 	e.AnsibleConfig.AddToViper(v)
@@ -52,6 +54,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&e.GitRef, flagGitRefExec, "", "Git reference on which the benchmarks will run.")
 	cmd.Flags().StringVar(&e.Source, flagSourceExec, "", "Name of the source that triggered the execution.")
 	cmd.Flags().StringVar(&e.typeOf, flagExecType, "", "Defines the execution type (oltp, tpcc, micro).")
+	cmd.Flags().StringVar(&e.vtgatePlannerVersion, flagVtgatePlannerVersion, "V3", "Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback.")
 	cmd.Flags().IntVar(&e.pullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
 
 	_ = viper.BindPFlag(flagRootExec, cmd.Flags().Lookup(flagRootExec))

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -56,6 +56,8 @@ const (
 
 	keyExecutionType = "arewefastyet_execution_type"
 
+	keyVtgatePlanner = "planner_version"
+
 	stderrFile = "exec-stderr.log"
 	stdoutFile = "exec-stdout.log"
 
@@ -102,8 +104,11 @@ type Exec struct {
 	stderr io.Writer
 
 	createdInDB bool
-	prepared   bool
-	configPath string
+	prepared    bool
+	configPath  string
+
+	// vtgatePlannerVersion is the planner version that vtgate is going to use
+	vtgatePlannerVersion string
 }
 
 // SetStdout sets the standard output of Exec.
@@ -169,7 +174,7 @@ func (e *Exec) Prepare() error {
 	e.Infra.SetTags(map[string]string{
 		"execution_git_ref": git.ShortenSHA(e.GitRef),
 		"execution_source":  e.Source,
-		"execution_type": e.typeOf,
+		"execution_type":    e.typeOf,
 	})
 
 	err = e.prepareDirectories()
@@ -227,6 +232,7 @@ func (e *Exec) Execute() (err error) {
 	e.AnsibleConfig.ExtraVars[keyVitessVersion] = e.GitRef
 	e.AnsibleConfig.ExtraVars[keyExecSource] = e.Source
 	e.AnsibleConfig.ExtraVars[keyExecutionType] = e.typeOf
+	e.AnsibleConfig.ExtraVars[keyVtgatePlanner] = e.vtgatePlannerVersion
 
 	// Infra will run the given config.
 	err = e.Infra.Run(&e.AnsibleConfig)

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -172,9 +172,10 @@ func (e *Exec) Prepare() error {
 	e.createdInDB = true
 
 	e.Infra.SetTags(map[string]string{
-		"execution_git_ref": git.ShortenSHA(e.GitRef),
-		"execution_source":  e.Source,
-		"execution_type":    e.typeOf,
+		"execution_git_ref":         git.ShortenSHA(e.GitRef),
+		"execution_source":          e.Source,
+		"execution_type":            e.typeOf,
+		"execution_planner_version": e.VtgatePlannerVersion,
 	})
 
 	err = e.prepareDirectories()

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -22,16 +22,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/vitessio/arewefastyet/go/storage/mysql"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/vitessio/arewefastyet/go/storage/mysql"
 )
 
 const (
-	ErrorNoSysBenchResult          = "no sysbench results were found"
+	ErrorNoSysBenchResult = "no sysbench results were found"
 
 	prefixMacroBenchSysbenchConfig = "macrobench_"
+)
+
+var (
+	PlannerVersions = []string{
+		"V3",
+		"Gen4Fallback",
+	}
 )
 
 func buildSysbenchArgString(m map[string]string, step string) []string {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -20,5 +20,5 @@ resource "metal_device" "node" {
   operating_system = var.operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id
-  tags             = [var.execution_source, var.execution_git_ref, var.execution_type]
+  tags             = [var.execution_source, var.execution_git_ref, var.execution_type, var.execution_planner_version]
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -55,3 +55,8 @@ variable "execution_type" {
   description = "The type of execution (can be micro, oltp, tpcc)"
   default = ""
 }
+
+variable "execution_planner_version" {
+  description = "The planner being used by vtgate for execution (can be V3, Gen4FallBack)"
+  default = ""
+}

--- a/sql/migration/005_add_vtgate_planner_version_to_macrobenchmarks.sql
+++ b/sql/migration/005_add_vtgate_planner_version_to_macrobenchmarks.sql
@@ -1,0 +1,19 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+alter table macrobenchmark add column vtgate_planner_version varchar(20) NOT NULL DEFAULT "V3";

--- a/sql/migration/test_migration.sh
+++ b/sql/migration/test_migration.sh
@@ -18,3 +18,4 @@ mysql -u root < ./001_New_parent_table_for_executions_125.sql
 mysql -u root < ./002_add_foreign_key_to_microbenchmark_details.sql
 mysql -u root < ./003_add_type_to_execution.sql
 mysql -u root < ./004_add_pull_request_to_execution.sql
+mysql -u root < ./005_add_vtgate_planner_version_to_macrobenchmarks.sql

--- a/sql/vitess-benchmark.sql
+++ b/sql/vitess-benchmark.sql
@@ -82,6 +82,7 @@ CREATE TABLE `macrobenchmark` (
                                   `DateTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                                   `source` varchar(100) DEFAULT NULL,
                                   `exec_uuid` varchar(100) DEFAULT NULL,
+                                  `vtgate_planner_version` varchar(20) NOT NULL DEFAULT 'V3',
                                   PRIMARY KEY (`macrobenchmark_id`),
                                   KEY `macrobenchmark_ibfk_1` (`exec_uuid`),
                                   CONSTRAINT `macrobenchmark_ibfk_1` FOREIGN KEY (`exec_uuid`) REFERENCES `execution` (`uuid`)


### PR DESCRIPTION
## Description

This PR adds a new flag to the execution of macrobenchmarks which allows us to change the planner version that vtgate is using - (V3, Gen4Fallback). It also updates the cron jobs to run for both versions for planner.
Finally, it adds additional tags to the equinix servers that are running.

## Linked Issues

Fixes #214 