### PR TITLE
Closing rows after select

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -267,7 +267,11 @@ func (e *Exec) Execute() (err error) {
 func (e *Exec) Success() {
 	// checking if the execution has not already failed
 	rows, errSQL := e.clientDB.Select("SELECT uuid FROM execution WHERE uuid = ? AND status = ?", e.UUID.String(), StatusFailed)
-	if errSQL != nil || rows.Next() {
+	if errSQL != nil {
+		return
+	}
+	defer rows.Close()
+	if rows.Next() {
 		return
 	}
 	_, _ = e.clientDB.Insert("UPDATE execution SET finished_at = CURRENT_TIME, status = ? WHERE uuid = ?", StatusFinished, e.UUID.String())
@@ -353,6 +357,7 @@ func GetPreviousFromSourceMicrobenchmark(client storage.SQLClient, source, gitRe
 	if err != nil {
 		return
 	}
+	defer result.Close()
 	for result.Next() {
 		err = result.Scan(&execUUID, &gitRefOut)
 		if err != nil {
@@ -370,6 +375,7 @@ func GetPreviousFromSourceMacrobenchmark(client storage.SQLClient, source, typeO
 	if err != nil {
 		return
 	}
+	defer result.Close()
 	for result.Next() {
 		err = result.Scan(&execUUID, &gitRefOut)
 		if err != nil {
@@ -388,6 +394,7 @@ func GetLatestCronJobForMicrobenchmarks(client storage.SQLClient) (gitSha string
 		return "", err
 	}
 
+	defer rows.Close()
 	for rows.Next() {
 		err = rows.Scan(&gitSha)
 		return gitSha, err
@@ -404,6 +411,7 @@ func GetLatestCronJobForMacrobenchmarks(client storage.SQLClient) (gitSha string
 		return "", err
 	}
 
+	defer rows.Close()
 	for rows.Next() {
 		err = rows.Scan(&gitSha)
 		return gitSha, err
@@ -421,6 +429,7 @@ func Exists(client storage.SQLClient, gitRef, source, typeOf, status string, wan
 	if err != nil {
 		return false, err
 	}
+	defer result.Close()
 	return result.Next(), nil
 }
 
@@ -430,6 +439,7 @@ func ExistsStartedToday(client storage.SQLClient, gitRef, source, typeOf string)
 	if err != nil {
 		return false, err
 	}
+	defer result.Close()
 	return result.Next(), nil
 }
 
@@ -442,6 +452,7 @@ func ExistsMacrobenchmark(client storage.SQLClient, gitRef, source, typeOf, stat
 	if err != nil {
 		return false, err
 	}
+	defer result.Close()
 	return result.Next(), nil
 }
 
@@ -452,6 +463,7 @@ func ExistsMacrobenchmarkStartedToday(client storage.SQLClient, gitRef, source, 
 		return false, err
 	}
 	exists := result.Next()
+	result.Close()
 	if exists {
 		return true,nil
 	}
@@ -460,6 +472,7 @@ func ExistsMacrobenchmarkStartedToday(client storage.SQLClient, gitRef, source, 
 	if err != nil {
 		return false, err
 	}
+	defer result.Close()
 	for result.Next() {
 		var exec_uuid string
 		err = result.Scan(&exec_uuid)
@@ -471,7 +484,9 @@ func ExistsMacrobenchmarkStartedToday(client storage.SQLClient, gitRef, source, 
 		if err != nil {
 			return false, err
 		}
-		if !resultMacro.Next() {
+		next := resultMacro.Next()
+		resultMacro.Close()
+		if !next {
 			return true, nil
 		}
 	}

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -129,6 +129,7 @@ func GetExecutionMetricsSQL(client storage.SQLClient, execUUID string) (Executio
 	if err != nil {
 		return ExecutionMetrics{}, err
 	}
+	defer rows.Close()
 
 	result := newExecMetrics()
 	for rows.Next() {

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -296,6 +296,7 @@ func GetResultsForLastDays(macroType Type, source string, planner PlannerVersion
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 	for result.Next() {
 		var res Details
 		err = result.Scan(&res.ID, &res.GitRef, &res.Source, &res.CreatedAt, &res.ExecUUID, &res.Result.TPS, &res.Result.Latency,
@@ -328,6 +329,7 @@ func GetResultsForGitRefAndPlanner(macroType Type, ref string, planner PlannerVe
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 	for result.Next() {
 		var res Details
 		err = result.Scan(&res.ID, &res.GitRef, &res.Source, &res.CreatedAt, &res.ExecUUID, &res.Result.TPS, &res.Result.Latency,

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -197,6 +197,7 @@ func GetResultsForGitRef(ref string, client storage.SQLClient) (mrs DetailsArray
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 
 	for result.Next() {
 		var res Details
@@ -222,6 +223,7 @@ func GetLatestResultsFor(name, subBenchmarkName string, count int, client storag
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var res Details


### PR DESCRIPTION
## Description

Closing rows fetched after calling `SQLClient.Select`. This reduces the number of fd opened concurrently and solves the issue mentioned in #253.

## Related issue

Fixes #253.