### PR TITLE
Remove old `arewefastyetcli` binary from the bin before updating it

### DIFF
--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -31,6 +31,7 @@
     - name: Install arewefastyet CLI
       shell: |
         cd /go/src/github.com/vitessio/arewefastyet
+        rm -f /usr/bin/arewefastyetcli
         cp arewefastyetcli /usr/bin/arewefastyetcli
       changed_when: false
 

--- a/ansible/roles/microbench/tasks/main.yml
+++ b/ansible/roles/microbench/tasks/main.yml
@@ -36,6 +36,7 @@
     - name: Install arewefastyet CLI
       shell: |
         cd /go/src/github.com/vitessio/arewefastyet
+        rm -f /usr/bin/arewefastyetcli
         cp arewefastyetcli /usr/bin/arewefastyetcli
       changed_when: false
 


### PR DESCRIPTION
## Description

When can happen if the webserver responsible for the execution queue restarts, the ongoing benchmark will not be managed anymore, which leads to an issue where the `arewefastyetcli` binary is kept running on the benchmark server. Having the binary used does not allow us to write to the same file, the following error appears:
```
cp: cannot create regular file '/usr/bin/arewefastyetcli': Text file busy
```

This pull request ensure the `arewefastyetcli` binary is removed before creating a new one.

