### PR TITLE
More regression runs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ The purpose of this project is to do a benchmark run when ever there is a push. 
 1. [Installation](Installation.md)
 2. [Cli](arewefastyet.md)
 3. [Makefile](Makefile.md)
+3. [Cron](cron.md)

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -41,8 +41,6 @@ arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --db-
       --exec-vtgate-planner-version string   Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
   -h, --help                                 help for exec
       --infra-path string                    Path to the infra directory
-      --slack-channel string                 Slack channel on which to post messages
-      --slack-token string                   Token used to authenticate Slack
       --stats-remote-db-database string      Name of the stats remote database.
       --stats-remote-db-host string          Hostname of the stats remote database.
       --stats-remote-db-password string      Password to authenticate the stats remote database.

--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -34,6 +34,8 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
       --influx-password string              Password used to connect to InfluxDB.
       --influx-port string                  Port on which to InfluxDB listens. (default "8086")
       --influx-username string              Username used to connect to InfluxDB.
+      --slack-channel string                Slack channel on which to post messages
+      --slack-token string                  Token used to authenticate Slack
       --web-cron-nb-retry int               Number of retries allowed for each cron job.
       --web-cron-schedule string            Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON. (default "@midnight")
       --web-macrobench-oltp-config string   Path to the configuration file used to execute OLTP macrobenchmark.

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,0 +1,35 @@
+# Arewefastyet cron and regression testing
+
+## Sources
+In arewefastyet, we run benchmark for multiple reasons, these reasons are named as “sources”. We use the four following sources:
+
+- New commits to the master branch: **cron**
+- New tags: **cron_tags_{tag_name}**
+- New commits to release branches: **cron_release_{release_name}**
+- New commits to pull requests: **cron_pr**
+- Base commit for a pull request: **cron_pr_base**
+
+## Cron and Schedule
+For each of the listed sources, we initiate a cron job that will periodically create new benchmarks. 
+The cron schedule used for those jobs is defined through one of the CLI’s flags, which defaults to every day at midnight.
+
+## Regressions and Notifications
+After running and analyzing a benchmark, we can determine that the result is a regression. 
+However, regression will be evaluated differently based on the benchmark’s source. 
+The different ways of evaluating a regression are:
+
+
+| Source | How to compare results |
+| ---- | -------------- |
+| **cron** |  Compare result against latest **cron** and latest release |
+| **cron_tags** | None |
+| **cron_release** | Compare result against the previous tag on this release branch and last **cron_release** |
+| **cron_pr** | Compare result against the pull request base’s reference refered by **cron_pr_base** |
+
+After the comparison and if we have detected a regression, we send a notification on the dedicated Slack channel. 
+The notification includes the performance difference calculated in %, the benchmark UUID, and the 
+different commit SHAs used for the comparison.
+
+Notification is always sent upon regression, however, cron_pr benchmarks will always issue a 
+new notification, the notification will be formatted based on whether we have a regression or not.
+

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -45,7 +45,6 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	e.Infra.AddToViper(v)
 	e.configDB.AddToViper(v)
 	e.statsRemoteDBConfig.AddToViper(v)
-	e.slackConfig.AddToViper(v)
 	return nil
 }
 
@@ -68,5 +67,4 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	e.Infra.AddToCommand(cmd)
 	e.statsRemoteDBConfig.AddToCommand(cmd)
 	e.configDB.AddToCommand(cmd)
