### PR TITLE
Fix Cron Jobs

### DIFF
--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -42,6 +42,6 @@
 
 - name: Run macrobenchmarks
   shell: |
-    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ planner_version }}
+    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ planner_version | default("V3") }}
   register: arewefastyetcli
   changed_when: False

--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -25,7 +25,9 @@ EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
             -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }},waitSig
         {%- endfor %}
     {% endif %}
-    -planner_version {{ planner_version | default("V3") }}
+    {% if planner_version is defined %}
+        -planner_version {{ planner_version }}
+    {% endif %}
     {{gateway.extra_flags|default("")}} \
     {{extra_vtgate_flags|default("")}} \
 "

--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -24,29 +24,30 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
 ### Options
 
 ```
-      --db-database string                  Database to use.
-      --db-host string                      Hostname of the database
-      --db-password string                  Password to authenticate the database.
-      --db-user string                      User used to connect to the database
-  -h, --help                                help for web
-      --influx-database string              Name of the database to use in InfluxDB.
-      --influx-hostname string              Hostname of InfluxDB.
-      --influx-password string              Password used to connect to InfluxDB.
-      --influx-port string                  Port on which to InfluxDB listens. (default "8086")
-      --influx-username string              Username used to connect to InfluxDB.
-      --slack-channel string                Slack channel on which to post messages
-      --slack-token string                  Token used to authenticate Slack
-      --web-cron-nb-retry int               Number of retries allowed for each cron job.
-      --web-cron-schedule string            Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON. (default "@midnight")
-      --web-macrobench-oltp-config string   Path to the configuration file used to execute OLTP macrobenchmark.
-      --web-macrobench-tpcc-config string   Path to the configuration file used to execute TPCC macrobenchmark.
-      --web-microbench-config string        Path to the configuration file used to execute microbenchmark.
-      --web-mode string                     Specify the mode on which the server will run
-      --web-port string                     Port used for the HTTP server (default "8080")
-      --web-pr-label-trigger string         GitHub Pull Request label that will trigger the execution of new execution. (default "Benchmark me")
-      --web-static-path string              Path to the static directory
-      --web-template-path string            Path to the template directory
-      --web-vitess-path string              Absolute path where the vitess directory is located or where it should be cloned (default "/")
+      --db-database string                       Database to use.
+      --db-host string                           Hostname of the database
+      --db-password string                       Password to authenticate the database.
+      --db-user string                           User used to connect to the database
+  -h, --help                                     help for web
+      --influx-database string                   Name of the database to use in InfluxDB.
+      --influx-hostname string                   Hostname of InfluxDB.
+      --influx-password string                   Password used to connect to InfluxDB.
+      --influx-port string                       Port on which to InfluxDB listens. (default "8086")
+      --influx-username string                   Username used to connect to InfluxDB.
+      --slack-channel string                     Slack channel on which to post messages
+      --slack-token string                       Token used to authenticate Slack
+      --web-cron-nb-retry int                    Number of retries allowed for each cron job.
+      --web-cron-schedule string                 Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON. (default "@midnight")
+      --web-macrobench-oltp-config string        Path to the configuration file used to execute OLTP macrobenchmark.
+      --web-macrobench-tpcc-config string        Path to the configuration file used to execute TPCC macrobenchmark.
+      --web-microbench-config string             Path to the configuration file used to execute microbenchmark.
+      --web-mode string                          Specify the mode on which the server will run
+      --web-port string                          Port used for the HTTP server (default "8080")
+      --web-pr-label-trigger string              GitHub Pull Request label that will trigger the execution of new execution. (default "Benchmark me")
+      --web-pr-label-trigger-planner-v3 string   GitHub Pull Request label that will trigger the execution of new execution using the V3 planner. (default "Benchmark me (V3)")
+      --web-static-path string                   Path to the static directory
+      --web-template-path string                 Path to the template directory
+      --web-vitess-path string                   Absolute path where the vitess directory is located or where it should be cloned (default "/")
 ```
 
 ### Options inherited from parent commands

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -404,8 +404,11 @@ func GetLatestCronJobForMacrobenchmarks(client *mysql.Client) (gitSha string, er
 	return "", nil
 }
 
