### PR TITLE
Fixing v3vsGen4 macro benchmark results graphs order

### DIFF
--- a/go/server/templates/v3VsGen4.tmpl
+++ b/go/server/templates/v3VsGen4.tmpl
@@ -202,7 +202,7 @@ limitations under the License.
                     datasets: [
                         {
                             label: 'V3',
-                            data: dataRef,
+                            data: dataCmp,
                             color: 'black',
                             backgroundColor: [
                                 'rgba(255, 99, 132, 0.5)',
@@ -219,7 +219,7 @@ limitations under the License.
                         },
                         {
                             label: 'Gen4',
-                            data: dataCmp,
+                            data: dataRef,
                             backgroundColor: [
                                 'rgba(54, 162, 235, 0.5)',
                                 'rgba(54, 162, 235, 0.5)',


### PR DESCRIPTION
## Description

The graphs used to render the results of v3vsGen4 macrobenchmarks had their columns inversed, and thus not matching the data they were being labeled for. This pull request fixes that.

**Before:**
![image](https://user-images.githubusercontent.com/35779988/122911378-8613eb80-d357-11eb-9f35-de4534e35986.png)


**Now:**
![image](https://user-images.githubusercontent.com/35779988/122911178-4ea53f00-d357-11eb-8990-f5c0f5bc2620.png)
