### PR TITLE
Switch between vtgate planner V3 and Gen4

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -309,7 +309,7 @@ Comparison can be seen at : ` + getComparisonLink(e.GitRef, previousGitRef) + `
 			return err
 		}
 
-		macrosMatrices, err := macrobench.CompareMacroBenchmarks(e.clientDB, influxClient, e.GitRef, previousGitRef)
+		macrosMatrices, err := macrobench.CompareMacroBenchmarks(e.clientDB, influxClient, e.GitRef, previousGitRef, macrobench.PlannerVersion(e.VtgatePlannerVersion))
 		if err != nil {
 			return err
 		}

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -49,7 +49,10 @@ func (s *Server) informationHandler(c *gin.Context) {
 
 func (s *Server) homeHandler(c *gin.Context) {
 	planner := macrobench.V3Planner
-	plannerStr := c.Query("planner")
+	plannerStr, err := c.Cookie("vtgatePlanner")
+	if err != nil {
+		slog.Warn(err.Error())
+	}
 	if plannerStr == string(macrobench.Gen4FallbackPlanner) {
 		planner = macrobench.Gen4FallbackPlanner
 	}
@@ -68,7 +71,6 @@ func (s *Server) homeHandler(c *gin.Context) {
 		"title":     "Vitess benchmark",
 		"data_oltp": oltpData,
 		"data_tpcc": tpccData,
-		"planner":   plannerStr,
 	})
 }
 

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -48,12 +48,18 @@ func (s *Server) informationHandler(c *gin.Context) {
 }
 
 func (s *Server) homeHandler(c *gin.Context) {
-	oltpData, err := macrobench.GetResultsForLastDays(macrobench.OLTP, "cron", macrobench.V3Planner, 31, s.dbClient)
+	planner := macrobench.V3Planner
+	plannerStr := c.Query("planner")
+	if plannerStr == string(macrobench.Gen4FallbackPlanner) {
+		planner = macrobench.Gen4FallbackPlanner
+	}
+
+	oltpData, err := macrobench.GetResultsForLastDays(macrobench.OLTP, "cron", planner, 31, s.dbClient)
 	if err != nil {
 		slog.Warn(err.Error())
 	}
 
-	tpccData, err := macrobench.GetResultsForLastDays(macrobench.TPCC, "cron", macrobench.V3Planner, 31, s.dbClient)
+	tpccData, err := macrobench.GetResultsForLastDays(macrobench.TPCC, "cron", planner, 31, s.dbClient)
 	if err != nil {
 		slog.Warn(err.Error())
 	}
@@ -62,6 +68,7 @@ func (s *Server) homeHandler(c *gin.Context) {
 		"title":     "Vitess benchmark",
 		"data_oltp": oltpData,
 		"data_tpcc": tpccData,
+		"planner":   plannerStr,
 	})
 }
 

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -153,6 +153,7 @@ func (s *Server) Run() error {
 	s.router.SetFuncMap(template.FuncMap{
 		"formatFloat": func(f float64) string { return humanize.FormatFloat("#,###.##", f) },
 		"formatBytes": func(f float64) string { return humanize.Bytes(uint64(f)) },
+
 	})
 
 	s.router.Static("/static", s.staticPath)

--- a/go/server/templates/index.tmpl
+++ b/go/server/templates/index.tmpl
@@ -28,13 +28,6 @@ limitations under the License.
       <h1>Are We Fast Yet</h1>
       <p class="lead"></p>
       <p>Nightly benchmark project for <a href="https://vitess.io">Vitess</a>.</p>
-      <h3>
-        Settings
-      </h3>
-          <div class="custom-control custom-switch">
-            <input type="checkbox" class="custom-control-input" id="vtgateplanner-switch" {{ if eq .planner "Gen4Fallback" }}checked{{ end }} onclick="switchVtgatePlanner()">
-            <label class="custom-control-label" for="vtgateplanner-switch">VTGate Planner Gen4</label>
-          </div>
     </div>
   </section>
 
@@ -402,14 +395,6 @@ limitations under the License.
     {{ if .data_tpcc}}
       plotTPCC({{ .data_tpcc }})
     {{ end }}
-
-    function switchVtgatePlanner() {
-      if ($("#vtgateplanner-switch").is(":checked")) {
-        window.open("/?planner=Gen4Fallback", '_self');
-      } else {
-        window.open("/", "_self");
-      }
-    }
   </script>
 
 </body>

--- a/go/server/templates/index.tmpl
+++ b/go/server/templates/index.tmpl
@@ -23,12 +23,27 @@ limitations under the License.
     <!-- Navigation -->
     {{ template "navigation" "/" }}
 
+  <section class="py-5" style="padding-top: 10px !important;">
+    <div class="container">
+      <h1>Are We Fast Yet</h1>
+      <p class="lead"></p>
+      <p>Nightly benchmark project for <a href="https://vitess.io">Vitess</a>.</p>
+      <h3>
+        Settings
+      </h3>
+          <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="vtgateplanner-switch" {{ if eq .planner "Gen4Fallback" }}checked{{ end }} onclick="switchVtgatePlanner()">
+            <label class="custom-control-label" for="vtgateplanner-switch">VTGate Planner Gen4</label>
+          </div>
+    </div>
+  </section>
+
 
     <!--------------------------------------------------------------------------- OLTP ---------------------------------------------------------------------------------------------->
 
-    <section class="py-5">
+  <section class="py-5" style="padding-top: 10px !important;">
       <div class="container">
-        <h1>SYSBENCH OLTP BENCHMARK</h1>
+        <h2>SYSBENCH OLTP BENCHMARK</h2>
         <p class="lead"></p>
         <p>The Sysbench OLTP application benchmark runs on top of a MySQL database running the InnoDB storage engine.
           The
@@ -59,7 +74,9 @@ limitations under the License.
       {{ if not .data_oltp }}
       <p class="text-center font-italic">The graph could not be rendered.</p>
       {{ else }}
-      <canvas id="tps" height="100"></canvas>
+      <div class="container-xl">
+        <canvas id="tps" height="100"></canvas>
+      </div>
       {{ end }}
     </header>
 
@@ -79,7 +96,9 @@ limitations under the License.
       {{ if not .data_oltp }}
       <p class="text-center font-italic">The graph could not be rendered.</p>
       {{ else }}
-      <canvas id="qps" height="100"></canvas>
+      <div class="container-xl">
+        <canvas id="qps" height="100"></canvas>
+      </div>
       {{ end }}
     </header>
 
@@ -99,7 +118,9 @@ limitations under the License.
       {{ if not .data_oltp }}
       <p class="text-center font-italic">The graph could not be rendered.</p>
       {{ else }}
-      <canvas id="latency" height="100"></canvas>
+      <div class="container-xl">
+        <canvas id="latency" height="100"></canvas>
+      </div>
       {{ end }}
     </header>
 
@@ -109,7 +130,7 @@ limitations under the License.
 
     <section class="py-5">
       <div class="container">
-        <h1>TPC-C BENCHMARK</h1>
+        <h2>TPC-C BENCHMARK</h2>
         <p class="lead"></p>
         <p>"Despite being 25 years old, the TPC-C benchmark can still provide an interesting intensive workload for a
           database in my opinion. It runs multi-statement transactions
@@ -134,7 +155,9 @@ limitations under the License.
       {{ if not .data_tpcc }}
       <p class="text-center font-italic">The graph could not be rendered.</p>
       {{ else }}
-      <canvas id="tps_tpcc" height="100"></canvas>
+      <div class="container-xl">
+        <canvas id="tps_tpcc" height="100"></canvas>
+      </div>
       {{ end }}
     </header>
 
@@ -154,7 +177,9 @@ limitations under the License.
       {{ if not .data_tpcc }}
       <p class="text-center font-italic">The graph could not be rendered.</p>
       {{ else }}
-      <canvas id="qps_tpcc" height="100"></canvas>
+      <div class="container-xl">
+        <canvas id="qps_tpcc" height="100"></canvas>
+      </div>
       {{ end }}
     </header>
 
@@ -174,7 +199,9 @@ limitations under the License.
       {{ if not .data_tpcc }}
       <p class="text-center font-italic">The graph could not be rendered.</p>
       {{ else }}
-      <canvas id="latency_tpcc" height="100"></canvas>
+      <div class="container-xl">
+        <canvas id="latency_tpcc" height="100"></canvas>
+      </div>
       {{ end }}
     </header>
 
@@ -375,6 +402,14 @@ limitations under the License.
     {{ if .data_tpcc}}
       plotTPCC({{ .data_tpcc }})
     {{ end }}
+
+    function switchVtgatePlanner() {
+      if ($("#vtgateplanner-switch").is(":checked")) {
+        window.open("/?planner=Gen4Fallback", '_self');
+      } else {
+        window.open("/", "_self");
+      }
+    }
   </script>
 
 </body>

--- a/go/server/templates/navigation.tmpl
+++ b/go/server/templates/navigation.tmpl
@@ -26,6 +26,10 @@
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
+        <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="vtgateplanner-switch" onclick="switchVtgatePlanner()">
+            <label class="custom-control-label" for="vtgateplanner-switch" style="color: white">Gen4</label>
+        </div>
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item {{if eq . `/`}} active {{end}}">
@@ -88,4 +92,38 @@
         </div>
     </div>
 </nav>
+<script>
+    vtgatePlanner = "V3"
+
+    // get our planner cookie
+    vtgatePlannerCookie = document.cookie.split('; ').find(row => row.startsWith('vtgatePlanner='));
+    if (vtgatePlannerCookie !== undefined) {
+        vtgatePlanner = vtgatePlannerCookie.split('=')[1]
+        if (vtgatePlanner !== "Gen4Fallback") {
+            vtgatePlanner = "V3"
+        }
+        console.log(vtgatePlanner)
+    }
+    // change the switch
+    if (vtgatePlanner === "Gen4Fallback") {
+        $("#vtgateplanner-switch").prop('checked', true)
+    } else {
+        $("#vtgateplanner-switch").prop('checked', false)
+    }
+
+    function switchVtgatePlanner() {
+        function setCookie(cname, cvalue, exdays) {
+            var d = new Date();
+            d.setTime(d.getTime() + (exdays*24*60*60*1000));
+            var expires = "expires="+ d.toUTCString();
+            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+        }
+        if ($("#vtgateplanner-switch").is(":checked")) {
+            setCookie("vtgatePlanner", "Gen4Fallback", 7)
+        } else {
+            setCookie("vtgatePlanner", "V3", 7)
+        }
+        location.reload()
+    }
+</script>
 {{ end }}

--- a/go/tools/macrobench/compare.go
+++ b/go/tools/macrobench/compare.go
@@ -27,13 +27,13 @@ import (
 
 // CompareMacroBenchmarks takes in 3 arguments, the database, and 2 SHAs. It reads from the database, the macrobenchmark
 // results for the 2 SHAs and compares them. The result is a map with the key being the macrobenchmark name.
-func CompareMacroBenchmarks(dbClient *mysql.Client, metricsClient *influxdb.Client, reference string, compare string) (map[Type]interface{}, error) {
+func CompareMacroBenchmarks(dbClient *mysql.Client, metricsClient *influxdb.Client, reference, compare string, planner PlannerVersion) (map[Type]interface{}, error) {
 	// Get macro benchmarks from all the different types
 	SHAs := []string{reference, compare}
 	var err error
 	macros := map[string]map[Type]DetailsArray{}
 	for _, sha := range SHAs {
-		macros[sha], err = GetDetailsArraysFromAllTypes(sha, V3Planner, dbClient, metricsClient)
+		macros[sha], err = GetDetailsArraysFromAllTypes(sha, planner, dbClient, metricsClient)
 		if err != nil {
 			return nil, err
 		}

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -74,7 +74,7 @@ type tableCell struct {
 // to read the results. It also takes as an argument the name of the report that will be generated
 func GenerateCompareReport(client *mysql.Client, metricsClient *influxdb.Client, fromSHA, toSHA, reportFile string) error {
 	// Compare macrobenchmark results for the 2 SHAs
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(client, metricsClient, fromSHA, toSHA)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(client, metricsClient, fromSHA, toSHA, macrobench.V3Planner)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This pull request adds a switch to change which vtgate planner we want to use to query results on the website. The default is to use V3 planner, but can be switched to `Gen4Fallback` by turning the switch on.


