### PR TITLE
Update the flag syntax used to create Vitess services

### DIFF
--- a/ansible/roles/vtctld/files/vtctld@.service
+++ b/ansible/roles/vtctld/files/vtctld@.service
@@ -7,7 +7,7 @@ Environment="VTROOT=/vt"
 Environment="USER=vitess"
 Environment="VTCTLD_PORT=15000"
 Environment="GRPC_PORT=15999"
-Environment="EXTRA_VTCTLD_FLAGS=-alsologtostderr"
+Environment="EXTRA_VTCTLD_FLAGS=--alsologtostderr"
 EnvironmentFile=/etc/vitess/conf/vtctld-%i.conf
 Type=simple
 Restart=always

--- a/ansible/roles/vtctld/templates/cell@.service.j2
+++ b/ansible/roles/vtctld/templates/cell@.service.j2
@@ -10,12 +10,21 @@ WorkingDirectory={{vitess_root}}
 Type=oneshot
 User={{vitess_user}}
 ExecStart=/bin/bash -c 'vtctl \
-    -topo_implementation ${TOPO_IMPLEMENTATION} \
-    -topo_global_root ${TOPO_GLOBAL_ROOT} \
-    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-    AddCellInfo \
-    -root ${CELL_ROOT} \
-    -server_address ${CELL_TOPO_SERVER} \
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+		-topo_implementation ${TOPO_IMPLEMENTATION} \
+		-topo_global_root ${TOPO_GLOBAL_ROOT} \
+		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+		AddCellInfo \
+		-root ${CELL_ROOT} \
+		-server_address ${CELL_TOPO_SERVER} \
+	{% else %}
+		--topo_implementation ${TOPO_IMPLEMENTATION} \
+		--topo_global_root ${TOPO_GLOBAL_ROOT} \
+		--topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+		AddCellInfo \
+		--root ${CELL_ROOT} \
+		--server_address ${CELL_TOPO_SERVER} \
+	{% endif %}
     %i || /bin/true'
 RemainAfterExit=true
 StandardOutput=journal

--- a/ansible/roles/vtctld/templates/vtctld@.service.j2
+++ b/ansible/roles/vtctld/templates/vtctld@.service.j2
@@ -8,7 +8,7 @@ Environment="VTDATAROOT={{vitess_root}}"
 Environment="USER={{vitess_user}}"
 Environment="VTCTLD_PORT={{vtctld_port}}"
 Environment="GRPC_PORT={{vtctld_grpc_port}}"
-Environment="EXTRA_VTCTLD_FLAGS=-alsologtostderr"
+Environment="EXTRA_VTCTLD_FLAGS=--alsologtostderr"
 EnvironmentFile=/etc/vitess/conf/vtctld-%i.conf
 Type=simple
 Restart=on-failure
@@ -16,18 +16,33 @@ WorkingDirectory={{vitess_root}}
 User={{vitess_user}}
 ExecStartPre=/bin/bash -c "${TOPO_PREPARE_COMMAND}"
 ExecStart=/bin/bash -c 'vtctld \
-    -cell %i \
-    -service_map "grpc-vtctl" \
-    -enable_realtime_stats \
-    -workflow_manager_init \
-    -workflow_manager_use_election \
-    -enable_queries \
-    -log_dir ${VTROOT}/tmp \
-    -port ${VTCTLD_PORT} \
-    -grpc_port ${GRPC_PORT} \
-    -topo_implementation ${TOPO_IMPLEMENTATION} \
-    -topo_global_root ${TOPO_GLOBAL_ROOT} \
-    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+		-cell %i \
+		-service_map "grpc-vtctl" \
+		-enable_realtime_stats \
+		-workflow_manager_init \
+		-workflow_manager_use_election \
+		-enable_queries \
+		-log_dir ${VTROOT}/tmp \
+		-port ${VTCTLD_PORT} \
+		-grpc_port ${GRPC_PORT} \
+		-topo_implementation ${TOPO_IMPLEMENTATION} \
+		-topo_global_root ${TOPO_GLOBAL_ROOT} \
+		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+	{% else %}
+		--cell %i \
+		--service_map "grpc-vtctl" \
+		--enable_realtime_stats \
+		--workflow_manager_init \
+		--workflow_manager_use_election \
+		--enable_queries \
+		--log_dir ${VTROOT}/tmp \
+		--port ${VTCTLD_PORT} \
+		--grpc_port ${GRPC_PORT} \
+		--topo_implementation ${TOPO_IMPLEMENTATION} \
+		--topo_global_root ${TOPO_GLOBAL_ROOT} \
+		--topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+	{% endif %}
     ${EXTRA_VTCTLD_FLAGS}'
 
 [Install]

