### PR TITLE
Update the default branch to main in the `Deploy` workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:
@@ -22,7 +22,7 @@ jobs:
             cd $HOME/arewefastyet
             git reset --hard FETCH_HEAD
             git clean -fd
-            git fetch origin master
+            git fetch origin main
             git checkout FETCH_HEAD
             /usr/local/go/bin/go build ./go/main.go
             ./supervisor/update.sh


### PR DESCRIPTION
## Description

This pull request updates the default branch of arewefastyet in the Deploy workflow from `master` to `main`.