### PR TITLE
Fixing compareSafeComponentMap when left map is empty

### DIFF
--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -183,6 +183,12 @@ func compareSafeComponentMap(left, right map[string]float64) map[string]float64 
 		}
 		result[component] = compareSafe(left[component], right[component])
 	}
+	for component := range right {
+		if _, ok := left[component]; ok {
+			continue
+		}
+		result[component] = compareSafe(0, right[component])
+	}
 	return result
 }
 

--- a/go/exec/metrics/metrics_test.go
+++ b/go/exec/metrics/metrics_test.go
@@ -122,6 +122,8 @@ func Test_compareSafeComponentMap(t *testing.T) {
 		{name: "Same component", left: map[string]float64{"vtgate": 10}, right: map[string]float64{"vtgate": 10}, want: map[string]float64{"vtgate": 0}},
 		{name: "Same component with performance increase", left: map[string]float64{"vtgate": 10}, right: map[string]float64{"vtgate": 5}, want: map[string]float64{"vtgate": 50}},
 		{name: "Compare multiple components", left: map[string]float64{"vtgate": 10, "vttablet": 10}, right: map[string]float64{"vtgate": 5, "vttablet": 20}, want: map[string]float64{"vtgate": 50, "vttablet": -100}},
+		{name: "Left empty", left: map[string]float64{}, right: map[string]float64{"vtgate": 10, "vttablet": 10}, want: map[string]float64{"vtgate": -100, "vttablet": -100}},
+		{name: "Right empty", right: map[string]float64{}, left: map[string]float64{"vtgate": 10, "vttablet": 10}, want: map[string]float64{"vtgate": 0, "vttablet": 0}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Fixing a use case where `metrics.compareSafeComponentMap`'s left map is empty and caused the output to be empty as well.