### PR TITLE
Fetch tags while fetching from origin before each cron

### DIFF
--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -240,6 +240,13 @@ func (s Server) createPullRequestElementWithBaseComparison(configFile, ref, conf
 }
 
 func (s *Server) tagsCronHandler() {
+	// update the local clone of vitess from remote
+	err := s.pullLocalVitess()
+	if err != nil {
+		slog.Error(err.Error())
+		return
+	}
+
 	configs := s.getConfigFiles()
 
 	releases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())

--- a/go/server/git.go
+++ b/go/server/git.go
@@ -49,7 +49,7 @@ func (s *Server) getVitessPath() string {
 
 // pullLocalVitess is used to execute
 func (s *Server) pullLocalVitess() error {
-	_, err := git.ExecCmd(s.getVitessPath(), "git", "fetch", "origin")
+	_, err := git.ExecCmd(s.getVitessPath(), "git", "fetch", "origin", "--tags")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This pull request ensures that tags ref are fetched before starting a new cron. Benchmarks for Vitess' `v12.0.0` were missing due to the tags not being fetched on the local clone of Vitess.