### PR TITLE
Set cookie default instead of warning

### DIFF
--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -51,14 +51,14 @@ func getPlannerVersion(c *gin.Context) macrobench.PlannerVersion {
 	planner := macrobench.V3Planner
 	plannerStr, err := c.Cookie("vtgatePlanner")
 	if err != nil {
-		slog.Warn(err.Error())
+		// cookie is not set, then use the default
+		return planner
 	}
 	if plannerStr == string(macrobench.Gen4FallbackPlanner) {
 		planner = macrobench.Gen4FallbackPlanner
 	}
 	return planner
 }
-
 
 func (s *Server) homeHandler(c *gin.Context) {
 	planner := getPlannerVersion(c)


### PR DESCRIPTION
## Description

The first time the website is accessed, the `vtgatePlanner` cookie is not set. For now, we would throw a warning when this happened. The behavior has been changed to just return the default.

## Related Issues
Fixes #232 