### PR TITLE
Don't skip systemd reload for vtgate, vttablet and vtctld

### DIFF
--- a/ansible/roles/vtctld/tasks/systemd.yml
+++ b/ansible/roles/vtctld/tasks/systemd.yml
@@ -13,7 +13,6 @@
 - name: install config
   become: yes
   become_user: root
-  register: vtctld_service_modified
   with_items:
     - s: vtctld.conf
       d: '/etc/vitess/conf/vtctld-{{ vitess_cell }}.conf'
@@ -31,6 +30,6 @@
 - name: systemctl daemon-reload
   become: yes
   become_user: root
-  when: vtctld_service_modified is changed
+  changed_when: false
   systemd:
     daemon_reload: yes

--- a/ansible/roles/vtgate/tasks/systemd.yml
+++ b/ansible/roles/vtgate/tasks/systemd.yml
@@ -13,7 +13,6 @@
 - name: install systemd units
   become: yes
   become_user: root
-  register: vtgate_service_modified
   changed_when: false
   with_items:
     - s: vtgate@.service
@@ -29,6 +28,6 @@
 - name: systemctl daemon-reload
   become: yes
   become_user: root
-  when: vtgate_service_modified is changed
+  changed_when: false
   systemd:
     daemon_reload: yes

--- a/ansible/roles/vttablet/tasks/systemd.yml
+++ b/ansible/roles/vttablet/tasks/systemd.yml
@@ -13,7 +13,6 @@
 - name: install systemd units
   become: yes
   become_user: root
-  register: vttablet_service_modified
   with_items:
     - s: vttablet@.service
       d: /etc/systemd/system/vttablet@.service
@@ -31,6 +30,6 @@
 - name: systemctl daemon-reload
   become: yes
   become_user: root
-  when: vttablet_service_modified is changed
+  changed_when: false
   systemd:
     daemon_reload: yes


### PR DESCRIPTION
## Description

In certain cases where the `vtgate` service file (`/etc/systemd/system/vtgate@.service`) was present but was not reloaded using systemd, Ansible would skip the reload, and thus any `vtgate@*` service would fail to start.

This pull request fixes that issue by not skipping the reload.