### PR TITLE
Add analytics routes and improve OLTP reliability

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -13,6 +13,23 @@ jobs:
       with:
         python-version: '3.7.9'
 
+    - name: Update pip
+      run: |
+        python -m pip install --upgrade pip
+
+    - name: Set up virtualenv
+      run: |
+        pip3 install virtualenv
+        virtualenv --python=python${{ matrix.python-version }} benchmark
+        source benchmark/bin/activate
+        pip install -r requirements.txt
+
+    - name: Install ansible dependencies
+      run: |
+        source benchmark/bin/activate
+        ansible-galaxy install cloudalchemy.node_exporter
+        ansible-galaxy install cloudalchemy.prometheus
+
     - name: Lint Ansible Playbook
       uses: ansible/ansible-lint-action@main
       with:

--- a/config/macro/oltp.yaml
+++ b/config/macro/oltp.yaml
@@ -5,9 +5,9 @@ macrobench_all_mysql-port: 13306
 macrobench_all_db-ps-mode: disable
 macrobench_all_db-driver: mysql
 macrobench_all_luajit-cmd: "off"
-macrobench_all_threads: 42
+macrobench_all_threads: 400
 macrobench_all_auto-inc: "off"
-macrobench_all_tables: 10
+macrobench_all_tables: 100
 macrobench_all_table_size: 10000
 macrobench_all_rand-type: uniform
 macrobench_all_rand-seed: 1

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/montanaflynn/stats v0.6.6 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.3.0
 	github.com/jung-kurt/gofpdf v1.16.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/montanaflynn/stats v0.6.6
 	github.com/otiai10/copy v1.5.0
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/slack-go/slack v0.8.1
@@ -48,7 +49,6 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/montanaflynn/stats v0.6.6 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -77,9 +77,10 @@ func (s *Server) createCrons() error {
 		schedule string
 		f        func()
 	}{
-		{schedule: s.cronSchedule, f: s.branchCronHandler},
-		{schedule: s.cronSchedulePullRequests, f: s.pullRequestsCronHandler},
-		{schedule: s.cronScheduleTags, f: s.tagsCronHandler},
+		// {schedule: s.cronSchedule, f: s.branchCronHandler},
+		// {schedule: s.cronSchedulePullRequests, f: s.pullRequestsCronHandler},
+		// {schedule: s.cronScheduleTags, f: s.tagsCronHandler},
+		{schedule: s.cronScheduleTags, f: s.analyticsCronHandler},
 	}
 	for _, c := range crons {
 		err := createIndividualCron(c.schedule, c.f)
@@ -93,9 +94,9 @@ func (s *Server) createCrons() error {
 
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
-		"micro": s.microbenchConfigPath,
-		"oltp":  s.macrobenchConfigPathOLTP,
-		"tpcc":  s.macrobenchConfigPathTPCC,
+		// "micro": s.microbenchConfigPath,
+		"oltp": s.macrobenchConfigPathOLTP,
+		// "tpcc":  s.macrobenchConfigPathTPCC,
 	}
 	return configs
 }
@@ -116,7 +117,7 @@ func (s *Server) addToQueue(element *executionQueueElement) {
 		slog.Error(err.Error())
 		return
 	}
