### PR TITLE
Run all the microbenchmarks located in `./go/...`

### DIFF
--- a/ansible/microbench_inventory.yml
+++ b/ansible/microbench_inventory.yml
@@ -24,4 +24,4 @@ all:
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
     arewefastyet_git_version: "HEAD"
-    microbenchmarks_vitess_package: "./go/vt/..."
+    microbenchmarks_vitess_package: "./go/..."


### PR DESCRIPTION
This PR changes the scope of the microbenchmarks. Instead of running only on `./go/vt/...` they will now run on `./go/...`.