--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -17,20 +17,22 @@ GRPC_PORT='{{gateway.grpc_port | default(vtgate_grpc_port)}}'
 
 CELL={{ cell }}
 ADDITIONAL_CELLS=""
-EXTRA_VTGATE_FLAGS="-vschema_ddl_authorized_users \"%\" \
-    -vtgate-config-terse-errors \
-    -gate_query_cache_size {{ vtgate_query_cache_size }} \
-    -tablet_types_to_wait REPLICA \
+EXTRA_VTGATE_FLAGS="\
 	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
     	-planner_version {{ vitess_planner_version }} \
+		-vschema_ddl_authorized_users \"%\" \
+		-vtgate-config-terse-errors \
+		-gate_query_cache_size {{ vtgate_query_cache_size }} \
+		-tablet_types_to_wait REPLICA \
+		{{gateway.extra_flags|default("")}} \
+		{{extra_vtgate_flags|default("")}} \
 	{% else %}
 		-planner-version {{ vitess_planner_version }} \
+		--vschema_ddl_authorized_users \"%\" \
+		--vtgate-config-terse-errors \
+		--gate_query_cache_size {{ vtgate_query_cache_size }} \
+		-tablet_types_to_wait REPLICA \
+		{{gateway.extra_flags|default("")}} \
+		{{extra_vtgate_flags|default("")}} \
 	{% endif %}
-    {% if pprof_targets is defined %}
-        {% for target in pprof_targets if target == "vtgate" %}
-            -pprof {{ pprof_args }},path=/tmp/pprof/vtgate-{{ gateway.id }},waitSig
-        {%- endfor %}
-    {% endif %}
-    {{gateway.extra_flags|default("")}} \
-    {{extra_vtgate_flags|default("")}} \
 "

--- a/ansible/roles/vtgate/templates/vtgate@.service.j2
+++ b/ansible/roles/vtgate/templates/vtgate@.service.j2
@@ -23,22 +23,41 @@ LimitNPROC=infinity
 LimitNOFILE=infinity
 LimitMEMLOCK=infinity
 ExecStart=/bin/bash -c 'vtgate \
-    -service_map "grpc-vtgateservice" \
-    -alsologtostderr \
-    -enable_buffer \
-    -buffer_size=${VTGATE_BUFFER_SIZE} \
-    -buffer_max_failover_duration ${VTGATE_BUFFER_DURATION} \
-    -cell ${CELL} \
-    -cells_to_watch ${CELL}${ADDITIONAL_CELLS} \
-    -mysql_server_port ${MYSQL_PORT} \
-    -mysql_server_socket_path ${VTROOT}/socket/gateway-%i.sock \
-    -grpc_port ${GRPC_PORT} \
-    -port ${VTGATE_PORT} \
-    -mysql_auth_server_impl none \
-    -topo_global_root ${TOPO_GLOBAL_ROOT} \
-    -topo_implementation ${TOPO_IMPLEMENTATION} \
-    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-    -log_dir ${VTROOT}/tmp/vtgate-%i \
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+		-service_map "grpc-vtgateservice" \
+		-alsologtostderr \
+		-enable_buffer \
+		-buffer_size=${VTGATE_BUFFER_SIZE} \
+		-buffer_max_failover_duration ${VTGATE_BUFFER_DURATION} \
+		-cell ${CELL} \
+		-cells_to_watch ${CELL}${ADDITIONAL_CELLS} \
+		-mysql_server_port ${MYSQL_PORT} \
+		-mysql_server_socket_path ${VTROOT}/socket/gateway-%i.sock \
+		-grpc_port ${GRPC_PORT} \
+		-port ${VTGATE_PORT} \
+		-mysql_auth_server_impl none \
+		-topo_global_root ${TOPO_GLOBAL_ROOT} \
+		-topo_implementation ${TOPO_IMPLEMENTATION} \
+		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+		-log_dir ${VTROOT}/tmp/vtgate-%i \
+	{% else %}
+		--service_map "grpc-vtgateservice" \
+		--alsologtostderr \
+		--enable_buffer \
+		--buffer_size=${VTGATE_BUFFER_SIZE} \
+		--buffer_max_failover_duration ${VTGATE_BUFFER_DURATION} \
+		--cell ${CELL} \
+		--cells_to_watch ${CELL}${ADDITIONAL_CELLS} \
+		--mysql_server_port ${MYSQL_PORT} \
+		--mysql_server_socket_path ${VTROOT}/socket/gateway-%i.sock \
+		--grpc_port ${GRPC_PORT} \
+		--port ${VTGATE_PORT} \
+		--mysql_auth_server_impl none \
+		--topo_global_root ${TOPO_GLOBAL_ROOT} \
+		--topo_implementation ${TOPO_IMPLEMENTATION} \
+		--topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+		--log_dir ${VTROOT}/tmp/vtgate-%i \
+	{% endif %}
     ${EXTRA_VTGATE_FLAGS}'
 
 [Install]

