### PR TITLE
Fix concurrent pull/fetch in the Vitess repository

### DIFF
--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -26,6 +26,8 @@ import (
 
 func (s *Server) branchCronHandler() {
 	// update the local clone of vitess from remote
+	s.vitessPathMu.Lock()
+	defer s.vitessPathMu.Unlock()
 	err := s.pullLocalVitess()
 	if err != nil {
 		slog.Error(err.Error())
@@ -241,6 +243,8 @@ func (s Server) createPullRequestElementWithBaseComparison(configFile, ref, conf
 
 func (s *Server) tagsCronHandler() {
 	// update the local clone of vitess from remote
+	s.vitessPathMu.Lock()
+	defer s.vitessPathMu.Unlock()
 	err := s.pullLocalVitess()
 	if err != nil {
 		slog.Error(err.Error())

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -183,7 +183,7 @@ func (s *Server) createSimpleExecutionQueueElement(source, configFile, ref, conf
 	}
 }
 
-func (s Server) pullRequestsCronHandler() {
+func (s *Server) pullRequestsCronHandler() {
 	configs := s.getConfigFiles()
 	prLabelsInfo := []struct {
 		label   string
@@ -226,7 +226,7 @@ func (s Server) pullRequestsCronHandler() {
 	}
 }
 
-func (s Server) createPullRequestElementWithBaseComparison(configFile, ref, configType, previousGitRef string, version macrobench.PlannerVersion, pullNb int) []*executionQueueElement {
+func (s *Server) createPullRequestElementWithBaseComparison(configFile, ref, configType, previousGitRef string, version macrobench.PlannerVersion, pullNb int) []*executionQueueElement {
 	var elements []*executionQueueElement
 
 	newExecutionElement := s.createSimpleExecutionQueueElement(exec.SourcePullRequest, configFile, ref, configType, string(version), true, pullNb)

--- a/go/server/logger.go
+++ b/go/server/logger.go
@@ -37,7 +37,7 @@ func initLogger(mode Mode) (err error) {
 	return nil
 }
 
-func (s Server) initLogger() (err error) {
+func (s *Server) initLogger() (err error) {
 	return initLogger(s.Mode)
 }
 

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -121,7 +121,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	s.dbCfg.AddToCommand(cmd)
 }
 
-func (s Server) isReady() bool {
+func (s *Server) isReady() bool {
 	return s.port != "" && s.templatePath != "" && s.staticPath != "" &&
 		s.microbenchConfigPath != "" && s.macrobenchConfigPathOLTP != "" && s.macrobenchConfigPathTPCC != "" && s.localVitessPath != ""
 }

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/slack"
 	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"html/template"
+	"sync"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -51,11 +52,13 @@ const (
 )
 
 type Server struct {
-	port            string
-	templatePath    string
-	staticPath      string
+	port         string
+	templatePath string
+	staticPath   string
+	router       *gin.Engine
+
+	vitessPathMu    sync.Mutex
 	localVitessPath string
-	router          *gin.Engine
 
 	dbCfg    *psdb.Config
 	dbClient *psdb.Client

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -60,11 +60,11 @@ func TestRun(t *testing.T) {
 func TestServer_Run(t *testing.T) {
 	tests := []struct {
 		name    string
-		s       Server
+		s       *Server
 		wantErr bool
 		err     string
 	}{
-		{name: "Server not ready", s: Server{}, wantErr: true, err: ErrorIncorrectConfiguration},
+		{name: "Server not ready", s: &Server{}, wantErr: true, err: ErrorIncorrectConfiguration},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -82,18 +82,18 @@ func TestServer_Run(t *testing.T) {
 func TestServer_isReady(t *testing.T) {
 	tests := []struct {
 		name string
-		s    Server
+		s    *Server
 		want bool
 	}{
-		{name: "Server fully ready", s: Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/", microbenchConfigPath: "micro/config.yaml", macrobenchConfigPathOLTP: "oltp/config.yaml", macrobenchConfigPathTPCC: "tpcc/config.yaml"}, want: true},
-		{name: "Missing port", s: Server{templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
-		{name: "Missing template path", s: Server{port: "8888", staticPath: "./", localVitessPath: "~/"}},
-		{name: "Missing static path", s: Server{port: "9999", templatePath: "./", localVitessPath: "~/"}},
-		{name: "Missing api key", s: Server{port: "8080", templatePath: "./", staticPath: "./static", localVitessPath: "~/"}},
-		{name: "Missing local vitess path", s: Server{port: "8080", templatePath: "./", staticPath: "./static"}},
-		{name: "Missing multiple elements (1)", s: Server{port: "8080", staticPath: "", localVitessPath: "~/"}},
-		{name: "Missing multiple elements (2)", s: Server{templatePath: "", staticPath: "./", localVitessPath: "~/"}},
-		{name: "Missing execution configuration paths", s: Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Server fully ready", s: &Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/", microbenchConfigPath: "micro/config.yaml", macrobenchConfigPathOLTP: "oltp/config.yaml", macrobenchConfigPathTPCC: "tpcc/config.yaml"}, want: true},
+		{name: "Missing port", s: &Server{templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Missing template path", s: &Server{port: "8888", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Missing static path", s: &Server{port: "9999", templatePath: "./", localVitessPath: "~/"}},
+		{name: "Missing api key", s: &Server{port: "8080", templatePath: "./", staticPath: "./static", localVitessPath: "~/"}},
+		{name: "Missing local vitess path", s: &Server{port: "8080", templatePath: "./", staticPath: "./static"}},
+		{name: "Missing multiple elements (1)", s: &Server{port: "8080", staticPath: "", localVitessPath: "~/"}},
+		{name: "Missing multiple elements (2)", s: &Server{templatePath: "", staticPath: "./", localVitessPath: "~/"}},
+		{name: "Missing execution configuration paths", s: &Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request alleviates an issue that appeared in the log of our web server when two concurrent threads were updating the local clone of Vitess.

Sample of the error:
```
cannot lock ref 'refs/remotes/origin/main': is at 8245b11cb511fde9de7adb9c73fa551f05c5582e but expected f2663ec9e54c60445d77545a5387b0130ffd5762
From https://github.com/vitessio/vitess
 ! f2663ec9e5..8245b11cb5  main         -> origin/main  (unable to update local ref)
error: cannot lock ref 'refs/remotes/origin/mp-help-fix': is at fadc4e2abd4906b7913b99a58a55972ca9f00149 but expected 2dc6cc72082e697561e5c66d3fa4a6702dcd5c13
 ! 2dc6cc7208..fadc4e2abd  mp-help-fix  -> origin/mp-help-fix  (unable to update local ref)
error: cannot lock ref 'refs/remotes/origin/release-12.0': is at aee4b9c0aa8e57244b7b7df72584021495337dce but expected baa5c8dddb963261e4d01d3af15f46a9ab04c944
 ! baa5c8dddb..aee4b9c0aa  release-12.0 -> origin/release-12.0  (unable to update local ref)
```