### PR TITLE
Execute With Timeout and enhanced clean up

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -196,7 +196,10 @@ func (e *Exec) Prepare() error {
 }
 
 // ExecuteWithTimeout will call execution's Execute method with the given timeout.
-func (e Exec) ExecuteWithTimeout(timeout time.Duration) error {
+func (e Exec) ExecuteWithTimeout(timeout time.Duration) (err error) {
+	defer func() {
+		e.handleStepEnd(err)
+	}()
 	errs := make(chan error)
 
 	go func() {
@@ -204,10 +207,11 @@ func (e Exec) ExecuteWithTimeout(timeout time.Duration) error {
 	}()
 
 	select {
-	case err := <-errs:
-		return err
+	case err = <-errs:
+		return
 	case <-time.After(timeout):
-		return errors.New(ErrorExecutionTimeout)
+		err = errors.New(ErrorExecutionTimeout)
+		return
 	}
 }
 

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
@@ -56,7 +57,8 @@ const (
 	stderrFile = "exec-stderr.log"
 	stdoutFile = "exec-stdout.log"
 
-	ErrorNotPrepared = "exec is not prepared"
+	ErrorNotPrepared      = "exec is not prepared"
+	ErrorExecutionTimeout = "execution timeout"
 )
 
 type Exec struct {
@@ -191,6 +193,23 @@ func (e *Exec) Prepare() error {
 
 	e.prepared = true
 	return nil
+}
+
+// ExecuteWithTimeout will call execution's Execute method with the given timeout.
+// Note that a timeout too small will result in
+func (e Exec) ExecuteWithTimeout(timeout time.Duration) error {
+	errs := make(chan error)
+
+	go func() {
+		errs <- e.Execute()
+	}()
+
+	select {
+	case err := <-errs:
+		return err
+	case <-time.After(timeout):
+		return errors.New(ErrorExecutionTimeout)
+	}
 }
 
 // Execute will provision infra, configure Ansible files, and run the given Ansible config.

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -196,7 +196,6 @@ func (e *Exec) Prepare() error {
 }
 
 // ExecuteWithTimeout will call execution's Execute method with the given timeout.
-// Note that a timeout too small will result in
 func (e Exec) ExecuteWithTimeout(timeout time.Duration) error {
 	errs := make(chan error)
 

--- a/go/infra/equinix/equinix.go
+++ b/go/infra/equinix/equinix.go
@@ -87,7 +87,7 @@ func (e *Equinix) CleanUp() error {
 	for _, varValue := range e.TerraformVarArray() {
 		destroyOpts = append(destroyOpts, varValue)
 	}
-
+	destroyOpts = append(destroyOpts, tfexec.LockTimeout("120s"))
 	err := e.tf.Destroy(context.Background(), destroyOpts...)
 	if err != nil {
 		return err
@@ -105,6 +105,7 @@ func (e Equinix) Create(wantOutputs ...string) (output map[string]string, err er
 	for _, varValue := range varArray {
 		planOpts = append(planOpts, varValue)
 	}
+
 	changed, err := e.tf.Plan(context.Background(), planOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", infra.ErrorProvision, err)
@@ -114,6 +115,7 @@ func (e Equinix) Create(wantOutputs ...string) (output map[string]string, err er
 		for _, varValue := range varArray {
 			applyOpts = append(applyOpts, varValue)
 		}
+
 		err = e.tf.Apply(context.Background(), applyOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", infra.ErrorProvision, err)

--- a/go/infra/equinix/equinix.go
+++ b/go/infra/equinix/equinix.go
@@ -87,7 +87,11 @@ func (e *Equinix) CleanUp() error {
 	for _, varValue := range e.TerraformVarArray() {
 		destroyOpts = append(destroyOpts, varValue)
 	}
-	destroyOpts = append(destroyOpts, tfexec.LockTimeout("120s"))
+	// tfTimeout allows us to wait for the state's lock to be unlocked
+	// before proceeding to the destroy. 120s = 120 seconds.
+	tfTimeout := tfexec.LockTimeout("120s")
+	destroyOpts = append(destroyOpts, tfTimeout)
+
 	err := e.tf.Destroy(context.Background(), destroyOpts...)
 	if err != nil {
 		return err

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -382,7 +382,7 @@ func (s *Server) executeSingle(config, source, ref, typeOf, plannerVersion strin
 		return err
 	}
 
-	err = e.Execute()
+	err = e.ExecuteWithTimeout(time.Hour * 2)
 	if err != nil {
 		slog.Errorf("Execution step: %v", err)
 		return err

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -49,7 +49,7 @@ type execInfo struct {
 }
 
 const (
-	maxConcurJob = 1
+	maxConcurJob = 5
 )
 
 var (


### PR DESCRIPTION
## Description

This pull request enhances the clean-up and execution workflow for cron jobs. A new method is added to exec: `ExecuteWithTimeout(timeout time.Duration)`, this method wraps the original `Execute` method with a timeout that will stop the execution if `timeout` is reached. The clean-up step is enhanced by adding the [flag](https://www.terraform.io/docs/cli/commands/init.html#lock-timeout-lt-duration-gt-) `-lock-timeout=<duration>` to Terraform's destroy command. This flag allows us to wait for terraform state's lock to be unlocked before attempting to destroy the resource, this tweak is useful in the event where we have to destroy our Equinix Metal instance even though its provision is not complete.