### PR TITLE
Migrated to Go 1.17 and better setup of PR numbers during CRONs

### DIFF
--- a/ansible/roles/vitess_build/defaults/main.yml
+++ b/ansible/roles/vitess_build/defaults/main.yml
@@ -11,13 +11,14 @@
 
 ---
 
-golang_gover: 1.15.8
+golang_gover: 1.17
 golang_hash_linux_amd64:
   1.13.7: 'sha256:b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3'
   1.13.11: 'sha256:a4d71ca9e02923fa96669a4b5faf78ee8331b18e7209b09dd87fe763b4838ada'
   1.14.3: 'sha256:1c39eac4ae95781b066c144c58e45d6859652247f7515f0d2cba7be7d57d2226'
   1.15.3: 'sha256:010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d'
   1.15.8: 'sha256:d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b'
+  1.17: 'sha256:6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d'
 
 vitess_git_repo: "https://github.com/vitessio/vitess.git"
 vitess_git_version: "main"

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -38,7 +38,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	_ = v.UnmarshalKey(flagSourceExec, &e.Source)
 	_ = v.UnmarshalKey(flagExecType, &e.typeOf)
 	_ = v.UnmarshalKey(flagVtgatePlannerVersion, &e.VtgatePlannerVersion)
-	_ = v.UnmarshalKey(flagExecPullNB, &e.pullNB)
+	_ = v.UnmarshalKey(flagExecPullNB, &e.PullNB)
 
 	e.AnsibleConfig.AddToViper(v)
 	e.InfraConfig.AddToViper(v)
@@ -54,7 +54,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&e.Source, flagSourceExec, "", "Name of the source that triggered the execution.")
 	cmd.Flags().StringVar(&e.typeOf, flagExecType, "", "Defines the execution type (oltp, tpcc, micro).")
 	cmd.Flags().StringVar(&e.VtgatePlannerVersion, flagVtgatePlannerVersion, "V3", "Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback.")
-	cmd.Flags().IntVar(&e.pullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
+	cmd.Flags().IntVar(&e.PullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
 
 	_ = viper.BindPFlag(flagRootExec, cmd.Flags().Lookup(flagRootExec))
 	_ = viper.BindPFlag(flagGitRefExec, cmd.Flags().Lookup(flagGitRefExec))

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -75,8 +75,8 @@ type Exec struct {
 	// Defines the type of execution (oltp, tpcc, micro, ...)
 	typeOf string
 
-	// Defines the pull request number linked to this execution.
-	pullNB int
+	// PullNB defines the pull request number linked to this execution.
+	PullNB int
 
 	// Configuration used to interact with the SQL database.
 	configDB *psdb.Config
@@ -167,7 +167,7 @@ func (e *Exec) Prepare() error {
 	}
 
 	// insert new exec in SQL
-	if _, err = e.clientDB.Insert("INSERT INTO execution(uuid, status, source, git_ref, type, pull_nb) VALUES(?, ?, ?, ?, ?, ?)", e.UUID.String(), StatusCreated, e.Source, e.GitRef, e.typeOf, e.pullNB); err != nil {
+	if _, err = e.clientDB.Insert("INSERT INTO execution(uuid, status, source, git_ref, type, pull_nb) VALUES(?, ?, ?, ?, ?, ?)", e.UUID.String(), StatusCreated, e.Source, e.GitRef, e.typeOf, e.PullNB); err != nil {
 		return err
 	}
 	e.createdInDB = true
@@ -193,9 +193,9 @@ func (e *Exec) Prepare() error {
 	}
 	e.AnsibleConfig.ExtraVars = map[string]interface{}{}
 	e.statsRemoteDBConfig.AddToAnsible(&e.AnsibleConfig)
-	if e.pullNB != 0 {
-		e.AnsibleConfig.ExtraVars["vitess_git_version_fetch_pr"] = "refs/pull/" + strconv.Itoa(e.pullNB) + "/head"
-		e.AnsibleConfig.ExtraVars["vitess_git_version_pr_nb"] = e.pullNB
+	if e.PullNB != 0 {
+		e.AnsibleConfig.ExtraVars["vitess_git_version_fetch_pr"] = "refs/pull/" + strconv.Itoa(e.PullNB) + "/head"
+		e.AnsibleConfig.ExtraVars["vitess_git_version_pr_nb"] = e.PullNB
 	}
 
 	// Enable schema tracking only if we execute macrobenchmark main CRONs


### PR DESCRIPTION
## Description

This pull request bumps the golang version used for the benchmarks to `go1.17` and improves the way we configure pull request numbers when executions are triggered by the `cron_pr` cron.