### PR TITLE
Benchmarks and E2E test for CompareMacroBenchmarks

### DIFF
--- a/go/storage/influxdb/config.go
+++ b/go/storage/influxdb/config.go
@@ -76,6 +76,14 @@ func (cfg Config) IsValid() bool {
 	return cfg.Host != ""
 }
 
+func (cfg *Config) AddToViper(v *viper.Viper) {
+	_ = v.UnmarshalKey(flagInfluxHostname, &cfg.Host)
+	_ = v.UnmarshalKey(flagInfluxPort, &cfg.Port)
+	_ = v.UnmarshalKey(flagInfluxUsername, &cfg.User)
+	_ = v.UnmarshalKey(flagInfluxPassword, &cfg.Password)
+	_ = v.UnmarshalKey(flagInfluxDatabase, &cfg.Database)
+}
+
 // AddToCommand adds Config to the given cobra.Command.
 func (cfg *Config) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cfg.Host, flagInfluxHostname, "", "Hostname of InfluxDB.")

--- a/go/tools/macrobench/endtoend/compare_test.go
+++ b/go/tools/macrobench/endtoend/compare_test.go
@@ -1,0 +1,97 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package endtoend
+
+import (
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/viper"
+	"github.com/vitessio/arewefastyet/go/storage/influxdb"
+	"github.com/vitessio/arewefastyet/go/storage/mysql"
+	"github.com/vitessio/arewefastyet/go/tools/macrobench"
+	"log"
+	"os"
+	"testing"
+)
+
+var (
+	v = viper.New()
+
+	dbConfig = mysql.ConfigDB{}
+	dbClient = new(mysql.Client)
+
+	execMetricsConfig = influxdb.Config{}
+	execMetricsClient = new(influxdb.Client)
+)
+
+func TestMain(m *testing.M) {
+	configFile := os.Getenv("CONFIG_FILE_PATH_ENDTOEND")
+	if configFile == "" {
+		configFile = "../../../../config/config.yaml"
+	}
+	var err error
+
+	v.SetConfigFile(configFile)
+	if err = v.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
+
+	dbConfig.AddToViper(v)
+	dbClient, err = dbConfig.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	execMetricsConfig.AddToViper(v)
+	execMetricsClient, err = execMetricsConfig.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestCompareMacroBenchmark(t *testing.T) {
+	c := qt.New(t)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, execMetricsClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner)
+	if err != nil {
+		c.Fatal(err)
+	}
+	c.Assert(macrosMatrices, qt.HasLen, len(macrobench.Types))
+}
+
+func BenchmarkCompareMacroBenchmark(b *testing.B) {
+	c := qt.New(b)
+
+	run := func(b *testing.B, planner macrobench.PlannerVersion, reference, compare string) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, execMetricsClient, reference, compare, planner)
+			if err != nil {
+				c.Fatal(err)
+			}
+			c.Assert(macrosMatrices, qt.HasLen, len(macrobench.Types))
+		}
+	}
+
+	b.Run("Gen4 planner", func(b *testing.B) {
+		run(b, macrobench.Gen4FallbackPlanner, "48dccf56282dc79903c0ab0b1d0177617f927403", "f7304cd1893accfefee0525910098a8e0e68deec")
+	})
+	b.Run("V3 planner", func(b *testing.B) {
+		run(b, macrobench.V3Planner, "48dccf56282dc79903c0ab0b1d0177617f927403", "f7304cd1893accfefee0525910098a8e0e68deec")
+	})
+}


### PR DESCRIPTION
## Description

This pull request adds an E2E test and two benchmarks for the CompareMacroBenchmarks function. This function was the source of suspicions regarding an extended loading time for the `/macrobench` and `/compare` web page. In fact, those endpoints take a few seconds to answer. @GuptaManan100 and I initially thought the time was lost in the CompareMacroBenchmarks method, the added microbenchmarks prove that this fact is true.

```
goos: darwin
goarch: amd64
pkg: github.com/vitessio/arewefastyet/go/tools/macrobench/endtoend
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkCompareMacroBenchmark
BenchmarkCompareMacroBenchmark/Gen4_planner
BenchmarkCompareMacroBenchmark/Gen4_planner-16         	       1	3476018355 ns/op	 3402888 B/op	   11923 allocs/op
BenchmarkCompareMacroBenchmark/V3_planner
BenchmarkCompareMacroBenchmark/V3_planner-16           	       1	3427345517 ns/op	 4156808 B/op	   13962 allocs/op
```