### PR TITLE
Migration of vitess default branch from master to main

### DIFF
--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -110,8 +110,8 @@ func (s *Server) cronBranchHandler() {
 		slog.Warn(err.Error())
 		return
 	}
-	// master branch
-	compareInfos, err := s.compareMasterBranch()
+	// main branch
+	compareInfos, err := s.compareMainBranch()
 	if err != nil {
 		slog.Warn(err.Error())
 		return
@@ -127,7 +127,7 @@ func (s *Server) cronBranchHandler() {
 	s.cronPrepare(compareInfos)
 }
 
-func (s *Server) compareMasterBranch() ([]*CompareInfo, error) {
+func (s *Server) compareMainBranch() ([]*CompareInfo, error) {
 	configs := s.getConfigFiles()
 
 	var compareInfos []*CompareInfo
@@ -141,25 +141,25 @@ func (s *Server) compareMasterBranch() ([]*CompareInfo, error) {
 		slog.Warn(err.Error())
 		return nil, nil
 	}
-	// We compare master with the previous hash of master and with the latest release
+	// We compare main with the previous hash of main and with the latest release
 	for configType, configFile := range configs {
 		if configType == "micro" {
 			_, previousGitRef, err := exec.GetPreviousFromSourceMicrobenchmark(s.dbClient, "cron", ref)
 			if err != nil {
 				slog.Warn(err.Error())
 			} else if previousGitRef != "" {
-				compareInfos = append(compareInfos, newCompareInfo("Comparing master with previous master - micro", configFile, ref, "cron", 0, previousGitRef, "", s.cronNbRetry, configType, "", false))
+				compareInfos = append(compareInfos, newCompareInfo("Comparing main with previous main - micro", configFile, ref, "cron", 0, previousGitRef, "", s.cronNbRetry, configType, "", false))
 			}
-			compareInfos = append(compareInfos, newCompareInfo("Comparing master with latest release - "+lastRelease.Name+" - micro", configFile, ref, "cron", 0, lastRelease.CommitHash, "cron_tags_"+lastRelease.Name, s.cronNbRetry, configType, "", false))
+			compareInfos = append(compareInfos, newCompareInfo("Comparing main with latest release - "+lastRelease.Name+" - micro", configFile, ref, "cron", 0, lastRelease.CommitHash, "cron_tags_"+lastRelease.Name, s.cronNbRetry, configType, "", false))
 		} else {
 			for _, version := range macrobench.PlannerVersions {
 				_, previousGitRef, err := exec.GetPreviousFromSourceMacrobenchmark(s.dbClient, "cron", configType, string(version), ref)
 				if err != nil {
 					slog.Warn(err.Error())
 				} else if previousGitRef != "" {
-					compareInfos = append(compareInfos, newCompareInfo("Comparing master with previous master - "+configType+" - "+string(version), configFile, ref, "cron", 0, previousGitRef, "", s.cronNbRetry, configType, string(version), false))
+					compareInfos = append(compareInfos, newCompareInfo("Comparing main with previous main - "+configType+" - "+string(version), configFile, ref, "cron", 0, previousGitRef, "", s.cronNbRetry, configType, string(version), false))
 				}
-				compareInfos = append(compareInfos, newCompareInfo("Comparing master with latest release - "+lastRelease.Name+" - "+configType+" - "+string(version), configFile, ref, "cron", 0, lastRelease.CommitHash, "cron_tags_"+lastRelease.Name, s.cronNbRetry, configType, string(version), false))
+				compareInfos = append(compareInfos, newCompareInfo("Comparing main with latest release - "+lastRelease.Name+" - "+configType+" - "+string(version), configFile, ref, "cron", 0, lastRelease.CommitHash, "cron_tags_"+lastRelease.Name, s.cronNbRetry, configType, string(version), false))
 			}
 		}
 	}

--- a/go/server/git.go
+++ b/go/server/git.go
@@ -53,6 +53,6 @@ func (s *Server) pullLocalVitess() error {
 	if err != nil {
 		return err
 	}
-	_, err = git.ExecCmd(s.getVitessPath(), "git", "reset", "--hard", "origin/master")
+	_, err = git.ExecCmd(s.getVitessPath(), "git", "reset", "--hard", "origin/main")
 	return err
 }

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -166,7 +166,7 @@ func (s *Server) requestBenchmarkHandler(c *gin.Context) {
 func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	var err error
 
-	// get all the latest releases and the last cron job for master
+	// get all the latest releases and the last cron job for main
 	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
 	if err != nil {
 		handleRenderErrors(c, err)
@@ -177,11 +177,11 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 		handleRenderErrors(c, err)
 		return
 	}
-	masterRelease := []*git.Release{{
-		Name:       "master",
+	mainRelease := []*git.Release{{
+		Name:       "main",
 		CommitHash: lastrunCronSHA,
 	}}
-	allReleases = append(masterRelease, allReleases...)
+	allReleases = append(mainRelease, allReleases...)
 	// get all the latest release branches as well
 	allReleaseBranches, err := git.GetLatestVitessReleaseBranchCommitHash(s.getVitessPath())
 	if err != nil {
@@ -195,7 +195,7 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	leftSHA := ""
 	if leftTag == "" {
 		// get the latest cron job if leftTag is not specified
-		leftTag = "master"
+		leftTag = "main"
 		leftSHA = lastrunCronSHA
 	} else {
 		leftSHA, err = findSHA(allReleases, leftTag)
@@ -282,7 +282,7 @@ func (s *Server) microbenchmarkSingleResultsHandler(c *gin.Context) {
 func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 	var err error
 	planner := getPlannerVersion(c)
-	// get all the latest releases and the last cron job for master
+	// get all the latest releases and the last cron job for main
 	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
 	if err != nil {
 		handleRenderErrors(c, err)
@@ -293,11 +293,11 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 		handleRenderErrors(c, err)
 		return
 	}
-	masterRelease := []*git.Release{{
-		Name:       "master",
+	mainRelease := []*git.Release{{
+		Name:       "main",
 		CommitHash: lastrunCronSHA,
 	}}
-	allReleases = append(masterRelease, allReleases...)
+	allReleases = append(mainRelease, allReleases...)
 	// get all the latest release branches as well
 	allReleaseBranches, err := git.GetLatestVitessReleaseBranchCommitHash(s.getVitessPath())
 	if err != nil {
@@ -311,7 +311,7 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 	leftSHA := ""
 	if leftTag == "" {
 		// get the latest cron job if leftTag is not specified
-		leftTag = "master"
+		leftTag = "main"
 		leftSHA = lastrunCronSHA
 	} else {
 		leftSHA, err = findSHA(allReleases, leftTag)
@@ -361,7 +361,7 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 func (s *Server) v3VsGen4Handler(c *gin.Context) {
 	var err error
 
-	// get all the latest releases and the last cron job for master
+	// get all the latest releases and the last cron job for main
 	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
 	if err != nil {
 		handleRenderErrors(c, err)
@@ -372,11 +372,11 @@ func (s *Server) v3VsGen4Handler(c *gin.Context) {
 		handleRenderErrors(c, err)
 		return
 	}
-	masterRelease := []*git.Release{{
-		Name:       "master",
+	mainRelease := []*git.Release{{
+		Name:       "main",
 		CommitHash: lastrunCronSHA,
 	}}
-	allReleases = append(masterRelease, allReleases...)
+	allReleases = append(mainRelease, allReleases...)
 	// get all the latest release branches as well
 	allReleaseBranches, err := git.GetLatestVitessReleaseBranchCommitHash(s.getVitessPath())
 	if err != nil {
@@ -390,7 +390,7 @@ func (s *Server) v3VsGen4Handler(c *gin.Context) {
 	sha := ""
 	if tag == "" {
 		// get the latest cron job if tag is not specified
-		tag = "master"
+		tag = "main"
 		sha = lastrunCronSHA
 	} else {
 		sha, err = findSHA(allReleases, tag)


### PR DESCRIPTION
## Description

Applying the changes brought by vitessio/vitess#6378, renaming vitess's default branch from `master` to `main`.