### PR TITLE
Remove the v3 planner from the list of execution and from the website

### DIFF
--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -43,6 +43,6 @@
 
 - name: Run macrobenchmarks
   shell: |
-    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ planner_version | default("V3") }} --macrobench-vtgate-web-ports {{ vtgate_web_ports }}
+    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ planner_version | default("gen4") }} --macrobench-vtgate-web-ports {{ vtgate_web_ports }}
   register: arewefastyetcli
   changed_when: False

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -93,9 +93,9 @@ func (s *Server) createCrons() error {
 
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
-		// "micro": s.microbenchConfigPath,
-		// "oltp":  s.macrobenchConfigPathOLTP,
-		// "tpcc":  s.macrobenchConfigPathTPCC,
+		"micro": s.microbenchConfigPath,
+		"oltp":  s.macrobenchConfigPathOLTP,
+		"tpcc":  s.macrobenchConfigPathTPCC,
 	}
 	return configs
 }

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -93,9 +93,9 @@ func (s *Server) createCrons() error {
 
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
-		"micro": s.microbenchConfigPath,
-		"oltp":  s.macrobenchConfigPathOLTP,
-		"tpcc":  s.macrobenchConfigPathTPCC,
+		// "micro": s.microbenchConfigPath,
+		// "oltp":  s.macrobenchConfigPathOLTP,
+		// "tpcc":  s.macrobenchConfigPathTPCC,
 	}
 	return configs
 }

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -79,7 +79,7 @@ func (s *Server) mainBranchCronHandler() ([]*executionQueueElement, error) {
 			}
 			elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, "", exec.SourceCron, lastRelease)...)
 		} else {
-			for _, version := range macrobench.PlannerVersions {
+			for _, version := range git.GetPlannerVersions() {
 				_, previousGitRef, err := exec.GetPreviousFromSourceMacrobenchmark(s.dbClient, exec.SourceCron, configType, string(version), ref)
 				if err != nil {
 					slog.Warn(err.Error())
@@ -123,7 +123,7 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 
 				elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, "", source, lastPatchRelease)...)
 			} else {
-				versions := git.GetPlannerVersionsForRelease(release)
+				versions := git.GetPlannerVersions()
 
 				for _, version := range versions {
 					_, previousGitRef, err := exec.GetPreviousFromSourceMacrobenchmark(s.dbClient, source, configType, string(version), ref)
@@ -200,7 +200,7 @@ func (s *Server) pullRequestsCronHandler() {
 				} else {
 					versions := []macrobench.PlannerVersion{macrobench.V3Planner}
 					if labelInfo.useGen4 {
-						versions = append(versions, macrobench.Gen4FallbackPlanner)
+						versions = []macrobench.PlannerVersion{macrobench.Gen4Planner}
 					}
 					for _, version := range versions {
 						elements = append(elements, s.createPullRequestElementWithBaseComparison(configFile, ref, configType, previousGitRef, version, pullNb)...)
@@ -256,7 +256,7 @@ func (s *Server) tagsCronHandler() {
 			if configType == "micro" {
 				elements = append(elements, s.createSimpleExecutionQueueElement(source, configFile, release.CommitHash, configType, "", true, 0))
 			} else {
-				versions := git.GetPlannerVersionsForRelease(release)
+				versions := git.GetPlannerVersions()
 				for _, version := range versions {
 					elements = append(elements, s.createSimpleExecutionQueueElement(source, configFile, release.CommitHash, configType, string(version), true, 0))
 				}

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -43,7 +43,7 @@ func handleRenderErrors(c *gin.Context, err error) {
 }
 
 func (s *Server) cronHandler(c *gin.Context) {
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 
 	oltpData, err := macrobench.GetResultsForLastDays(macrobench.OLTP, "cron", planner, 31, s.dbClient)
 	if err != nil {
@@ -63,7 +63,7 @@ func (s *Server) cronHandler(c *gin.Context) {
 }
 
 func (s *Server) analyticsHandler(c *gin.Context) {
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 
 	oltpData, err := macrobench.GetResultsForLastDays(macrobench.OLTP, "cron_analytics", planner, 31, s.dbClient)
 	if err != nil {
@@ -84,17 +84,8 @@ func (s *Server) analyticsHandler(c *gin.Context) {
 	})
 }
 
-func getPlannerVersion(c *gin.Context) macrobench.PlannerVersion {
-	planner := macrobench.V3Planner
-	plannerStr, err := c.Cookie("vtgatePlanner")
-	if err != nil {
-		// cookie is not set, then use the default
-		return planner
-	}
-	if plannerStr == string(macrobench.Gen4FallbackPlanner) {
-		planner = macrobench.Gen4FallbackPlanner
-	}
-	return planner
+func getPlannerVersion() macrobench.PlannerVersion {
+	return macrobench.Gen4Planner
 }
 
 func (s *Server) homeHandler(c *gin.Context) {
@@ -117,7 +108,7 @@ func (s *Server) statusHandler(c *gin.Context) {
 }
 
 func (s *Server) compareHandler(c *gin.Context) {
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 	reference := c.Query("r")
 	compare := c.Query("c")
 
@@ -162,7 +153,7 @@ func (s *Server) compareHandler(c *gin.Context) {
 }
 
 func (s *Server) searchHandler(c *gin.Context) {
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 	search := c.Query("s")
 	if search == "" {
 		c.HTML(http.StatusOK, "search.tmpl", gin.H{
@@ -317,7 +308,7 @@ func (s *Server) microbenchmarkSingleResultsHandler(c *gin.Context) {
 
 func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 	var err error
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 	// get all the latest releases and the last cron job for main
 	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
 	if err != nil {
@@ -395,7 +386,7 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 }
 
 func (s *Server) macrobenchmarkQueriesDetails(c *gin.Context) {
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 	gitRef := c.Param("git_ref")
 	macroType := macrobench.Type(c.Query("type"))
 
@@ -436,7 +427,7 @@ func (s *Server) macrobenchmarkCompareQueriesDetails(c *gin.Context) {
 		return
 	}
 
-	planner := getPlannerVersion(c)
+	planner := getPlannerVersion()
 	leftPlanner := macrobench.PlannerVersion(c.Query("left_planner"))
 	rightPlanner := macrobench.PlannerVersion(c.Query("right_planner"))
 

--- a/go/server/templates/index.tmpl
+++ b/go/server/templates/index.tmpl
@@ -51,7 +51,6 @@ limitations under the License.
         <li><a href="/compare">Compare two commits.</a></li>
         <li><a href="/microbench">Microbenchmarks results.</a></li>
         <li><a href="/macrobench">Macrobenchmarks results.</a></li>
-        <li><a href="/v3_VS_Gen4">Compare between v3 and Gen4 planners.</a></li>
         <li><a href="/status">See previous and ongoing executions.</a></li>
       </ul>
     </div>

--- a/go/server/templates/navigation.tmpl
+++ b/go/server/templates/navigation.tmpl
@@ -26,10 +26,6 @@
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="custom-control custom-switch" data-toggle="tooltip"  data-placement="bottom" title="See results from VTGate's Gen4 planner. Defaults to V3 planner." style="margin-left: 10px;">
-            <input type="checkbox" class="custom-control-input" id="vtgateplanner-switch" onclick="switchVtgatePlanner()">
-            <label class="custom-control-label" for="vtgateplanner-switch" style="color: white">Gen4</label>
-        </div>
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item {{if eq . `/`}} active {{end}}">
@@ -96,53 +92,8 @@
                         {{ end }}
                     </a>
                 </li>
-                <li class="nav-item {{if eq . `/v3_VS_Gen4`}} active {{end}}">
-                    <a class="nav-link" href="/v3_VS_Gen4">
-                        v3 vs Gen4
-                        {{ if eq . "/v3_VS_Gen4" }}
-                            <span class="sr-only">(current)</span>
-                        {{ end }}
-                    </a>
-                </li>
             </ul>
         </div>
     </div>
 </nav>
-<script>
-    vtgatePlanner = "V3"
-
-    // get our planner cookie
-    vtgatePlannerCookie = document.cookie.split('; ').find(row => row.startsWith('vtgatePlanner='));
-    if (vtgatePlannerCookie !== undefined) {
-        vtgatePlanner = vtgatePlannerCookie.split('=')[1]
-        if (vtgatePlanner !== "Gen4Fallback") {
-            vtgatePlanner = "V3"
-        }
-        console.log(vtgatePlanner)
-    }
-    // change the switch
-    if (vtgatePlanner === "Gen4Fallback") {
-        $("#vtgateplanner-switch").prop('checked', true)
-    } else {
-        $("#vtgateplanner-switch").prop('checked', false)
-    }
-
-    function switchVtgatePlanner() {
-        function setCookie(cname, cvalue, exdays) {
-            var d = new Date();
-            d.setTime(d.getTime() + (exdays*24*60*60*1000));
-            var expires = "expires="+ d.toUTCString();
-            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-        }
-        if ($("#vtgateplanner-switch").is(":checked")) {
-            setCookie("vtgatePlanner", "Gen4Fallback", 7)
-        } else {
-            setCookie("vtgatePlanner", "V3", 7)
-        }
-        location.reload()
-    }
-    $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
-    })
-</script>
 {{ end }}

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -43,12 +43,8 @@ var (
 	regexPatternReleaseBranch = regexp.MustCompile(`^refs/remotes/origin/release-(\d+)\.(\d+)$`)
 )
 
-func GetPlannerVersionsForRelease(release *Release) []macrobench.PlannerVersion {
-	versions := []macrobench.PlannerVersion{macrobench.V3Planner}
-	if release.Number[0] >= 10 {
-		versions = append(versions, macrobench.Gen4FallbackPlanner)
-	}
-	return versions
+func GetPlannerVersions() []macrobench.PlannerVersion {
+	return []macrobench.PlannerVersion{macrobench.Gen4Planner}
 }
 
 // GetAllVitessReleaseCommitHash gets all the vitess releases and the commit hashes given the directory of the clone of vitess

--- a/go/tools/macrobench/compare.go
+++ b/go/tools/macrobench/compare.go
@@ -52,7 +52,7 @@ func ComparePlanners(client storage.SQLClient, sha string) (map[Type]interface{}
 	// Get macro benchmarks from all the different types
 	var err error
 	macros := map[string]map[Type]DetailsArray{}
-	for _, planner := range PlannerVersions {
+	for _, planner := range LegacyPlannerVersions {
 		macros[string(planner)], err = GetDetailsArraysFromAllTypes(sha, planner, client)
 		if err != nil {
 			return nil, err

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -39,10 +39,11 @@ const (
 
 	V3Planner           PlannerVersion = "V3"
 	Gen4FallbackPlanner PlannerVersion = "Gen4Fallback"
+	Gen4Planner         PlannerVersion = "Gen4"
 )
 
 var (
-	PlannerVersions = []PlannerVersion{
+	LegacyPlannerVersions = []PlannerVersion{
 		V3Planner,
 		Gen4FallbackPlanner,
 	}


### PR DESCRIPTION
## Description

This Pull Request removes the execution of benchmarks using the `v3` planner, instead only `Gen4` benchmarks will be run (instead of `v3` & `Gen4Fallback`).

The visualization of results for both `v3` and `Gen4` is removed. Now we can only see the results for `Gen4`.