### PR TITLE
Close opened mysql FDs

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -413,6 +413,8 @@ func GetRecentExecutions(client storage.SQLClient) ([]*Exec, error) {
 			if err != nil {
 				return nil, err
 			}
+			defer macroResult.Close()
+
 			var plannerVersion string
 			if macroResult.Next() {
 				err = macroResult.Scan(&plannerVersion)
@@ -572,6 +574,8 @@ func ExistsMacrobenchmarkStartedToday(client storage.SQLClient, gitRef, source, 
 		if err != nil {
 			return false, err
 		}
+		defer resultMacro.Close()
+
 		next := resultMacro.Next()
 		resultMacro.Close()
 		if !next {


### PR DESCRIPTION
## Description

This pull request closes mysql's FDs through a `defer` statement after opening them. This will avoid reaching `too many open files` errors.