-func Exists(clientDB *mysql.Client, gitRef, source, typeOf, status string) (bool, error) {
+func Exists(clientDB *mysql.Client, gitRef, source, typeOf, status string, wantOld bool) (bool, error) {
 	query := "SELECT uuid FROM execution WHERE status = ? AND git_ref = ? AND type = ? AND source = ?"
+	if wantOld {
+		query += " AND started_at < CURDATE()"
+	}
 	result, err := clientDB.Select(query, status, gitRef, typeOf, source)
 	if err != nil {
 		return false, err
@@ -413,8 +416,11 @@ func Exists(clientDB *mysql.Client, gitRef, source, typeOf, status string) (bool
 	return result.Next(), nil
 }
 
-func ExistsMacrobenchmark(clientDB *mysql.Client, gitRef, source, typeOf, status, planner string) (bool, error) {
+func ExistsMacrobenchmark(clientDB *mysql.Client, gitRef, source, typeOf, status, planner string, wantOld bool) (bool, error) {
 	query := "SELECT uuid FROM execution e, macrobenchmark m WHERE e.status = ? AND e.git_ref = ? AND e.type = ? AND e.source = ? AND m.vtgate_planner_version = ? AND e.uuid = m.exec_uuid"
+	if wantOld {
+		query += " AND e.started_at < CURDATE()"
+	}
 	result, err := clientDB.Select(query, status, gitRef, typeOf, source, planner)
 	if err != nil {
 		return false, err

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -21,6 +21,7 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"github.com/vitessio/arewefastyet/go/tools/macrobench"
 	"io"
 	"os"
 	"path"
@@ -248,7 +249,11 @@ func (e *Exec) Execute() (err error) {
 	e.AnsibleConfig.ExtraVars[keyVitessVersion] = e.GitRef
 	e.AnsibleConfig.ExtraVars[keyExecSource] = e.Source
 	e.AnsibleConfig.ExtraVars[keyExecutionType] = e.typeOf
-	e.AnsibleConfig.ExtraVars[keyVtgatePlanner] = e.VtgatePlannerVersion
+
+	// not adding the -planner_version flag to ansible if we did not specify it or if using the default value
+	if e.VtgatePlannerVersion == string(macrobench.Gen4FallbackPlanner) {
+		e.AnsibleConfig.ExtraVars[keyVtgatePlanner] = e.VtgatePlannerVersion
+	}
 
 	// Infra will run the given config.
 	err = e.Infra.Run(&e.AnsibleConfig)

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -60,6 +60,14 @@ type execInfo struct {
 	source string
 }
 
+type executionStatus int
+
+const (
+	executionFailed executionStatus = iota
+	executionSucceeded
+	executionExists
+)
+
 const (
 	// maxConcurJob is the maximum number of concurrent jobs that we can execute
 	maxConcurJob = 5
@@ -281,16 +289,37 @@ func (s *Server) cronPrepare(compareInfos []*CompareInfo) {
 	}
 }
 
-func (s *Server) checkIfExists(ref, typeOf, plannerVersion, source string) (bool, error) {
+// checkIfExists is used to check if the results for a given configuration exists or not
+// wantOld defines wether we only want a day old results or not.
+// wantOld = true -> check existence for a day older results
+// wantOld = false -> check existence for any time
+func (s *Server) checkIfExists(ref, typeOf, plannerVersion, source string, wantOld bool) (bool, error) {
 	if typeOf == "micro" {
-		exist, err := exec.Exists(s.dbClient, ref, source, typeOf, exec.StatusFinished)
+		exist, err := exec.Exists(s.dbClient, ref, source, typeOf, exec.StatusFinished, wantOld)
 		if err != nil {
 			slog.Error(err)
 			return false, err
 		}
 		return exist, nil
 	}
-	exist, err := exec.ExistsMacrobenchmark(s.dbClient, ref, source, typeOf, exec.StatusFinished, plannerVersion)
+	exist, err := exec.ExistsMacrobenchmark(s.dbClient, ref, source, typeOf, exec.StatusFinished, plannerVersion, wantOld)
+	if err != nil {
+		slog.Error(err)
+		return false, err
+	}
+	return exist, nil
+}
+
+func (s *Server) checkIfStarted(ref, typeOf, plannerVersion, source string) (bool, error) {
+	if typeOf == "micro" {
+		exist, err := exec.Exists(s.dbClient, ref, source, typeOf, exec.StatusStarted, false)
+		if err != nil {
+			slog.Error(err)
+			return false, err
+		}
+		return exist, nil
+	}
+	exist, err := exec.ExistsMacrobenchmark(s.dbClient, ref, source, typeOf, exec.StatusStarted, plannerVersion, false)
 	if err != nil {
 		slog.Error(err)
 		return false, err
@@ -358,9 +387,68 @@ func (s *Server) cronExecution(compInfo *CompareInfo) {
 	}
 }
 
+// checkAndExecuteSingle checks whether there already exists a run or if one is in progress.
+// It runs the execution if there are no results.
+// It returns the executionStatus and an error. Returned values are
+// executionExists -> there already exist results from yesterdays cron jobs ; err will be nil
+// executionSucceeded -> results have been found today during cron jobs ; err will be nil
+// executionFailed -> an error occurred while reading results or execution ; requires not nil err
+func (s *Server) checkAndExecuteSingle(config, source, ref, typeOf, plannerVersion string) (executionStatus, error) {
+	// First check if an old execution exists or not
+	exists, err := s.checkIfExists(ref, typeOf, plannerVersion, source, true)
+	if err != nil {
+		return executionFailed, err
+	}
+	if exists {
+		return executionExists, nil
+	}
+
+	// Now check if an execution is in progress or not
+	isStarted, err := s.checkIfStarted(ref, typeOf, plannerVersion, source)
+	if err != nil {
+		return executionFailed, err
+	}
+	if isStarted {
+		// Wait for the execution to finish, with a timeout
+		timeOut := time.After(2 * time.Hour)
+
+		for {
+			select {
+			case <-timeOut:
+				// return error due to timeout
+				return executionFailed, fmt.Errorf("timed out waiting for existing execution to finish for source: %s, ref: %s, typeOf: %s, plannerVersion: %s", source, ref, typeOf, plannerVersion)
+			case <-time.After(1 * time.Minute):
+				// check again after every minute if execution finished or not, if it did then exit the for loop
+				isStarted, err = s.checkIfStarted(ref, typeOf, plannerVersion, source)
+				if err != nil {
+					return executionFailed, err
+				}
+				if !isStarted {
+					break
+				}
+			}
+		}
+	}
+
+	// check if there are results already. These would only be from this days cron jobs since we already checked for older results earlier
+	exists, err = s.checkIfExists(ref, typeOf, plannerVersion, source, false)
+	if err != nil {
+		return executionFailed, err
+	}
+	if exists {
+		return executionSucceeded, nil
+	}
+
+	// try executing given the configuration.
+	err = s.executeSingle(config, source, ref, typeOf, plannerVersion)
+	if err != nil {
+		return executionFailed, err
+	}
+	return executionSucceeded, nil
+}
+
 func (s *Server) executeSingle(config, source, ref, typeOf, plannerVersion string) (err error) {
 	var e *exec.Exec
-	var exists bool
 	defer func() {
 		if e != nil {
 			errCleanUp := e.CleanUp()
@@ -376,11 +464,6 @@ func (s *Server) executeSingle(config, source, ref, typeOf, plannerVersion strin
 			slog.Info("Finished execution: ", e.UUID.String())
 		}
 	}()
-
-	exists, err = s.checkIfExists(ref, typeOf, plannerVersion, source)
-	if exists || err != nil {
-		return err
-	}
 
 	e, err = exec.NewExecWithConfig(config)
 	if err != nil {

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -472,14 +472,14 @@ func (s *Server) checkAndExecuteSingle(config, source, ref, typeOf, plannerVersi
 	}
 
 	// try executing given the configuration.
-	err = s.executeSingle(config, source, ref, typeOf, plannerVersion)
+	err = s.executeSingle(config, source, ref, plannerVersion)
 	if err != nil {
 		return executionFailed, err
 	}
 	return executionSucceeded, nil
 }
 
-func (s *Server) executeSingle(config, source, ref, typeOf, plannerVersion string) (err error) {
+func (s *Server) executeSingle(config, source, ref, plannerVersion string) (err error) {
 	var e *exec.Exec
 	defer func() {
 		if e != nil {

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -35,17 +35,18 @@ import (
 const (
 	ErrorIncorrectConfiguration = "incorrect configuration"
 
-	flagPort                     = "web-port"
-	flagTemplatePath             = "web-template-path"
-	flagStaticPath               = "web-static-path"
-	flagVitessPath               = "web-vitess-path"
-	flagMode                     = "web-mode"
-	flagMicroBenchConfigFile     = "web-microbench-config"
-	flagMacroBenchConfigFileOLTP = "web-macrobench-oltp-config"
-	flagMacroBenchConfigFileTPCC = "web-macrobench-tpcc-config"
-	flagCronSchedule             = "web-cron-schedule"
-	flagPullRequestLabelTrigger  = "web-pr-label-trigger"
-	flagCronNbRetry              = "web-cron-nb-retry"
+	flagPort                                 = "web-port"
+	flagTemplatePath                         = "web-template-path"
+	flagStaticPath                           = "web-static-path"
+	flagVitessPath                           = "web-vitess-path"
+	flagMode                                 = "web-mode"
+	flagMicroBenchConfigFile                 = "web-microbench-config"
+	flagMacroBenchConfigFileOLTP             = "web-macrobench-oltp-config"
+	flagMacroBenchConfigFileTPCC             = "web-macrobench-tpcc-config"
+	flagCronSchedule                         = "web-cron-schedule"
+	flagPullRequestLabelTrigger              = "web-pr-label-trigger"
+	flagPullRequestLabelTriggerWithPlannerV3 = "web-pr-label-trigger-planner-v3"
+	flagCronNbRetry                          = "web-cron-nb-retry"
 )
 
 type Server struct {
@@ -70,7 +71,8 @@ type Server struct {
 	macrobenchConfigPathOLTP string
 	macrobenchConfigPathTPCC string
 
-	prLabelTrigger string
+	prLabelTrigger   string
+	prLabelTriggerV3 string
 
 	// Mode used to run the server.
 	Mode
@@ -90,6 +92,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.cronSchedule, flagCronSchedule, "@midnight", "Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON.")
 	cmd.Flags().IntVar(&s.cronNbRetry, flagCronNbRetry, 0, "Number of retries allowed for each cron job.")
 	cmd.Flags().StringVar(&s.prLabelTrigger, flagPullRequestLabelTrigger, "Benchmark me", "GitHub Pull Request label that will trigger the execution of new execution.")
+	cmd.Flags().StringVar(&s.prLabelTriggerV3, flagPullRequestLabelTriggerWithPlannerV3, "Benchmark me (V3)", "GitHub Pull Request label that will trigger the execution of new execution using the V3 planner.")
 	_ = cmd.MarkFlagRequired(flagMicroBenchConfigFile)
 	_ = cmd.MarkFlagRequired(flagMacroBenchConfigFileOLTP)
 	_ = cmd.MarkFlagRequired(flagMacroBenchConfigFileTPCC)
@@ -105,6 +108,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagCronSchedule, cmd.Flags().Lookup(flagCronSchedule))
 	_ = viper.BindPFlag(flagCronNbRetry, cmd.Flags().Lookup(flagCronNbRetry))
 	_ = viper.BindPFlag(flagPullRequestLabelTrigger, cmd.Flags().Lookup(flagPullRequestLabelTrigger))
+	_ = viper.BindPFlag(flagPullRequestLabelTriggerWithPlannerV3, cmd.Flags().Lookup(flagPullRequestLabelTriggerWithPlannerV3))
 
 	s.slackConfig.AddToCommand(cmd)
 	if s.dbCfg == nil {

--- a/go/tools/git/github.go
+++ b/go/tools/git/github.go
@@ -63,7 +63,7 @@ func labelsToURL(labels []string) string {
 }
 
 func getPullRequestsForLabels(labels, repo string) ([]string, error) {
-	query := fmt.Sprintf("https://api.github.com/search/issues?q=repo:%s+is:pr+is:open", repo)
+	query := fmt.Sprintf("https://api.github.com/search/issues?q=repo:%s+is:pr", repo)
 	if labels != "" {
 		query += "+" + labels
 	}

--- a/go/tools/git/github.go
+++ b/go/tools/git/github.go
@@ -63,7 +63,7 @@ func labelsToURL(labels []string) string {
 }
 
 func getPullRequestsForLabels(labels, repo string) ([]string, error) {
-	query := fmt.Sprintf("https://api.github.com/search/issues?q=repo:%s+is:pr", repo)
+	query := fmt.Sprintf("https://api.github.com/search/issues?q=repo:%s+is:pr+is:open", repo)
 	if labels != "" {
 		query += "+" + labels
 	}


### PR DESCRIPTION
## Description

This pull request resolves various bugs and a feature request, all of them are detailed in #241.

- VTGate's `-planner_version` flag is used only when the git ref used is recent enough and includes the flag, meaning that git ref below V10.0.0 will not be benchmarked using the Gen4 planner.

- Only send slack notifications for comparisons that are new and do not repeat the same message that we have already sent earlier.

- Currently, the benchmarks are running for the same configuration multiple times. This issue arises because we are only testing `ifExists` for `finished` benchmarks while spawning new ones and not the ones which are in execution.

## Related issue(s)

Resolves #241.
