### PR TITLE
Send Slack notification on every PR execution

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -279,10 +279,18 @@ func (e Exec) SendNotificationForRegression() (err error) {
 		return nil
 	}
 
+	// regression header, appender to header in the event of a regression
 	regressionHeader := `*Observed a regression.*
 `
-	header := `Comparing: recent commit <https://github.com/vitessio/vitess/commit/` + e.GitRef + `|` + git.ShortenSHA(e.GitRef) + `> with old commit <https://github.com/vitessio/vitess/commit/` + previousGitRef + `|` + git.ShortenSHA(previousGitRef) + `>.
-Benchmark UUIDs, recent: ` + e.UUID.String()[:7] + ` old: ` + previousExec[:7] + `.
+
+	// header of the message, before the regression explanation
+	header := ``
+	if e.pullNB > 0 {
+		header += fmt.Sprintf(`Benchmarked PR #<https://github.com/vitessio/vitess/pull/%d>.`, e.pullNB)
+	} else {
+		header += `Comparing: recent commit <https://github.com/vitessio/vitess/commit/` + e.GitRef + `|` + git.ShortenSHA(e.GitRef) + `> with old commit <https://github.com/vitessio/vitess/commit/` + previousGitRef + `|` + git.ShortenSHA(previousGitRef) + `>.`
+	}
+	header += `Benchmark UUIDs, recent: ` + e.UUID.String()[:7] + ` old: ` + previousExec[:7] + `.
 Comparison can be seen at : ` + getComparisonLink(e.GitRef, previousGitRef) + `
 
 `


### PR DESCRIPTION
## Description

The changes brought by this pull request will allow the notification of each PR execution as well as an enhanced message for PR executions. Regardless of possible regressions, a notification will always be issued.

## Related issue(s)

Fixes #215.