### PR TITLE
Fixed improved by % for the macrobenchmark errors

### DIFF
--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -130,7 +130,7 @@ func CompareDetailsArrays(references, compares DetailsArray) (compared Compariso
 			cmp.Diff.TPS = (cmp.Reference.Result.TPS - cmp.Compare.Result.TPS) / cmp.Reference.Result.TPS * 100
 			cmp.Diff.Latency = (cmp.Compare.Result.Latency - cmp.Reference.Result.Latency) / cmp.Compare.Result.Latency * 100
 			cmp.Diff.Reconnects = (cmp.Reference.Result.Reconnects - cmp.Compare.Result.Reconnects) / cmp.Reference.Result.Reconnects * 100
-			cmp.Diff.Errors = (cmp.Reference.Result.Errors - cmp.Compare.Result.Errors) / cmp.Reference.Result.Errors * 100
+			cmp.Diff.Errors = (cmp.Compare.Result.Errors - cmp.Reference.Result.Errors) / cmp.Compare.Result.Errors * 100
 			cmp.Diff.Time = int((float64(cmp.Reference.Result.Time) - float64(cmp.Compare.Result.Time)) / float64(cmp.Reference.Result.Time) * 100)
 			cmp.Diff.Threads = (cmp.Reference.Result.Threads - cmp.Compare.Result.Threads) / cmp.Reference.Result.Threads * 100
 			awftmath.CheckForNaN(&cmp.Diff, 0)

--- a/go/tools/macrobench/results_test.go
+++ b/go/tools/macrobench/results_test.go
@@ -155,7 +155,7 @@ func TestCompareDetailsArrays(t *testing.T) {
 	resultOfOne := *newResult(qpsOfOne, 1.0, 1.0, 1.0, 1.0, 1, 1.0)
 	resultOfTwo := *newResult(qpsOfTwo, 2.0, 2.0, 2.0, 2.0, 2, 2.0)
 	qpsOfFifty := *newQPS(-100, -100, -100, -100)
-	resultOfFifty := *newResult(qpsOfFifty, -100, 50, -100, -100, -100, -100)
+	resultOfFifty := *newResult(qpsOfFifty, -100, 50, 50, -100, -100, -100)
 
 	tests := []struct {
 		name         string
@@ -197,7 +197,7 @@ func TestCompareDetailsArrays(t *testing.T) {
 			Comparison{
 				Reference:   *newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 				Compare:     *newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
-				Diff:        *newResult(*newQPS(50, 50, 50, 50), 50, -100, 50, 50, 50, 50),
+				Diff:        *newResult(*newQPS(50, 50, 50, 50), 50, -100, -100, 50, 50, 50),
 				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},
 		}},


### PR DESCRIPTION
## Description

Small fix to change the way we calculate the `Improved by %` for the `Errors` field. If the recent version has `Errors` higher than the old version then the `Improved by %` column should be negative.

**Before**
![image](https://user-images.githubusercontent.com/35779988/123801527-a9f0a780-d8ea-11eb-9a04-f6e1aea65320.png)

**After**
![image](https://user-images.githubusercontent.com/35779988/123801564-b1b04c00-d8ea-11eb-9a33-ab40539965a8.png)
