### PR TITLE
Changing InfluxDB default settings for max-series-per-database 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+arewefastyetcli

--- a/infra/monitoring/playbook.yaml
+++ b/infra/monitoring/playbook.yaml
@@ -26,7 +26,6 @@
 - hosts: storage
   roles:
     - role: influxdb
-      when: influxdb is defined
 
 - hosts: metrics
   roles:

--- a/infra/monitoring/roles/influxdb/tasks/main.yaml
+++ b/infra/monitoring/roles/influxdb/tasks/main.yaml
@@ -14,22 +14,32 @@
   apt_key:
     url: https://repos.influxdata.com/influxdb.key
     state: present
+  when: create_influxdb is defined
 
 - name: Add InfluxDB repository
   apt_repository:
     repo: 'deb https://repos.influxdata.com/ubuntu xenial stable'
     state: present
+  when: create_influxdb is defined
 
 - name: Install InfluxDB packages
   apt:
     name: influxdb
     state: present
+  when: create_influxdb is defined
 
 - name: Modify InfluxDB hostname
   replace:
     dest: /etc/influxdb/influxdb.conf
     regexp: '^# hostname = "localhost"$'
     replace: 'hostname = \"{{ ansible_hostname }}\"'
+    backup: yes
+
+- name: Modify InfluxDB inmem
+  replace:
+    dest: /etc/influxdb/influxdb.conf
+    regexp: '# max-series-per-database = 1000000'
+    replace: 'max-series-per-database = 0'
     backup: yes
 
 - name: Start Service
@@ -40,15 +50,19 @@
 
 - name: Create Admin User
   command: /usr/bin/influx -execute "CREATE USER admin WITH PASSWORD '{{ influxdb_admin_password }}' WITH ALL PRIVILEGES;"
+  when: create_influxdb is defined
 
 - name: Create Prometheus User
   command: /usr/bin/influx -execute "CREATE USER prometheus WITH PASSWORD '{{ influxdb_prometheus_password }}';"
+  when: create_influxdb is defined
 
 - name: Create Prometheus Database
   command: /usr/bin/influx -execute "CREATE DATABASE prometheus;"
+  when: create_influxdb is defined
 
 - name: Grant Prometheus User
   command: /usr/bin/influx -execute "GRANT ALL ON prometheus TO prometheus;"
+  when: create_influxdb is defined
 
 - name: Enable Auth
   replace:


### PR DESCRIPTION
## Description

Changing the `max-series-per-database` configuration to `0` (unlimited). The default value (1000000) got reached pretty fast and was causing an outage, the default retention policy will handle old results.

The error we got is written below and documented [here](https://docs.influxdata.com/influxdb/v1.8/troubleshooting/errors/#error-max-series-per-database-exceeded--).

```
error: max series per database exceeded: < >
```