### PR TITLE
Upgrading Ansible from 2.9.11 to 2.9.20

### DIFF
--- a/ansible/roles/vitess_build/molecule/all/molecule.yml
+++ b/ansible/roles/vitess_build/molecule/all/molecule.yml
@@ -24,7 +24,7 @@ platforms:
       - sysbench
     image: centos:8
     privileged: True
-    command: /sbin/init
+    command: /lib/systemd/systemd
     exposed_ports:
       - 15999
     published_ports:

--- a/ansible/roles/vitess_build/tasks/mysql.yml
+++ b/ansible/roles/vitess_build/tasks/mysql.yml
@@ -69,7 +69,10 @@
 
     - name: Install the MySQL 8 repository
       yum:
-        name='{{ mysql_repo_rpm }}'
+        name: '{{ mysql_repo_rpm }}'
+        state: present
+        disable_gpg_check: true
+
     - name: Register packages to install
       set_fact:
         mysql_packages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-ansible==2.9.12
+ansible==2.9.20
 molecule[ansible, docker]
 supervisor
 ansible_runner
 jmespath
+passlib[bcrypt]


### PR DESCRIPTION
## Description

Upgrade ansible to `2.9.20`, enabling the fix of a bug related to `systemd` (https://github.com/ansible/ansible/pull/72337 and https://github.com/ansible/ansible/issues/71528). The upgrade brought up a new bug related to GPG keys, which was fixed using this https://github.com/ansible/ansible/pull/71640.

The issue with `systemd` was impacting all ongoing pull requests' status.