-	if !exists {
+	if !exists || exists {
 		queue[element.identifier] = element
 		slog.Infof("%+v is added to the queue", element.identifier)
 

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -95,8 +95,8 @@ func (s *Server) createCrons() error {
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
 		// "micro": s.microbenchConfigPath,
-		"oltp": s.macrobenchConfigPathOLTP,
-		// "tpcc":  s.macrobenchConfigPathTPCC,
+		// "oltp": s.macrobenchConfigPathOLTP,
+		"tpcc": s.macrobenchConfigPathTPCC,
 	}
 	return configs
 }

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -77,10 +77,10 @@ func (s *Server) createCrons() error {
 		schedule string
 		f        func()
 	}{
-		// {schedule: s.cronSchedule, f: s.branchCronHandler},
-		// {schedule: s.cronSchedulePullRequests, f: s.pullRequestsCronHandler},
-		// {schedule: s.cronScheduleTags, f: s.tagsCronHandler},
-		{schedule: s.cronScheduleTags, f: s.analyticsCronHandler},
+		{schedule: s.cronSchedule, f: s.branchCronHandler},
+		{schedule: s.cronSchedulePullRequests, f: s.pullRequestsCronHandler},
+		{schedule: s.cronScheduleTags, f: s.tagsCronHandler},
+		// {schedule: s.cronScheduleTags, f: s.analyticsCronHandler}, TODO: implemented a proper analytics schedule
 	}
 	for _, c := range crons {
 		err := createIndividualCron(c.schedule, c.f)
@@ -94,9 +94,9 @@ func (s *Server) createCrons() error {
 
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
-		// "micro": s.microbenchConfigPath,
-		"oltp": s.macrobenchConfigPathOLTP,
-		"tpcc": s.macrobenchConfigPathTPCC,
+		"micro": s.microbenchConfigPath,
+		"oltp":  s.macrobenchConfigPathOLTP,
+		"tpcc":  s.macrobenchConfigPathTPCC,
 	}
 	return configs
 }
@@ -117,7 +117,7 @@ func (s *Server) addToQueue(element *executionQueueElement) {
 		slog.Error(err.Error())
 		return
 	}
-	if !exists || exists {
+	if !exists {
 		queue[element.identifier] = element
 		slog.Infof("%+v is added to the queue", element.identifier)
 

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -95,7 +95,7 @@ func (s *Server) createCrons() error {
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
 		// "micro": s.microbenchConfigPath,
-		// "oltp": s.macrobenchConfigPathOLTP,
+		"oltp": s.macrobenchConfigPathOLTP,
 		"tpcc": s.macrobenchConfigPathTPCC,
 	}
 	return configs

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -49,10 +49,10 @@ func (s *Server) analyticsCreateCronHandler() []*executionQueueElement {
 	// We compare main with the previous hash of main and with the latest release
 	for configType, configFile := range configs {
 		if configType == "micro" {
-			elements = append(elements, s.createSimpleExecutionQueueElement("cron_analytics", configFile, ref, configType, "", true, 0))
+			elements = append(elements, s.createSimpleExecutionQueueElement("cron_analytics_mixed", configFile, ref, configType, "", true, 0))
 		} else {
 			for _, version := range macrobench.PlannerVersions {
-				elements = append(elements, s.createSimpleExecutionQueueElement("cron_analytics", configFile, ref, configType, string(version), true, 0))
+				elements = append(elements, s.createSimpleExecutionQueueElement("cron_analytics_mixed", configFile, ref, configType, string(version), true, 0))
 			}
 		}
 	}

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/tools/macrobench"
 )
 
+// nolint
 func (s *Server) analyticsCronHandler() {
 	// update the local clone of vitess from remote
 	s.vitessPathMu.Lock()
@@ -40,6 +41,7 @@ func (s *Server) analyticsCronHandler() {
 	}
 }
 
+// nolint
 func (s *Server) analyticsCreateCronHandler() []*executionQueueElement {
 	var elements []*executionQueueElement
 	configs := s.getConfigFiles()

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -24,6 +24,41 @@ import (
 	"github.com/vitessio/arewefastyet/go/tools/macrobench"
 )
 
+func (s *Server) analyticsCronHandler() {
+	// update the local clone of vitess from remote
+	s.vitessPathMu.Lock()
+	defer s.vitessPathMu.Unlock()
+	err := s.pullLocalVitess()
+	if err != nil {
+		slog.Error(err.Error())
+		return
+	}
+
+	elems := s.analyticsCreateCronHandler()
+	for _, elem := range elems {
+		s.addToQueue(elem)
+	}
+}
+
+func (s *Server) analyticsCreateCronHandler() []*executionQueueElement {
+	var elements []*executionQueueElement
+	configs := s.getConfigFiles()
+
+	ref := "331f4e837388547b60b72d25edffc31ffb689f4f"
+
+	// We compare main with the previous hash of main and with the latest release
+	for configType, configFile := range configs {
+		if configType == "micro" {
+			elements = append(elements, s.createSimpleExecutionQueueElement("cron_analytics", configFile, ref, configType, "", true, 0))
+		} else {
+			for _, version := range macrobench.PlannerVersions {
+				elements = append(elements, s.createSimpleExecutionQueueElement("cron_analytics", configFile, ref, configType, string(version), true, 0))
+			}
+		}
+	}
+	return elements
+}
+
 func (s *Server) branchCronHandler() {
 	// update the local clone of vitess from remote
 	s.vitessPathMu.Lock()

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -78,9 +78,13 @@ func (s *Server) analyticsHandlerOLTP(c *gin.Context) {
 		oltpData[i].Metrics = m
 	}
 
+	variation, variationPercentage := macrobench.GetVarianceForMacroBenchmarks(oltpData)
+
 	c.HTML(http.StatusOK, "analytics.tmpl", gin.H{
-		"title":     "Vitess benchmark - analytics",
-		"data_oltp": oltpData,
+		"title":                "Vitess benchmark - analytics",
+		"data_oltp":            oltpData,
+		"variation":            variation,
+		"variation_percentage": variationPercentage,
 	})
 }
 
@@ -100,9 +104,13 @@ func (s *Server) analyticsHandlerTPCC(c *gin.Context) {
 		oltpData[i].Metrics = m
 	}
 
+	variation, variationPercentage := macrobench.GetVarianceForMacroBenchmarks(oltpData)
+
 	c.HTML(http.StatusOK, "analytics.tmpl", gin.H{
-		"title":     "Vitess benchmark - analytics",
-		"data_oltp": oltpData,
+		"title":                "Vitess benchmark - analytics",
+		"data_oltp":            oltpData,
+		"variation":            variation,
+		"variation_percentage": variationPercentage,
 	})
 }
 

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -88,7 +88,7 @@ func (s *Server) analyticsHandlerMixed(c *gin.Context) {
 	tpccData, variationTPCC, variationPercentageTPCC := getAnalyticsData(planner, s.dbClient, macrobench.TPCC, "cron_analytics_mixed")
 
 	c.HTML(http.StatusOK, "analytics_mixed.tmpl", gin.H{
-		"title":                     "Vitess benchmark - analytics",
+		"title":                     "Vitess benchmark - analytics - oltp",
 		"data_oltp":                 oltpData,
 		"variation_oltp":            variationOLTP,
 		"variation_oltp_percentage": variationPercentageOLTP,
@@ -104,7 +104,7 @@ func (s *Server) analyticsHandlerOLTP(c *gin.Context) {
 	oltpData, variation, variationPercentage := getAnalyticsData(planner, s.dbClient, macrobench.OLTP, "cron_analytics")
 
 	c.HTML(http.StatusOK, "analytics.tmpl", gin.H{
-		"title":                "Vitess benchmark - analytics",
+		"title":                "Vitess benchmark - analytics - tpcc",
 		"data":                 oltpData,
 		"variation":            variation,
 		"variation_percentage": variationPercentage,
@@ -117,7 +117,7 @@ func (s *Server) analyticsHandlerTPCC(c *gin.Context) {
 	tpccData, variation, variationPercentage := getAnalyticsData(planner, s.dbClient, macrobench.TPCC, "cron_analytics")
 
 	c.HTML(http.StatusOK, "analytics.tmpl", gin.H{
-		"title":                "Vitess benchmark - analytics",
+		"title":                "Vitess benchmark - analytics - mixed",
 		"data":                 tpccData,
 		"variation":            variation,
 		"variation_percentage": variationPercentage,

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -198,7 +198,8 @@ func (s *Server) Run() error {
 	// Information page
 	s.router.GET("/cron", s.cronHandler)
 
-	s.router.GET("/analytics", s.analyticsHandler)
+	s.router.GET("/analytics", s.analyticsHandlerOLTP)
+	s.router.GET("/analytics_tpcc", s.analyticsHandlerTPCC)
 
 	// Home page
 	s.router.GET("/", s.homeHandler)

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -200,6 +200,7 @@ func (s *Server) Run() error {
 
 	s.router.GET("/analytics", s.analyticsHandlerOLTP)
 	s.router.GET("/analytics_tpcc", s.analyticsHandlerTPCC)
+	s.router.GET("/analytics_mixed", s.analyticsHandlerMixed)
 
 	// Home page
 	s.router.GET("/", s.homeHandler)

--- a/go/server/templates/analytics.tmpl
+++ b/go/server/templates/analytics.tmpl
@@ -47,6 +47,60 @@
             </tr>
             </thead>
             <tbody>
+            <tr>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation.Result.QPS.Total }}</td>
+                <td>{{ formatFloat .variation.Result.QPS.Reads }}</td>
+                <td>{{ formatFloat .variation.Result.QPS.Writes }}</td>
+                <td>{{ formatFloat .variation.Result.QPS.Other }}</td>
+                <td>{{ formatFloat .variation.Result.TPS }}</td>
+                <td>{{ formatFloat .variation.Result.Latency }}</td>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index .variation.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatBytes .variation.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatBytes (index .variation.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatBytes (index .variation.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            <tr>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation_percentage.Result.QPS.Total }}</td>
+                <td>{{ formatFloat .variation_percentage.Result.QPS.Reads }}</td>
+                <td>{{ formatFloat .variation_percentage.Result.QPS.Writes }}</td>
+                <td>{{ formatFloat .variation_percentage.Result.QPS.Other }}</td>
+                <td>{{ formatFloat .variation_percentage.Result.TPS }}</td>
+                <td>{{ formatFloat .variation_percentage.Result.Latency }}</td>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation_percentage.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index .variation_percentage.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_percentage.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatFloat .variation_percentage.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatFloat (index .variation_percentage.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_percentage.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            </tbody>
+        </table>
+        <table class="table table-striped table-hover table-sm table-bordered">
+            <thead>
+            <tr>
+                <th scope="col" class="text-center">UUID</th>
+                <th scope="col" class="text-center">QPS</th>
+                <th scope="col" class="text-center">Reads</th>
+                <th scope="col" class="text-center">Writes</th>
+                <th scope="col" class="text-center">Other</th>
+                <th scope="col" class="text-center">TPS</th>
+                <th scope="col" class="text-center">Latency</th>
+                <th scope="col" class="text-center">Errors</th>
+                <th scope="col" class="text-center">CPU Total</th>
+                <th scope="col" class="text-center">CPU Gate</th>
+                <th scope="col" class="text-center">CPU Tablet</th>
+                <th scope="col" class="text-center">Mem Total</th>
+                <th scope="col" class="text-center">Mem Gate</th>
+                <th scope="col" class="text-center">Mem Tablet</th>
+            </tr>
+            </thead>
+            <tbody>
             {{range $val := .data_oltp}}
             <tr>
                 <td>{{ first8Letters ($val.ExecUUID) }}</td>

--- a/go/server/templates/analytics.tmpl
+++ b/go/server/templates/analytics.tmpl
@@ -101,7 +101,7 @@
             </tr>
             </thead>
             <tbody>
-            {{range $val := .data_oltp}}
+            {{range $val := .data}}
             <tr>
                 <td>{{ first8Letters ($val.ExecUUID) }}</td>
                 <td>{{ $val.Result.QPS.Total }}</td>

--- a/go/server/templates/analytics_mixed.tmpl
+++ b/go/server/templates/analytics_mixed.tmpl
@@ -1,0 +1,181 @@
+<!--
+  ~ /*
+  ~ Copyright 2021 The Vitess Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ */
+  -->
+
+<!DOCTYPE html>
+<html lang="en">
+
+{{template "headHTML" .}}
+<body>
+
+<div style="min-height: 90vh;">
+
+{{ template "navigation" "/analytics_mixed" }}
+
+    <div class="container-xxl">
+        <table class="table table-striped table-hover table-sm table-bordered">
+            <thead>
+            <tr>
+                <th scope="col" class="text-center">Type</th>
+                <th scope="col" class="text-center">QPS</th>
+                <th scope="col" class="text-center">Reads</th>
+                <th scope="col" class="text-center">Writes</th>
+                <th scope="col" class="text-center">Other</th>
+                <th scope="col" class="text-center">TPS</th>
+                <th scope="col" class="text-center">Latency</th>
+                <th scope="col" class="text-center">Errors</th>
+                <th scope="col" class="text-center">CPU Total</th>
+                <th scope="col" class="text-center">CPU Gate</th>
+                <th scope="col" class="text-center">CPU Tablet</th>
+                <th scope="col" class="text-center">Mem Total</th>
+                <th scope="col" class="text-center">Mem Gate</th>
+                <th scope="col" class="text-center">Mem Tablet</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>OLTP</td>
+                <td>{{ formatFloat .variation_oltp.Result.QPS.Total }}</td>
+                <td>{{ formatFloat .variation_oltp.Result.QPS.Reads }}</td>
+                <td>{{ formatFloat .variation_oltp.Result.QPS.Writes }}</td>
+                <td>{{ formatFloat .variation_oltp.Result.QPS.Other }}</td>
+                <td>{{ formatFloat .variation_oltp.Result.TPS }}</td>
+                <td>{{ formatFloat .variation_oltp.Result.Latency }}</td>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation_oltp.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index .variation_oltp.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_oltp.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatBytes .variation_oltp.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatBytes (index .variation_oltp.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatBytes (index .variation_oltp.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            <tr>
+                <td>OLTP</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Result.QPS.Total }}</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Result.QPS.Reads }}</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Result.QPS.Writes }}</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Result.QPS.Other }}</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Result.TPS }}</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Result.Latency }}</td>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index .variation_oltp_percentage.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_oltp_percentage.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatFloat .variation_oltp_percentage.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatFloat (index .variation_oltp_percentage.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_oltp_percentage.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            <tr>
+                <td>TPCC</td>
+                <td>{{ formatFloat .variation_tpcc.Result.QPS.Total }}</td>
+                <td>{{ formatFloat .variation_tpcc.Result.QPS.Reads }}</td>
+                <td>{{ formatFloat .variation_tpcc.Result.QPS.Writes }}</td>
+                <td>{{ formatFloat .variation_tpcc.Result.QPS.Other }}</td>
+                <td>{{ formatFloat .variation_tpcc.Result.TPS }}</td>
+                <td>{{ formatFloat .variation_tpcc.Result.Latency }}</td>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation_tpcc.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index .variation_tpcc.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_tpcc.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatBytes .variation_tpcc.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatBytes (index .variation_tpcc.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatBytes (index .variation_tpcc.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            <tr>
+                <td>TPCC</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Result.QPS.Total }}</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Result.QPS.Reads }}</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Result.QPS.Writes }}</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Result.QPS.Other }}</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Result.TPS }}</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Result.Latency }}</td>
+                <td>n/a</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index .variation_tpcc_percentage.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_tpcc_percentage.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatFloat .variation_tpcc_percentage.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatFloat (index .variation_tpcc_percentage.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatFloat (index .variation_tpcc_percentage.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            </tbody>
+        </table>
+        <table class="table table-striped table-hover table-sm table-bordered">
+            <thead>
+            <tr>
+                <th scope="col" class="text-center">Type</th>
+                <th scope="col" class="text-center">UUID</th>
+                <th scope="col" class="text-center">QPS</th>
+                <th scope="col" class="text-center">Reads</th>
+                <th scope="col" class="text-center">Writes</th>
+                <th scope="col" class="text-center">Other</th>
+                <th scope="col" class="text-center">TPS</th>
+                <th scope="col" class="text-center">Latency</th>
+                <th scope="col" class="text-center">Errors</th>
+                <th scope="col" class="text-center">CPU Total</th>
+                <th scope="col" class="text-center">CPU Gate</th>
+                <th scope="col" class="text-center">CPU Tablet</th>
+                <th scope="col" class="text-center">Mem Total</th>
+                <th scope="col" class="text-center">Mem Gate</th>
+                <th scope="col" class="text-center">Mem Tablet</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{range $val := .data_oltp}}
+            <tr>
+                <td>OLTP</td>
+                <td>{{ first8Letters ($val.ExecUUID) }}</td>
+                <td>{{ $val.Result.QPS.Total }}</td>
+                <td>{{ $val.Result.QPS.Reads }}</td>
+                <td>{{ $val.Result.QPS.Writes }}</td>
+                <td>{{ $val.Result.QPS.Other }}</td>
+                <td>{{ $val.Result.TPS }}</td>
+                <td>{{ $val.Result.Latency }}</td>
+                <td>{{ $val.Result.Errors }}</td>
+                <td>{{ formatFloat $val.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index $val.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index $val.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatBytes $val.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatBytes (index $val.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatBytes (index $val.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            {{end}}
+            {{range $val := .data_tpcc}}
+            <tr>
+                <td>TPCC</td>
+                <td>{{ first8Letters ($val.ExecUUID) }}</td>
+                <td>{{ $val.Result.QPS.Total }}</td>
+                <td>{{ $val.Result.QPS.Reads }}</td>
+                <td>{{ $val.Result.QPS.Writes }}</td>
+                <td>{{ $val.Result.QPS.Other }}</td>
+                <td>{{ $val.Result.TPS }}</td>
+                <td>{{ $val.Result.Latency }}</td>
+                <td>{{ $val.Result.Errors }}</td>
+                <td>{{ formatFloat $val.Metrics.TotalComponentsCPUTime }}</td>
+                <td>{{ formatFloat (index $val.Metrics.ComponentsCPUTime "vtgate") }}</td>
+                <td>{{ formatFloat (index $val.Metrics.ComponentsCPUTime "vttablet") }}</td>
+                <td>{{ formatBytes $val.Metrics.TotalComponentsMemStatsAllocBytes }}</td>
+                <td>{{ formatBytes (index $val.Metrics.ComponentsMemStatsAllocBytes "vtgate") }}</td>
+                <td>{{ formatBytes (index $val.Metrics.ComponentsMemStatsAllocBytes "vttablet") }}</td>
+            </tr>
+            {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+
+</html>

--- a/go/tools/macrobench/variance.go
+++ b/go/tools/macrobench/variance.go
@@ -1,0 +1,97 @@
+/*
+ *
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package macrobench
+
+import (
+	"github.com/montanaflynn/stats"
+	"sort"
+)
+
+func GetVarianceForMacroBenchmarks(macrobenchmarks DetailsArray) (Details, Details) {
+	var qps, r, w, o, tps, lat, cpu, cpuGate, cpuTablet, mem, memGate, memTablet stats.Float64Data
+	res := newEmptyDetails()
+	resPercentage := newEmptyDetails()
+
+	for _, m := range macrobenchmarks {
+		qps = append(qps, m.Result.QPS.Total)
+		r = append(r, m.Result.QPS.Reads)
+		w = append(w, m.Result.QPS.Writes)
+		o = append(o, m.Result.QPS.Other)
+		tps = append(tps, m.Result.TPS)
+		lat = append(lat, m.Result.Latency)
+		cpu = append(cpu, m.Metrics.TotalComponentsCPUTime)
+		cpuGate = append(cpuGate, m.Metrics.ComponentsCPUTime["vtgate"])
+		cpuTablet = append(cpuTablet, m.Metrics.ComponentsCPUTime["vttablet"])
+		mem = append(mem, m.Metrics.TotalComponentsMemStatsAllocBytes)
+		memGate = append(memGate, m.Metrics.ComponentsMemStatsAllocBytes["vtgate"])
+		memTablet = append(memTablet, m.Metrics.ComponentsMemStatsAllocBytes["vttablet"])
+	}
+
+	sort.Sort(qps)
+	sort.Sort(r)
+	sort.Sort(w)
+	sort.Sort(o)
+	sort.Sort(tps)
+	sort.Sort(lat)
+	sort.Sort(cpu)
+	sort.Sort(cpuGate)
+	sort.Sort(cpuTablet)
+	sort.Sort(mem)
+	sort.Sort(memGate)
+	sort.Sort(memTablet)
+
+	res.Result.QPS.Total, _ = stats.StandardDeviationSample(qps)
+	res.Result.QPS.Reads, _ = stats.StandardDeviationSample(r)
+	res.Result.QPS.Writes, _ = stats.StandardDeviationSample(w)
+	res.Result.QPS.Other, _ = stats.StandardDeviationSample(o)
+	res.Result.TPS, _ = stats.StandardDeviationSample(tps)
+	res.Result.Latency, _ = stats.StandardDeviationSample(lat)
+	res.Metrics.TotalComponentsCPUTime, _ = stats.StandardDeviationSample(cpu)
+	res.Metrics.ComponentsCPUTime["vtgate"], _ = stats.StandardDeviationSample(cpuGate)
+	res.Metrics.ComponentsCPUTime["vttablet"], _ = stats.StandardDeviationSample(cpuTablet)
+	res.Metrics.TotalComponentsMemStatsAllocBytes, _ = stats.StandardDeviationSample(mem)
+	res.Metrics.ComponentsMemStatsAllocBytes["vtgate"], _ = stats.StandardDeviationSample(memGate)
+	res.Metrics.ComponentsMemStatsAllocBytes["vttablet"], _ = stats.StandardDeviationSample(memTablet)
+
+	resPercentage.Result.QPS.Total = res.Result.QPS.Total * 100 / mean(qps)
+	resPercentage.Result.QPS.Reads = res.Result.QPS.Reads * 100 / mean(r)
+	resPercentage.Result.QPS.Writes = res.Result.QPS.Writes * 100 / mean(w)
+	resPercentage.Result.QPS.Other = res.Result.QPS.Other * 100 / mean(o)
+	resPercentage.Result.TPS = res.Result.TPS * 100 / mean(tps)
+	resPercentage.Result.Latency = res.Result.Latency * 100 / mean(lat)
+	resPercentage.Metrics.TotalComponentsCPUTime = res.Metrics.TotalComponentsCPUTime * 100 / mean(cpu)
+	resPercentage.Metrics.ComponentsCPUTime["vtgate"] = res.Metrics.ComponentsCPUTime["vtgate"] * 100 / mean(cpuGate)
+	resPercentage.Metrics.ComponentsCPUTime["vttablet"] = res.Metrics.ComponentsCPUTime["vttablet"] * 100 / mean(cpuTablet)
+	resPercentage.Metrics.TotalComponentsMemStatsAllocBytes = res.Metrics.TotalComponentsMemStatsAllocBytes * 100 / mean(mem)
+	resPercentage.Metrics.ComponentsMemStatsAllocBytes["vtgate"] = res.Metrics.ComponentsMemStatsAllocBytes["vtgate"] * 100 / mean(memGate)
+	resPercentage.Metrics.ComponentsMemStatsAllocBytes["vttablet"] = res.Metrics.ComponentsMemStatsAllocBytes["vttablet"] * 100 / mean(memTablet)
+	return res, resPercentage
+}
+
+func mean(f stats.Float64Data) float64 {
+	m, _ := stats.Mean(f)
+	return m
+}
+
+func newEmptyDetails() Details {
+	res := Details{}
+	res.Metrics.ComponentsCPUTime = map[string]float64{}
+	res.Metrics.ComponentsMemStatsAllocBytes = map[string]float64{}
+	return res
+}


### PR DESCRIPTION
This pull request adds the different analytics pages for OLTP, TPCC, and both combined. New routes for these pages are available, however, the cron job that starts the analytics benchmark has been disabled for now until a proper scheduling pattern has been found.