### PR TITLE
Use absolute path to set the temporary go build directory

### DIFF
--- a/ansible/roles/vitess_build/tasks/main.yml
+++ b/ansible/roles/vitess_build/tasks/main.yml
@@ -33,13 +33,13 @@
     - name: Build Vitess Binaries
       changed_when: false
       shell: |
-        export TMPDIR=~/tmp
+        export TMPDIR=/root/tmp
         cd /go/src/vitess.io/vitess
         make build
 
     - name: Install Vitess Binaries
       shell: |
-        export TMPDIR=~/tmp
+        export TMPDIR=/root/tmp
         cd /go/src/vitess.io/vitess
         make install PREFIX=/usr/local VTROOT=/go/src/vitess.io/vitess
       changed_when: false


### PR DESCRIPTION
## Description

An issue appeared when running the `vitess_build/main` task in the production environment where golang was not able to stat the temporary build directory: `creating work dir: stat ~/tmp: no such file or directory`.

To fix this issue, this Pull Request changes the path (`~/tmp`) to an absolute path: `/root/tmp`.