### PR TITLE
Enable schema tracking in vttablet and vtgate on main cron

### DIFF
--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -29,6 +29,9 @@ EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
     {% if planner_version is defined %}
         -planner_version {{ planner_version }}
     {% endif %}
+    {% if vitess_schema_tracking is defined %}
+        -schema_change_signal \
+    {% endif %}
     {{gateway.extra_flags|default("")}} \
     {{extra_vtgate_flags|default("")}} \
 "

--- a/ansible/roles/vttablet/templates/vttablet.conf.j2
+++ b/ansible/roles/vttablet/templates/vttablet.conf.j2
@@ -39,8 +39,11 @@ EXTRA_VTTABLET_FLAGS="-alsologtostderr \
     --binlog_use_v3_resharding_mode=true \
     {% if pprof_targets is defined %}
         {% for target in pprof_targets if target == "vttablet" %}
-            -pprof {{ pprof_args }},path=/tmp/pprof/vttablet-{{ tablet.id }},waitSig
+            -pprof {{ pprof_args }},path=/tmp/pprof/vttablet-{{ tablet.id }},waitSig \
         {%- endfor %}
+    {% endif %}
+    {% if vitess_schema_tracking is defined %}
+        -queryserver-config-schema-change-signal \
     {% endif %}
     {{ tablet.extra_flags | default("") }} \
     {{ extra_vttablet_flags | default("") }} \

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -108,6 +108,10 @@ type Exec struct {
 	VtgatePlannerVersion string
 }
 
+const (
+	SourceCron = "cron"
+)
+
 // SetStdout sets the standard output of Exec.
 func (e *Exec) SetStdout(stdout *os.File) {
 	e.stdout = stdout
@@ -192,6 +196,11 @@ func (e *Exec) Prepare() error {
 	if e.pullNB != 0 {
 		e.AnsibleConfig.ExtraVars["vitess_git_version_fetch_pr"] = "refs/pull/" + strconv.Itoa(e.pullNB) + "/head"
 		e.AnsibleConfig.ExtraVars["vitess_git_version_pr_nb"] = e.pullNB
+	}
+
+	// Enable schema tracking only if we execute macrobenchmark main CRONs
+	if e.Source == SourceCron && e.typeOf != "micro" {
+		e.AnsibleConfig.ExtraVars["vitess_schema_tracking"] = 1
 	}
 
 	e.prepared = true


### PR DESCRIPTION
## Description

This pull request enables vtgate and vttablet schema tracking feature if we execute a macro benchmark through the nightly cron of type `cron`. This aims to test and ensure the stability of the changes brought by https://github.com/vitessio/vitess/pull/8074. Since we do not perform any DDL during our benchmarks, schema tracking should not impact performance, this pull request will confirm it.