### PR TITLE
Compute and store execution metrics after each execution

### DIFF
--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -20,6 +20,11 @@ arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-
 
 ```
   -h, --help                                       help for run
+      --influx-database string                     Name of the database to use in InfluxDB.
+      --influx-hostname string                     Hostname of InfluxDB.
+      --influx-password string                     Password used to connect to InfluxDB.
+      --influx-port string                         Port on which to InfluxDB listens. (default "8086")
+      --influx-username string                     Username used to connect to InfluxDB.
       --macrobench-exec-uuid string                UUID of the parent execution, an empty string will set to NULL.
       --macrobench-git-ref string                  Git SHA referring to the macro benchmark.
       --macrobench-skip-steps strings              Slice of sysbench steps to skip.

--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -25,11 +25,6 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
 
 ```
   -h, --help                                       help for web
-      --influx-database string                     Name of the database to use in InfluxDB.
-      --influx-hostname string                     Hostname of InfluxDB.
-      --influx-password string                     Password used to connect to InfluxDB.
-      --influx-port string                         Port on which to InfluxDB listens. (default "8086")
-      --influx-username string                     Username used to connect to InfluxDB.
       --planetscale-db-branch string               PlanetscaleDB branch to use. (default "main")
       --planetscale-db-database string             PlanetscaleDB database name.
       --planetscale-db-org string                  Name of the PlanetscaleDB organization.

