### PR TITLE
Fixed date and order rendering issue for single microbenchmarks

### DIFF
--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -239,7 +239,7 @@ func (s *Server) microbenchmarkResultsHandler(c *gin.Context) {
 	}
 	rightMbd = rightMbd.ReduceSimpleMedianByName()
 
-	matrix := microbench.MergeDetails(leftMbd, rightMbd)
+	matrix := microbench.MergeDetails(rightMbd, leftMbd)
 	c.HTML(http.StatusOK, "microbench.tmpl", gin.H{
 		"title":        "Vitess benchmark - microbenchmark",
 		"leftSHA":      leftSHA,
@@ -270,7 +270,7 @@ func (s *Server) microbenchmarkSingleResultsHandler(c *gin.Context) {
 		return
 	}
 	results = results.ReduceSimpleMedianByGitRef()
-
+	results.SortByDate()
 	c.HTML(http.StatusOK, "microbench_single.tmpl", gin.H{
 		"title":            "Vitess benchmark - microbenchmark - " + name,
 		"name":             name,

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -102,15 +102,15 @@ func NewResult(ops, NSPerOp, MBPerSec, BytesPerOp, AllocsPerOp float64) *Result 
 
 // MergeDetails merges two DetailsArray into a single
 // ComparisonArray.
-func MergeDetails(currentMbd, lastReleaseMbd DetailsArray) (compareMbs ComparisonArray) {
+func MergeDetails(currentMbd, lastMbd DetailsArray) (compareMbs ComparisonArray) {
 	for _, details := range currentMbd {
 		compareMb := Comparison{
 			BenchmarkId: details.BenchmarkId,
 			Current:     details.Result,
 		}
-		for j := 0; j < len(lastReleaseMbd); j++ {
-			if lastReleaseMbd[j].BenchmarkId == details.BenchmarkId {
-				compareMb.Last = lastReleaseMbd[j].Result
+		for j := 0; j < len(lastMbd); j++ {
+			if lastMbd[j].BenchmarkId == details.BenchmarkId {
+				compareMb.Last = lastMbd[j].Result
 				compareMb.Diff.NSPerOp = (compareMb.Current.NSPerOp - compareMb.Last.NSPerOp) / compareMb.Current.NSPerOp * -100
 				compareMb.Diff.Ops = (compareMb.Current.Ops - compareMb.Last.Ops) / compareMb.Current.Ops * 100
 				compareMb.Diff.BytesPerOp = (compareMb.Current.BytesPerOp - compareMb.Last.BytesPerOp) / compareMb.Current.BytesPerOp * -100
@@ -158,6 +158,21 @@ func (mbd DetailsArray) ReduceSimpleMedianByGitRef() (reduceMbd DetailsArray) {
 		return mbd[i].GitRef == mbd[j].GitRef
 	})
 	return reduceMbd
+}
+
+// SortByDate will sort the given DetailsArray by ascending date
+func (mbd DetailsArray) SortByDate() {
+	sort.SliceStable(mbd, func(i, j int) bool {
+		parseLeft, err := time.Parse(time.RFC3339, mbd[i].StartedAt)
+		if err != nil {
+			return false
+		}
+		parseRight, err := time.Parse(time.RFC3339, mbd[j].StartedAt)
+		if err != nil {
+			return false
+		}
+		return parseRight.After(parseLeft)
+	})
 }
 
 // mergeUsingCondition is used to merge the DetailsArray based on the compare condition provided


### PR DESCRIPTION
## Description

- Applying an `order by date` on the single microbenchmark results matrix before rendering it
- Swapping the `current` and `last` result columns on the `microbench` page