### PR TITLE
Addition of tablet_types_to_wait flag to vtgate's configuration

### DIFF
--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -20,6 +20,7 @@ ADDITIONAL_CELLS=""
 EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
     -vtgate-config-terse-errors \
     -gate_query_cache_size {{ vtgate_query_cache_size }} \
+    -tablet_types_to_wait REPLICA \
     {% if pprof_targets is defined %}
         {% for target in pprof_targets if target == "vtgate" %}
             -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }},waitSig


### PR DESCRIPTION
## Description

This pull request adds the `tablet_types_to_wait` flag to VTGate, the internal usage of the flag was modified by vitessio/vitess#8218. Not providing tablet types to wait provokes the following error:

```
tablet_types_to_wait flag must be set
```