### PR TITLE
Improve how elements in the execution queue are handled

### DIFF
--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -31,7 +31,7 @@ type (
 		retry                   int
 		identifier              executionIdentifier
 		compareWith             []executionIdentifier
-		notifyAlways, executing bool
+		notifyAlways, Executing bool
 	}
 
 	executionIdentifier struct {

--- a/go/server/templates/status.tmpl
+++ b/go/server/templates/status.tmpl
@@ -47,21 +47,23 @@ limitations under the License.
             </thead>
             <tbody>
               {{ range $key, $elem := .queue }}
-              <tr>
-                <td class="text-center">
-                  <a target="_blank" href="https://github.com/vitessio/vitess/commit/{{$key.GitRef}}">{{ first8Letters $key.GitRef }}</a>
-                </td>
-                <td class="text-center">{{ $key.Source }}</td>
-                <td class="text-center">{{ $key.BenchmarkType }}</td>
-                <td class="text-center">
-                  {{ if gt $key.PullNb 0 }}
-                    <a href="https://github.com/vitessio/vitess/pull/{{$key.PullNb}}">{{ $key.PullNb }}</a>
-                  {{ else }}
-                    {{ $key.PullNb }}
-                  {{ end }}
-                </td>
-                <td class="text-center">{{ $key.PlannerVersion }}</td>
-              </tr>
+				  {{ if not $elem.Executing }}
+					  <tr>
+						<td class="text-center">
+						  <a target="_blank" href="https://github.com/vitessio/vitess/commit/{{$key.GitRef}}">{{ first8Letters $key.GitRef }}</a>
+						</td>
+						<td class="text-center">{{ $key.Source }}</td>
+						<td class="text-center">{{ $key.BenchmarkType }}</td>
+						<td class="text-center">
+						  {{ if gt $key.PullNb 0 }}
+							<a href="https://github.com/vitessio/vitess/pull/{{$key.PullNb}}">{{ $key.PullNb }}</a>
+						  {{ else }}
+							{{ $key.PullNb }}
+						  {{ end }}
+						</td>
+						<td class="text-center">{{ $key.PlannerVersion }}</td>
+					  </tr>
+				  {{ end }}
               {{ end }}
             </tbody>
           </table>

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -22,12 +22,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/vitessio/arewefastyet/go/exec/metrics"
-	"github.com/vitessio/arewefastyet/go/storage/influxdb"
-	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/vitessio/arewefastyet/go/exec/metrics"
+	"github.com/vitessio/arewefastyet/go/storage/influxdb"
+	"github.com/vitessio/arewefastyet/go/storage/psdb"
 )
 
 type PlannerVersion string
@@ -110,6 +111,7 @@ func Run(mabcfg Config) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 
 	// Prepare

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -111,7 +111,6 @@ func Run(mabcfg Config) error {
 		if err != nil {
 			return err
 		}
-		return nil
 	}
 
 	// Prepare


### PR DESCRIPTION
This Pull Requests removes duplicated benchmarks in the execution queue web page and removes elements from the queue as soon as they are done being executed.