--- a/go/cmd/macrobench/run.go
+++ b/go/cmd/macrobench/run.go
@@ -20,13 +20,15 @@ package macrobench
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"github.com/vitessio/arewefastyet/go/tools/macrobench"
 )
 
 func run() *cobra.Command {
 	mabcfg := macrobench.Config{
-		DatabaseConfig: &psdb.Config{},
+		DatabaseConfig:        &psdb.Config{},
+		MetricsDatabaseConfig: &influxdb.Config{},
 	}
 
 	cmd := &cobra.Command{

--- a/go/exec/metrics/endtoend/main_test.go
+++ b/go/exec/metrics/endtoend/main_test.go
@@ -1,0 +1,126 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package endtoend
+
+import (
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/viper"
+	"github.com/vitessio/arewefastyet/go/exec/metrics"
+	"github.com/vitessio/arewefastyet/go/storage/psdb"
+	"log"
+	"math"
+	"os"
+	"testing"
+)
+
+var (
+	v = viper.New()
+
+	skip = ""
+
+	dbConfig = psdb.Config{}
+	dbClient = new(psdb.Client)
+)
+
+func TestMain(m *testing.M) {
+	configFile := os.Getenv("CONFIG_FILE_PATH_ENDTOEND")
+	if configFile == "" {
+		configFile = "../../../../config/config.yaml"
+	}
+
+	// Checking if the configuration file exists or not.
+	// Skipping the E2E tests if none were found.
+	//
+	// CI does not include configuration file / secrets, thus
+	// these tests will be skipped.
+	_, err := os.OpenFile(configFile, os.O_RDWR, 0755)
+	if err != nil {
+		if os.IsNotExist(err) {
+			skip = "no configuration file found."
+			os.Exit(m.Run())
+		}
+		log.Fatal(err)
+	}
+
+	v.SetConfigFile(configFile)
+	if err = v.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
+
+	dbConfig.AddToViper(v)
+	dbClient, err = dbConfig.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestInsertExecutionMetrics(t *testing.T) {
+	c := qt.New(t)
+	if skip != "" {
+		c.Skip(skip)
+	}
+
+	_, err := dbClient.Insert("DELETE FROM metrics WHERE exec_uuid='test_TestInsertExecutionMetrics'")
+	if err != nil {
+		return
+	}
+
+	cpu := map[string]float64{
+		"vtgate":   111987.93,
+		"vttablet": 789.12,
+	}
+	mem := map[string]float64{
+		"vtgate":   789.15,
+		"vttablet": 456789.3,
+	}
+
+	execMetrics := metrics.ExecutionMetrics{
+		TotalComponentsCPUTime: cpu["vtgate"] + cpu["vttablet"],
+		ComponentsCPUTime:      cpu,
+
+		TotalComponentsMemStatsAllocBytes: mem["vtgate"] + mem["vttablet"],
+		ComponentsMemStatsAllocBytes:      mem,
+	}
+
+	err = metrics.InsertExecutionMetrics(dbClient, "test_TestInsertExecutionMetrics", execMetrics)
+	c.Assert(err, qt.IsNil)
+
+	selectQ := "select name,value from metrics where exec_uuid='test_TestInsertExecutionMetrics'"
+	rows, err := dbClient.Select(selectQ)
+	c.Assert(err, qt.IsNil)
+
+	res := []float64{
+		cpu["vtgate"] + cpu["vttablet"],
+		mem["vtgate"] + mem["vttablet"],
+		cpu["vtgate"],
+		cpu["vttablet"],
+		mem["vtgate"],
+		mem["vttablet"],
+	}
+	for i := 0; rows.Next(); i++ {
+		var name string
+		var value float64
+		err = rows.Scan(&name, &value)
+		c.Assert(err, qt.IsNil)
+		diff := math.Abs(value - res[i])
+		c.Assert(diff < 1, qt.IsTrue)
+	}
+}

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/storage"
 	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	awftmath "github.com/vitessio/arewefastyet/go/tools/math"
+	"math"
 	"strings"
 )
 
@@ -103,19 +104,19 @@ func newExecMetrics() ExecutionMetrics {
 func InsertExecutionMetrics(client storage.SQLClient, execUUID string, execMetrics ExecutionMetrics) error {
 	query := "INSERT INTO metrics(exec_uuid, `name`, `value`) VALUES (?, ?, ?), (?, ?, ?)"
 	args := []interface{}{
-		execUUID, "TotalComponentsCPUTime", execMetrics.TotalComponentsCPUTime,
-		execUUID, "TotalComponentsMemStatsAllocBytes", execMetrics.TotalComponentsMemStatsAllocBytes,
+		execUUID, "TotalComponentsCPUTime", math.Round(execMetrics.TotalComponentsCPUTime*100)/100,
+		execUUID, "TotalComponentsMemStatsAllocBytes", math.Round(execMetrics.TotalComponentsMemStatsAllocBytes*100)/100,
 	}
 	for k, v := range execMetrics.ComponentsCPUTime {
 		query += ", (?,?,?)"
 		args = append(args, []interface{}{
-			execUUID, "ComponentsCPUTime." + k, v,
+			execUUID, "ComponentsCPUTime." + k, math.Round(v*100)/100,
 		}...)
 	}
 	for k, v := range execMetrics.ComponentsMemStatsAllocBytes {
 		query += ", (?,?,?)"
 		args = append(args, []interface{}{
-			execUUID, "ComponentsMemStatsAllocBytes." + k, v,
+			execUUID, "ComponentsMemStatsAllocBytes." + k, math.Round(v*100)/100,
 		}...)
 	}
 	_, err := client.Insert(query, args...)

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -104,19 +104,19 @@ func newExecMetrics() ExecutionMetrics {
 func InsertExecutionMetrics(client storage.SQLClient, execUUID string, execMetrics ExecutionMetrics) error {
 	query := "INSERT INTO metrics(exec_uuid, `name`, `value`) VALUES (?, ?, ?), (?, ?, ?)"
 	args := []interface{}{
-		execUUID, "TotalComponentsCPUTime", math.Round(execMetrics.TotalComponentsCPUTime*100)/100,
-		execUUID, "TotalComponentsMemStatsAllocBytes", math.Round(execMetrics.TotalComponentsMemStatsAllocBytes*100)/100,
+		execUUID, "TotalComponentsCPUTime", math.Round(float64(int(execMetrics.TotalComponentsCPUTime*100)))/100,
+		execUUID, "TotalComponentsMemStatsAllocBytes", math.Round(float64(int(execMetrics.TotalComponentsMemStatsAllocBytes*100)))/100,
 	}
 	for k, v := range execMetrics.ComponentsCPUTime {
 		query += ", (?,?,?)"
 		args = append(args, []interface{}{
-			execUUID, "ComponentsCPUTime." + k, math.Round(v*100)/100,
+			execUUID, "ComponentsCPUTime." + k, math.Round(float64(int(v*100)))/100,
 		}...)
 	}
 	for k, v := range execMetrics.ComponentsMemStatsAllocBytes {
 		query += ", (?,?,?)"
 		args = append(args, []interface{}{
-			execUUID, "ComponentsMemStatsAllocBytes." + k, math.Round(v*100)/100,
+			execUUID, "ComponentsMemStatsAllocBytes." + k, math.Round(float64(int(v*100)))/100,
 		}...)
 	}
 	_, err := client.Insert(query, args...)

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -20,6 +20,7 @@ package metrics
 
 import (
 	"fmt"
+	"github.com/vitessio/arewefastyet/go/storage"
 	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	awftmath "github.com/vitessio/arewefastyet/go/tools/math"
 )
@@ -92,6 +93,11 @@ func GetExecutionMetrics(client influxdb.Client, execUUID string) (ExecutionMetr
 		execMetrics.TotalComponentsMemStatsAllocBytes += execMetrics.ComponentsMemStatsAllocBytes[component]
 	}
 	return execMetrics, nil
+}
+
+func InsertExecutionMetrics(client storage.SQLClient, execUUID string, execMetrics ExecutionMetrics) error {
+
+	return nil
 }
 
 // getSumFloatValueForQuery return the sum of a float value based on the given query, for

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -103,7 +103,7 @@ func (s *Server) compareHandler(c *gin.Context) {
 	}
 
 	// Compare Macrobenchmarks for the two given SHAs.
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, s.executionMetricsDBClient, reference, compare, planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, reference, compare, planner)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -135,7 +135,7 @@ func (s *Server) searchHandler(c *gin.Context) {
 		return
 	}
 
-	macros, err := macrobench.GetDetailsArraysFromAllTypes(search, planner, s.dbClient, s.executionMetricsDBClient)
+	macros, err := macrobench.GetDetailsArraysFromAllTypes(search, planner, s.dbClient)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -342,7 +342,7 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 	}
 
 	// Compare Macrobenchmarks for the two given SHAs.
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, s.executionMetricsDBClient, rightSHA, leftSHA, planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, rightSHA, leftSHA, planner)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -401,7 +401,7 @@ func (s *Server) v3VsGen4Handler(c *gin.Context) {
 	}
 
 	// Compare Macrobenchmarks for the two planners for the given SHA.
-	macrosMatrices, err := macrobench.ComparePlanners(s.dbClient, s.executionMetricsDBClient, sha)
+	macrosMatrices, err := macrobench.ComparePlanners(s.dbClient, sha)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return

--- a/go/server/notification.go
+++ b/go/server/notification.go
@@ -55,7 +55,7 @@ func (s *Server) sendNotificationForRegression(compInfo *CompareInfo) (err error
 			return err
 		}
 	} else if compInfo.typeOf == "oltp" || compInfo.typeOf == "tpcc" {
-		macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, s.executionMetricsDBClient, compInfo.execMain.ref, compInfo.execComp.ref, macrobench.PlannerVersion(compInfo.plannerVersion))
+		macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, compInfo.execMain.ref, compInfo.execComp.ref, macrobench.PlannerVersion(compInfo.plannerVersion))
 		if err != nil {
 			return err
 		}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 )
 
 const (
@@ -58,9 +57,6 @@ type Server struct {
 
 	dbCfg    *psdb.Config
 	dbClient *psdb.Client
-
-	executionMetricsDBConfig *influxdb.Config
-	executionMetricsDBClient *influxdb.Client
 
 	// Configuration used to send message to Slack.
 	slackConfig slack.Config
@@ -115,11 +111,6 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 		s.dbCfg = &psdb.Config{}
 	}
 	s.dbCfg.AddToCommand(cmd)
-
-	if s.executionMetricsDBConfig == nil {
-		s.executionMetricsDBConfig = &influxdb.Config{}
-	}
-	s.executionMetricsDBConfig.AddToCommand(cmd)
 }
 
 func (s Server) isReady() bool {

--- a/go/server/storage.go
+++ b/go/server/storage.go
@@ -23,10 +23,5 @@ func (s *Server) createStorages() (err error) {
 	if err != nil {
 		return
 	}
-
-	s.executionMetricsDBClient, err = s.executionMetricsDBConfig.NewClient()
-	if err != nil {
-		return
-	}
 	return
 }

--- a/go/tools/macrobench/compare.go
+++ b/go/tools/macrobench/compare.go
@@ -21,19 +21,17 @@ package macrobench
 import (
 	"fmt"
 	"github.com/vitessio/arewefastyet/go/storage"
-
-	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 )
 
 // CompareMacroBenchmarks takes in 3 arguments, the database, and 2 SHAs. It reads from the database, the macrobenchmark
 // results for the 2 SHAs and compares them. The result is a map with the key being the macrobenchmark name.
-func CompareMacroBenchmarks(client storage.SQLClient, metricsClient *influxdb.Client, reference, compare string, planner PlannerVersion) (map[Type]interface{}, error) {
+func CompareMacroBenchmarks(client storage.SQLClient, reference, compare string, planner PlannerVersion) (map[Type]interface{}, error) {
 	// Get macro benchmarks from all the different types
 	SHAs := []string{reference, compare}
 	var err error
 	macros := map[string]map[Type]DetailsArray{}
 	for _, sha := range SHAs {
-		macros[sha], err = GetDetailsArraysFromAllTypes(sha, planner, client, metricsClient)
+		macros[sha], err = GetDetailsArraysFromAllTypes(sha, planner, client)
 		if err != nil {
 			return nil, err
 		}
@@ -50,12 +48,12 @@ func CompareMacroBenchmarks(client storage.SQLClient, metricsClient *influxdb.Cl
 
 // ComparePlanners takes in 2 arguments, the database, and a SHA. It reads from the database, the macrobenchmark
 // results for the 2 planners corresponding to the sha and compares them. The result is a map with the key being the macrobenchmark name.
-func ComparePlanners(client storage.SQLClient, metricsClient *influxdb.Client, sha string) (map[Type]interface{}, error) {
+func ComparePlanners(client storage.SQLClient, sha string) (map[Type]interface{}, error) {
 	// Get macro benchmarks from all the different types
 	var err error
 	macros := map[string]map[Type]DetailsArray{}
 	for _, planner := range PlannerVersions {
-		macros[string(planner)], err = GetDetailsArraysFromAllTypes(sha, planner, client, metricsClient)
+		macros[string(planner)], err = GetDetailsArraysFromAllTypes(sha, planner, client)
 		if err != nil {
 			return nil, err
 		}

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -21,6 +21,7 @@ package macrobench
 import (
 	"errors"
 	"github.com/vitessio/arewefastyet/go/storage"
+	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"strings"
 
@@ -38,10 +39,15 @@ type Config struct {
 	// WorkloadPath defines the path to the lua file used by sysbench.
 	WorkloadPath string
 
-	// DatabaseConfig points to the required configuration to create
+	// DatabaseConfig points to the configuration used to create
 	// a *psdb.Client. If no configuration, results and reports will
-	// not be saved to MySQL, though the program won't fail.
+	// not be saved to a database, though the program won't fail.
 	DatabaseConfig *psdb.Config
+
+	// MetricsDatabaseConfig points to the required configuration to create
+	// a *influxdb.Client. If no configuration is provided results will not be
+	// saved to the database and the program will not fail.
+	MetricsDatabaseConfig *influxdb.Config
 
 	// M contains all metadata used to parameter sysbench execution.
 	// This key value map stores the value of each CLI parameters.
@@ -93,6 +99,7 @@ const (
 // the given *cobra.Command.
 func (mabcfg *Config) AddToCommand(cmd *cobra.Command) {
 	mabcfg.DatabaseConfig.AddToCommand(cmd)
+	mabcfg.MetricsDatabaseConfig.AddToCommand(cmd)
 
 	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "Path to the workload used by sysbench.")
 	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "Path to the sysbench binary.")

--- a/go/tools/macrobench/endtoend/compare_test.go
+++ b/go/tools/macrobench/endtoend/compare_test.go
@@ -85,7 +85,7 @@ func TestCompareMacroBenchmark(t *testing.T) {
 	if skip != "" {
 		c.Skip(skip)
 	}
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, execMetricsClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func BenchmarkCompareMacroBenchmark(b *testing.B) {
 		}
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, execMetricsClient, reference, compare, planner)
+			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, reference, compare, planner)
 			if err != nil {
 				c.Fatal(err)
 			}

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -146,7 +146,7 @@ func handleResults(mabcfg Config, resStr []byte, sqlClient *psdb.Client, metrics
 	if err != nil {
 		return err
 	}
-	err = handleMetricsResults(metricsClient, mabcfg.execUUID)
+	err = handleMetricsResults(metricsClient, sqlClient, mabcfg.execUUID)
 	if err != nil {
 		return err
 	}
@@ -173,8 +173,12 @@ func createMetricsDatabaseClient(dbConfig *influxdb.Config) (client *influxdb.Cl
 	return
 }
 
-func handleMetricsResults(client *influxdb.Client, execUUID string) error {
-	_, err := metrics.GetExecutionMetrics(*client, execUUID)
+func handleMetricsResults(client *influxdb.Client, sqlClient *psdb.Client, execUUID string) error {
+	execMetrics, err := metrics.GetExecutionMetrics(*client, execUUID)
+	if err != nil {
+		return err
+	}
+	err = metrics.InsertExecutionMetrics(sqlClient, execUUID, execMetrics)
 	if err != nil {
 		return err
 	}

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/vitessio/arewefastyet/go/exec/metrics"
-	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	"github.com/vitessio/arewefastyet/go/storage/mysql"
 	awftmath "github.com/vitessio/arewefastyet/go/tools/math"
 )
@@ -254,7 +253,7 @@ func (qps QPS) OtherStr() string {
 }
 
 // GetDetailsArraysFromAllTypes returns a slice of Details based on the given git ref and Types.
-func GetDetailsArraysFromAllTypes(sha string, planner PlannerVersion, dbclient storage.SQLClient, metricsClient *influxdb.Client) (map[Type]DetailsArray, error) {
+func GetDetailsArraysFromAllTypes(sha string, planner PlannerVersion, dbclient storage.SQLClient) (map[Type]DetailsArray, error) {
 	macros := map[Type]DetailsArray{}
 	for _, mtype := range Types {
 		macro, err := GetResultsForGitRefAndPlanner(mtype, sha, planner, dbclient)
@@ -264,7 +263,7 @@ func GetDetailsArraysFromAllTypes(sha string, planner PlannerVersion, dbclient s
 
 		// Get the execution metrics of each macrobenchmark details
 		for i, details := range macro {
-			macro[i].Metrics, err = metrics.GetExecutionMetrics(*metricsClient, details.ExecUUID)
+			macro[i].Metrics, err = metrics.GetExecutionMetricsSQL(dbclient, details.ExecUUID)
 			if err != nil {
 				return nil, err
 			}

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -74,7 +74,7 @@ type tableCell struct {
 // to read the results. It also takes as an argument the name of the report that will be generated
 func GenerateCompareReport(client storage.SQLClient, metricsClient *influxdb.Client, fromSHA, toSHA, reportFile string) error {
 	// Compare macrobenchmark results for the 2 SHAs
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(client, metricsClient, fromSHA, toSHA, macrobench.V3Planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(client, fromSHA, toSHA, macrobench.V3Planner)
 	if err != nil {
 		return err
 	}

--- a/sql/migration/007_metrics_table.sql
+++ b/sql/migration/007_metrics_table.sql
@@ -1,0 +1,30 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+--
+-- Table structure for table `metrics`
+--
+
+DROP TABLE IF EXISTS `metrics`;
+CREATE TABLE `metrics` (
+                           `id` INT(11) NOT NULL AUTO_INCREMENT,
+                           `exec_uuid` VARCHAR(100) DEFAULT NULL,
+                           `name` VARCHAR(250) DEFAULT NULL,
+                           `value` DECIMAL(8,2) DEFAULT NULL,
+                           PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/migration/007_metrics_table.sql
+++ b/sql/migration/007_metrics_table.sql
@@ -25,6 +25,6 @@ CREATE TABLE `metrics` (
                            `id` INT(11) NOT NULL AUTO_INCREMENT,
                            `exec_uuid` VARCHAR(100) DEFAULT NULL,
                            `name` VARCHAR(250) DEFAULT NULL,
-                           `value` DECIMAL(8,2) DEFAULT NULL,
+                           `value` FLOAT DEFAULT NULL,
                            PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/vitess-benchmark.sql
+++ b/sql/vitess-benchmark.sql
@@ -99,6 +99,19 @@ CREATE TABLE `qps` (
 ) ENGINE=InnoDB AUTO_INCREMENT=865 DEFAULT CHARSET=utf8;
 
 --
+-- Table structure for table `metrics`
+--
+
+DROP TABLE IF EXISTS `metrics`;
+CREATE TABLE `metrics` (
+                       `id` INT(11) NOT NULL AUTO_INCREMENT,
+                       `exec_uuid` VARCHAR(100) DEFAULT NULL,
+                       `name` VARCHAR(250) DEFAULT NULL,
+                       `value` DECIMAL(8,2) DEFAULT NULL,
+                       PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
 -- Table structure for table `microbenchmark`
 --
 


### PR DESCRIPTION
## Description

This pull request changes the way we store and use execution metrics. Previously read from influxdb when using them in the web server, they are now read from a SQL database; this will increase the website performance. To be read from a SQL database, they are first written there at the end of each `macrobench run` call. The macrobenchmark toolset handles storing metrics to SQL.

A new table `metrics` has been added. It represents a key/value table with the name of the metric and its value (a float). Each metric is linked to an execution ID and has a unique primary key.

## Related issues

Resolves #248.