### PR TITLE
Changed single microbenchmark table header and year in footer

### DIFF
--- a/go/server/templates/footer.tmpl
+++ b/go/server/templates/footer.tmpl
@@ -17,7 +17,7 @@ limitations under the License.
 <!-- Footer -->
 <footer class="py-5 bg-dark">
   <div class="container">
-    <p class="m-0 text-center text-white">Copyright &copy; Vitess 2020</p>
+    <p class="m-0 text-center text-white">Copyright &copy 2021</p>
   </div>
   <!-- /.container -->
 </footer>

--- a/go/server/templates/microbench_single.tmpl
+++ b/go/server/templates/microbench_single.tmpl
@@ -42,8 +42,8 @@ limitations under the License.
                 <th scope="col" class="text-center">Number of Iterations</th>
                 <th scope="col" class="text-center">Time/op</th>
                 <th scope="col" class="text-center">Bytes/op</th>
-                <th scope="col" class="text-center">MB/s</th>
-                <th scope="col" class="text-center">Allocs/op</th>
+                <th scope="col" class="text-center">Megabytes/s</th>
+                <th scope="col" class="text-center">Allocations/op</th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Description

Changing `Allocs` to `Allocations` and `MB` to `Megabytes` on the single-microbench page, and changed `2020` to `2021`.