### PR TITLE
fixed the path to the golang binary in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+
       - name: executing remote ssh commands using password
         uses: appleboy/ssh-action@master
         with:
@@ -24,5 +29,5 @@ jobs:
             git clean -fd
             git fetch origin main
             git checkout FETCH_HEAD
-            /usr/local/go/bin/go build ./go/main.go
+            go build ./go/main.go
             ./supervisor/update.sh

--- a/.github/workflows/molecule-all.yml
+++ b/.github/workflows/molecule-all.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.8.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/molecule-etcd.yml
+++ b/.github/workflows/molecule-etcd.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.8.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/molecule-vitess-build.yml
+++ b/.github/workflows/molecule-vitess-build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.8.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/molecule-vtctld.yml
+++ b/.github/workflows/molecule-vtctld.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.8.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/molecule-vtgate.yml
+++ b/.github/workflows/molecule-vtgate.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.8.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/molecule-vttablet.yml
+++ b/.github/workflows/molecule-vttablet.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.8.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/ansible/roles/vitess_build/tasks/main.yml
+++ b/ansible/roles/vitess_build/tasks/main.yml
@@ -20,14 +20,26 @@
     - name: Fetch Updated Vitess
       include_tasks: install_vitess.yml
 
+    - name: Tmp directory gopath
+      become: yes
+      become_user: root
+      file:
+        state: directory
+        path: '{{ item }}'
+        mode: 0755
+      with_items:
+        - /root/tmp
+
     - name: Build Vitess Binaries
+      changed_when: false
       shell: |
+        export TMPDIR=~/tmp
         cd /go/src/vitess.io/vitess
         make build
-      changed_when: false
 
     - name: Install Vitess Binaries
       shell: |
+        export TMPDIR=~/tmp
         cd /go/src/vitess.io/vitess
         make install PREFIX=/usr/local VTROOT=/go/src/vitess.io/vitess
       changed_when: false


### PR DESCRIPTION
## Description

This pull request changes how the deploy workflow uses the `go` binary. Instead of calling `go` using the absolute path, it simply uses the `PATH`.