--- a/ansible/roles/vttablet/templates/mysqlctld@.service.j2
+++ b/ansible/roles/vttablet/templates/mysqlctld@.service.j2
@@ -6,7 +6,7 @@ After=network.service
 Environment="VTROOT={{ vitess_root }}"
 Environment="USER={{vitess_user}}"
 Environment="MYSQL_PORT={{vttablet_mysql_port}}"
-Environment="EXTRA_MYSQLCTLD_FLAGS=-alsologtostderr"
+Environment="EXTRA_MYSQLCTLD_FLAGS=--alsologtostderr"
 
 EnvironmentFile=/etc/vitess/conf/vttablet-%i.conf
 Type=simple

--- a/ansible/roles/vttablet/templates/vttablet.conf.j2
+++ b/ansible/roles/vttablet/templates/vttablet.conf.j2
@@ -24,7 +24,7 @@ MYSQLD_EXPORTER_PORT=:{{ tablet.mysqld_exporter_port | default(mysqld_exporter_p
 
 EXTRA_MY_CNF=/etc/vitess/extra_my{{ tablet.id | default('') }}.cnf
 
-EXTRA_VTTABLET_FLAGS="-alsologtostderr \
+EXTRA_VTTABLET_FLAGS="--alsologtostderr \
     --queryserver-config-max-result-size=100000 \
     --queryserver-config-pool-size={{ tablet.connection_pool_size | default(vttablet_connection_pool_size) }} \
     --queryserver-config-stream-pool-size={{ tablet.stream_pool_size | default(vttablet_stream_pool_size) }} \

--- a/ansible/roles/vttablet/templates/vttablet@.service.j2
+++ b/ansible/roles/vttablet/templates/vttablet@.service.j2
@@ -9,7 +9,7 @@ Environment="TABLET_TYPE={{ default_tablet_type }}"
 Environment="TABLET_PORT=16001"
 Environment="GRPC_PORT=17001"
 Environment="MYSQL_PORT=18001"
-Environment="EXTRA_VTTABLET_FLAGS=-alsologtostderr"
+Environment="EXTRA_VTTABLET_FLAGS=--alsologtostderr"
 
 EnvironmentFile=/etc/vitess/conf/vttablet-%i.conf
 Type=simple


### PR DESCRIPTION
This Pull Request changes the flag syntax used to create the different Vitess services. The syntax has changed in v14 to use `--flag` instead of `-flag`. In v15/main it is now mandatory, without the new syntax the benchmarks were failing.