-	e.slackConfig.AddToCommand(cmd)
 }

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -208,8 +208,7 @@ func (s Server) cronPRLabels() {
 		for configType, configFile := range configs {
 			ref := prInfo.SHA
 			previousGitRef := prInfo.Base
-			// TODO : Get non zero PR number and use it in execution
-			pullNb := 0
+			pullNb := prInfo.Number
 			if configType == "micro" {
 				compareInfos = append(compareInfos, newCompareInfo("Comparing pull request number - "+strconv.Itoa(pullNb)+" - micro", configFile, ref, source, pullNb, previousGitRef, source, s.cronNbRetry, configType, "", true))
 			} else {
@@ -392,7 +391,6 @@ func newCompareInfo(name, configFile, ref, source string, pullNB int, compareRef
 		},
 		execComp: &execInfo{
 			ref:    compareRef,
-			pullNB: pullNB,
 			source: compareSource,
 		},
 		retry:               retry,

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -49,7 +49,7 @@ type execInfo struct {
 }
 
 const (
-	maxConcurJob = 5
+	maxConcurJob = 1
 )
 
 var (

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -94,21 +94,10 @@ func (s *Server) cronBranchHandler() {
 	var execInfos []execInfo
 	for configType, configFile := range configs {
 		if configType == "micro" {
-			execInfos = append(execInfos, execInfo{
-				config: configFile,
-				ref:    ref,
-				retry:  s.cronNbRetry,
-				source: "cron",
-			})
+			execInfos = append(execInfos, newExecInfo(configFile, ref, s.cronNbRetry, "cron", "", configType))
 		} else {
 			for _, version := range macrobench.PlannerVersions {
-				execInfos = append(execInfos, execInfo{
-					config:         configFile,
-					ref:            ref,
-					retry:          s.cronNbRetry,
-					source:         "cron",
-					plannerVersion: string(version),
-				})
+				execInfos = append(execInfos, newExecInfo(configFile, ref, s.cronNbRetry, "cron", string(version), configType))
 			}
 		}
 	}
@@ -123,21 +112,10 @@ func (s *Server) cronBranchHandler() {
 		ref = release.CommitHash
 		for configType, configFile := range configs {
 			if configType == "micro" {
-				execInfos = append(execInfos, execInfo{
-					config: configFile,
-					ref:    ref,
-					retry:  s.cronNbRetry,
-					source: "cron_" + release.Name,
-				})
+				execInfos = append(execInfos, newExecInfo(configFile, ref, s.cronNbRetry, "cron_"+release.Name, "", configType))
 			} else {
 				for _, version := range macrobench.PlannerVersions {
-					execInfos = append(execInfos, execInfo{
-						config:         configFile,
-						ref:            ref,
-						retry:          s.cronNbRetry,
-						source:         "cron_" + release.Name,
-						plannerVersion: string(version),
-					})
+					execInfos = append(execInfos, newExecInfo(configFile, ref, s.cronNbRetry, "cron_"+release.Name, string(version), configType))
 				}
 			}
 		}
@@ -164,21 +142,10 @@ func (s Server) cronPRLabels() {
 	for _, prInfo := range prInfos {
 		for configType, configFile := range configs {
 			if configType == "micro" {
-				execInfos = append(execInfos, execInfo{
-					config: configFile,
-					ref:    prInfo.SHA,
-					retry:  s.cronNbRetry,
-					source: source,
-				})
+				execInfos = append(execInfos, newExecInfo(configFile, prInfo.SHA, s.cronNbRetry, source, "", configType))
 			} else {
 				for _, version := range macrobench.PlannerVersions {
-					execInfos = append(execInfos, execInfo{
-						config:         configFile,
-						ref:            prInfo.SHA,
-						retry:          s.cronNbRetry,
-						source:         source,
-						plannerVersion: string(version),
-					})
+					execInfos = append(execInfos, newExecInfo(configFile, prInfo.SHA, s.cronNbRetry, source, string(version), configType))
 				}
 			}
 		}
@@ -204,21 +171,10 @@ func (s *Server) cronTags() {
 	for _, release := range releases {
 		for configType, configFile := range configs {
 			if configType == "micro" {
-				execInfos = append(execInfos, execInfo{
-					config: configFile,
-					ref:    release.CommitHash,
-					retry:  s.cronNbRetry,
-					source: "cron_tags_" + release.Name,
-				})
+				execInfos = append(execInfos, newExecInfo(configFile, release.CommitHash, s.cronNbRetry, "cron_tags_"+release.Name, "", configType))
 			} else {
 				for _, version := range macrobench.PlannerVersions {
-					execInfos = append(execInfos, execInfo{
-						config:         configFile,
-						ref:            release.CommitHash,
-						retry:          s.cronNbRetry,
-						source:         "cron_tags_" + release.Name,
-						plannerVersion: string(version),
-					})
+					execInfos = append(execInfos, newExecInfo(configFile, release.CommitHash, s.cronNbRetry, "cron_tags_"+release.Name, string(version), configType))
 				}
 			}
 		}
@@ -328,4 +284,15 @@ func (s *Server) cronExecution(eI execInfo) {
 		return
 	}
 	slog.Info("Finished execution: ", e.UUID.String())
+}
+
+func newExecInfo(config, ref string, retry int, source, plannerVersion, execType string) execInfo {
+	return execInfo{
+		config:         config,
+		ref:            ref,
+		retry:          retry,
+		source:         source,
+		plannerVersion: plannerVersion,
+		execType:       execType,
+	}
 }

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -247,14 +247,10 @@ func (s *Server) cronTags() {
 	s.cronPrepare(compareInfos)
 }
 
-func (s *Server) cronPrepare(execInfos []execInfo) {
-	for _, info := range execInfos {
-		exists, err := s.checkIfExists(info)
-		if err != nil || exists {
-			continue
-		}
+func (s *Server) cronPrepare(compareInfos []*CompareInfo) {
+	for _, info := range compareInfos {
 		execQueue <- info
-		slog.Infof("New Execution (config: %s, ref: %s, source: %s, planner: %s) added to the queue (length: %d)", info.config, info.ref, info.source, info.plannerVersion, len(execQueue))
+		slog.Infof("New Comparison Execution - Name: %s (config: %s, refMain: %s, sourceMain: %s, planner: %s) added to the queue (length: %d)", info.Name, info.Config, info.execMain.ref, info.execMain.source, info.PlannerVersion, len(execQueue))
 	}
 }
 

--- a/go/server/notification.go
+++ b/go/server/notification.go
@@ -1,0 +1,103 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/vitessio/arewefastyet/go/slack"
+
+	"github.com/vitessio/arewefastyet/go/tools/git"
+	"github.com/vitessio/arewefastyet/go/tools/macrobench"
+	"github.com/vitessio/arewefastyet/go/tools/microbench"
+)
+
+func (s *Server) sendNotificationForRegression(compInfo *CompareInfo) (err error) {
+	// regression header, appender to header in the event of a regression
+	regressionHeader := `*Observed a regression.*
+`
+
+	// header of the message, before the regression explanation
+	header := ``
+	if compInfo.execMain.pullNB > 0 {
+		header += fmt.Sprintf(`Benchmarked PR #<https://github.com/vitessio/vitess/pull/%d>.`, compInfo.execMain.pullNB)
+	} else {
+		header += `Comparing: recent commit <https://github.com/vitessio/vitess/commit/` + compInfo.execMain.ref + `|` + git.ShortenSHA(compInfo.execMain.ref) + `> with old commit <https://github.com/vitessio/vitess/commit/` + compInfo.execComp.ref + `|` + git.ShortenSHA(compInfo.execComp.ref) + `>.`
+	}
+	header += `Comparison can be seen at : ` + getComparisonLink(compInfo.execMain.ref, compInfo.execComp.ref) + `
+
+`
+
+	if compInfo.typeOf == "micro" {
+		microBenchmarks, err := microbench.Compare(s.dbClient, compInfo.execMain.ref, compInfo.execComp.ref)
+		if err != nil {
+			return err
+		}
+		regression := microBenchmarks.Regression()
+		err = s.sendMessageIfRegression(compInfo.ignoreNonRegression, regression, header, regressionHeader)
+		if err != nil {
+			return err
+		}
+	} else if compInfo.typeOf == "oltp" || compInfo.typeOf == "tpcc" {
+		macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, s.executionMetricsDBClient, compInfo.execMain.ref, compInfo.execComp.ref, macrobench.PlannerVersion(compInfo.plannerVersion))
+		if err != nil {
+			return err
+		}
+
+		macroResults := macrosMatrices[macrobench.Type(compInfo.typeOf)].(macrobench.ComparisonArray)
+		if len(macroResults) == 0 {
+			return fmt.Errorf("no macrobenchmark result")
+		}
+
+		regression := macroResults[0].Regression()
+		err = s.sendMessageIfRegression(compInfo.ignoreNonRegression, regression, header, regressionHeader)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getComparisonLink(leftSHA, rightSHA string) string {
+	return "https://benchmark.vitess.io/compare?r=" + leftSHA + "&c=" + rightSHA
+}
+
+func (s *Server) sendMessageIfRegression(ignoreNonRegression bool, regression, header, regressionHeader string) error {
+	if regression != "" || ignoreNonRegression {
+		hd := header
+		if regression != "" {
+			hd = regressionHeader + header
+		}
+		err := s.sendSlackMessage(regression, hd)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) sendSlackMessage(regression, header string) error {
+	content := header + regression
+	msg := slack.TextMessage{Content: content}
+	err := msg.Send(s.slackConfig)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/server/notification.go
+++ b/go/server/notification.go
@@ -34,7 +34,7 @@ func (s *Server) sendNotificationForRegression(compInfo *CompareInfo) (err error
 `
 
 	// header of the message, before the regression explanation
-	header := ``
+	header := compInfo.name + "\n\n"
 	if compInfo.execMain.pullNB > 0 {
 		header += fmt.Sprintf(`Benchmarked PR #<https://github.com/vitessio/vitess/pull/%d>.`, compInfo.execMain.pullNB)
 	} else {

--- a/go/server/notification_test.go
+++ b/go/server/notification_test.go
@@ -16,7 +16,7 @@
  * /
  */
 
-package exec
+package server
 
 import (
 	"testing"

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -205,6 +205,22 @@ func GetLastReleaseAndCommitHash(repoDir string) (*Release, error) {
 	return res[0], nil
 }
 
+// GetLastPatchReleaseAndCommitHash gets the last release number given the major and minor release number along with the commit hash given the directory of the clone of vitess
+func GetLastPatchReleaseAndCommitHash(repoDir string, releaseNumber []int) (*Release, error) {
+	major := releaseNumber[0]
+	minor := releaseNumber[1]
+	res, err := GetAllVitessReleaseCommitHash(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, release := range res {
+		if release.Number[0] == major && release.Number[1] == minor {
+			return release, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find the latest patch release for %d.%d", major, minor)
+}
+
 // compareReleaseNumbers compares the two release numbers provided as input
 // the result is as follows -
 // 0, if release1 == release2


### PR DESCRIPTION
## Description

This PR refactors the cron jobs to allow running multiple regression checks. The changes made also guarantee that when a regression message is sent, both the sources have finished execution.

## Linked Issues
Fixes #231 