### PR TITLE
Change go version default value in Ansible's vitess-build role

### DIFF
--- a/ansible/roles/vitess_build/defaults/main.yml
+++ b/ansible/roles/vitess_build/defaults/main.yml
@@ -11,7 +11,7 @@
 
 ---
 
-golang_gover: '1.17'
+golang_gover: '1.18'
 golang_hash_linux_amd64:
   '1.13.7': 'sha256:b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3'
   '1.13.11': 'sha256:a4d71ca9e02923fa96669a4b5faf78ee8331b18e7209b09dd87fe763b4838ada'


### PR DESCRIPTION
This Pull Request changes the default value of the go version in `vitess-build`'s defaults.

Failing Ansible Molecule CI tests can be ignored.