### PR TITLE
Add the OLTP-SET benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,10 +140,6 @@ cython_debug/
 # pyc extension
 *.pyc
 
-# Config files
-config/**/*.yaml
-!config/macro/*.yaml
-
 # hide config-lock.json
 config-lock.json
 
@@ -196,3 +192,5 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 arewefastyetcli
+
+config/**/secrets.yaml

--- a/ansible/macrobench_sharded_inventory.yml
+++ b/ansible/macrobench_sharded_inventory.yml
@@ -18,7 +18,7 @@ all:
         partition: nvme0n1p1
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
-    arewefastyet_git_version: "HEAD"
+    arewefastyet_git_version: "add-more-benchmarks"
     macrobenchmark_vschema_oltp: "./vitess-benchmark/sysbench.json"
     macrobenchmark_vschema_tpcc: "./vitess-benchmark/tpcc_vschema.json"
     cell: local

--- a/ansible/macrobench_sharded_inventory.yml
+++ b/ansible/macrobench_sharded_inventory.yml
@@ -18,7 +18,7 @@ all:
         partition: nvme0n1p1
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
-    arewefastyet_git_version: "add-more-benchmarks"
+    arewefastyet_git_version: "HEAD"
     macrobenchmark_vschema_oltp: "./vitess-benchmark/sysbench.json"
     macrobenchmark_vschema_tpcc: "./vitess-benchmark/tpcc_vschema.json"
     cell: local

--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -41,8 +41,14 @@
     dest: /tmp/config.yaml
     mode: '0644'
 
+- name: Get macrobenchmarks secrets.yaml
+  ansible.builtin.copy:
+    src: "{{ arewefastyet_secrets_file_path }}"
+    dest: /tmp/secrets.yaml
+    mode: '0644'
+
 - name: Run macrobenchmarks
   shell: |
-    arewefastyetcli macrobench run --config /tmp/config.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ vitess_planner_version }} --macrobench-vtgate-web-ports {{ vtgate_web_ports }}
+    arewefastyetcli macrobench run --config /tmp/config.yaml --secrets /tmp/secrets.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ vitess_planner_version }} --macrobench-vtgate-web-ports {{ vtgate_web_ports }}
   register: arewefastyetcli
   changed_when: False

--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -49,6 +49,6 @@
 
 - name: Run macrobenchmarks
   shell: |
-    arewefastyetcli macrobench run --config /tmp/config.yaml --secrets /tmp/secrets.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-source {{ arewefastyet_source }} --macrobench-vtgate-planner-version {{ vitess_planner_version }} --macrobench-vtgate-web-ports {{ vtgate_web_ports }}
+    arewefastyetcli macrobench run --config /tmp/config.yaml --secrets /tmp/secrets.yaml --macrobench-git-ref {{ vitess_git_version }} --macrobench-exec-uuid {{ arewefastyet_exec_uuid }} --macrobench-vtgate-planner-version {{ vitess_planner_version }} --macrobench-vtgate-web-ports {{ vtgate_web_ports }}
   register: arewefastyetcli
   changed_when: False

--- a/ansible/roles/microbench/tasks/main.yml
+++ b/ansible/roles/microbench/tasks/main.yml
@@ -50,9 +50,15 @@
     dest: /tmp/config.yaml
     mode: '0644'
 
+- name: Get microbenchmarks secrets.yaml
+  ansible.builtin.copy:
+    src: "{{ arewefastyet_secrets_file_path }}"
+    dest: /tmp/secrets.yaml
+    mode: '0644'
+
 - name: Run microbenchmarks
   shell: |
     cd /go/src/vitess.io/vitess
-    arewefastyetcli microbench run {{ microbenchmarks_vitess_package }} output.txt --config /tmp/config.yaml --microbench-exec-uuid {{ arewefastyet_exec_uuid }}
+    arewefastyetcli microbench run {{ microbenchmarks_vitess_package }} output.txt --config /tmp/config.yaml --secrets /tmp/secrets.yaml --microbench-exec-uuid {{ arewefastyet_exec_uuid }}
   register: arewefastyetcli
   changed_when: False

--- a/config/benchmarks/micro.yaml
+++ b/config/benchmarks/micro.yaml
@@ -1,0 +1,6 @@
+## Exec configuration
+exec-type: micro
+
+## Ansible
+ansible-inventory-files: microbench_inventory.yml
+ansible-playbook-files: microbench.yml

--- a/config/benchmarks/oltp-set.yaml
+++ b/config/benchmarks/oltp-set.yaml
@@ -1,0 +1,39 @@
+## Exec Config
+exec-type: oltp-set
+
+## Ansible
+ansible-inventory-files: macrobench_sharded_inventory.yml
+ansible-playbook-files: macrobench.yml
+
+## Macrobench cmd
+macrobench-sysbench-executable: /usr/local/bin/sysbench
+macrobench-workload-path: oltp_read_write_with_settings
+macrobench-skip-steps:
+macrobench-type: oltp-set
+
+## Sysbench all steps
+macrobench_all_mysql-db: main
+macrobench_all_mysql-host: 127.0.0.1
+macrobench_all_mysql-port: 13306
+macrobench_all_db-ps-mode: disable
+macrobench_all_db-driver: mysql
+macrobench_all_luajit-cmd: "off"
+macrobench_all_threads: 42
+macrobench_all_auto-inc: "off"
+macrobench_all_tables: 10
+macrobench_all_table_size: 10000
+macrobench_all_rand-type: uniform
+macrobench_all_rand-seed: 1
+
+## Sysbench prepare step
+macrobench_prepare_time: 60
+macrobench_prepare_report-interval: 10
+
+## Sysbench warm up step
+macrobench_warmup_time: 60
+macrobench_warmup_report-interval: 10
+
+## Sysbench run step
+macrobench_run_time: 600
+macrobench_run_report_json: true
+macrobench_run_verbosity: 0

--- a/config/benchmarks/oltp.yaml
+++ b/config/benchmarks/oltp.yaml
@@ -1,3 +1,16 @@
+## Exec Config
+exec-type: oltp
+
+## Ansible
+ansible-inventory-files: macrobench_sharded_inventory.yml
+ansible-playbook-files: macrobench.yml
+
+## Macrobench cmd
+macrobench-sysbench-executable: /usr/local/bin/sysbench
+macrobench-workload-path: oltp_read_write
+macrobench-skip-steps:
+macrobench-type: oltp
+
 ## Sysbench all steps
 macrobench_all_mysql-db: main
 macrobench_all_mysql-host: 127.0.0.1

--- a/config/benchmarks/tpcc.yaml
+++ b/config/benchmarks/tpcc.yaml
@@ -1,3 +1,17 @@
+## Exec configuration
+exec-type: tpcc
+
+## Ansible
+ansible-inventory-files: macrobench_sharded_inventory.yml
+ansible-playbook-files: macrobench.yml
+
+## Macrobench cmd
+macrobench-sysbench-executable: /usr/local/bin/sysbench
+macrobench-workload-path: /src/sysbench-tpcc/tpcc.lua
+macrobench-skip-steps:
+macrobench-type: tpcc
+macrobench-working-directory: /src/sysbench-tpcc
+
 ## Sysbench all steps
 macrobench_all_mysql-db: main
 macrobench_all_mysql-host: 127.0.0.1

--- a/config/dev/server.yaml
+++ b/config/dev/server.yaml
@@ -1,0 +1,16 @@
+exec-go-version: "1.18.5"
+
+web-port: 9090
+web-template-path: ./go/server/templates
+web-static-path: ./go/server/static
+web-benchmark-config-path: ./config/benchmarks/
+
+web-pr-label-trigger: '"Benchmark me"'
+web-pr-label-trigger-planner-v3: '"Benchmark me (V3)"'
+web-vitess-path: /tmp
+
+web-cron-schedule: "*/1 * * * *"
+web-cron-schedule-pull-requests: "*/1 * * * *"
+web-cron-schedule-tags: "none"
+
+ansible-root-directory: "./ansible/"

--- a/config/prod/server.yaml
+++ b/config/prod/server.yaml
@@ -1,0 +1,16 @@
+exec-go-version: "1.18.5"
+
+web-cron-schedule: "@midnight"
+web-cron-schedule-pull-requests: "*/5 * * * *"
+web-cron-schedule-tags: "*/1 * * * *"
+
+web-port: 8080
+web-template-path: /root/arewefastyet/go/server/templates
+web-static-path: /root/arewefastyet/go/server/static
+web-benchmark-config-path: /root/arewefastyet/config/benchmarks/
+
+
+web-pr-label-trigger: '"Benchmark me"'
+web-pr-label-trigger-planner-v3: '"Benchmark me (V3)"'
+
+ansible-root-directory: /root/arewefastyet/ansible/

--- a/docs/arewefastyet.md
+++ b/docs/arewefastyet.md
@@ -9,9 +9,10 @@ Vitess has to ensure it's delivering flawless performance to its users. In order
 ### Options
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
-  -h, --help            help for arewefastyet
-  -t, --toggle          Help message for toggle
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+  -h, --help             help for arewefastyet
+      --secrets string   secrets file
+  -t, --toggle           Help message for toggle
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -51,7 +51,8 @@ arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --pla
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_gen.md
+++ b/docs/arewefastyet_gen.md
@@ -15,7 +15,8 @@ Top level command to generate files like documentation and reports
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_gen_doc.md
+++ b/docs/arewefastyet_gen_doc.md
@@ -26,7 +26,8 @@ arewefastyet gen doc --doc-dir ./arewefastyet/docs
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_gen_exec_metrics.md
+++ b/docs/arewefastyet_gen_exec_metrics.md
@@ -26,7 +26,8 @@ arewefastyet gen exec_metrics [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_gen_report.md
+++ b/docs/arewefastyet_gen_report.md
@@ -39,7 +39,8 @@ arewefastyet gen report --compare-from sha1 --compare-to sha2 --report-file repo
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_macrobench.md
+++ b/docs/arewefastyet_macrobench.md
@@ -15,7 +15,8 @@ Top level command to manage macrobenchmarks
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -28,7 +28,6 @@ arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-
       --macrobench-exec-uuid string                UUID of the parent execution, an empty string will set to NULL.
       --macrobench-git-ref string                  Git SHA referring to the macro benchmark.
       --macrobench-skip-steps strings              Slice of sysbench steps to skip.
-      --macrobench-source string                   The source or origin of the macro benchmark trigger.
       --macrobench-sysbench-executable string      Path to the sysbench binary.
       --macrobench-type Type                       Type of macro benchmark.
       --macrobench-vtgate-planner-version string   Vtgate planner version running on Vitess
@@ -46,7 +45,8 @@ arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_microbench.md
+++ b/docs/arewefastyet_microbench.md
@@ -15,7 +15,8 @@ Top level command to manage microbenchmarks
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_microbench_run.md
+++ b/docs/arewefastyet_microbench_run.md
@@ -34,7 +34,8 @@ arewastyet microbenchmark run ~/vitess ./go/vt/sqlparser output.txt
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -33,13 +33,11 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
       --planetscale-db-user string               Username used to authenticate to PlanetscaleDB.
       --slack-channel string                     Slack channel on which to post messages
       --slack-token string                       Token used to authenticate Slack
+      --web-benchmark-config-path string         Path to the configuration file folder for the benchmarks.
       --web-cron-nb-retry int                    Number of retries allowed for each cron job. (default 1)
       --web-cron-schedule string                 Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON. (default "@midnight")
       --web-cron-schedule-pull-requests string   Execution CRON schedule for pull requests benchmarks. An empty string will result in no CRON. Defaults to an execution every 5 minutes. (default "*/5 * * * *")
       --web-cron-schedule-tags string            Execution CRON schedule for tags/releases benchmarks. An empty string will result in no CRON. Defaults to an execution every minute. (default "*/1 * * * *")
-      --web-macrobench-oltp-config string        Path to the configuration file used to execute OLTP macrobenchmark.
-      --web-macrobench-tpcc-config string        Path to the configuration file used to execute TPCC macrobenchmark.
-      --web-microbench-config string             Path to the configuration file used to execute microbenchmark.
       --web-mode string                          Specify the mode on which the server will run
       --web-port string                          Port used for the HTTP server (default "8080")
       --web-pr-label-trigger string              GitHub Pull Request label that will trigger the execution of new execution. (default "Benchmark me")
@@ -52,7 +50,8 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --config string    config file (default is $HOME/.config/arewefastyet/config.yaml)
+      --secrets string   secrets file
 ```
 
 ### SEE ALSO

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -32,7 +32,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
+var (
+	cfgFile     string
+	secretsFile string
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -55,6 +58,7 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/arewefastyet/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&secretsFile, "secrets", "", "secrets file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -88,6 +92,14 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			log.Println(err)
+			os.Exit(1)
+		}
+	}
+	if secretsFile != "" {
+		viper.SetConfigFile(secretsFile)
+		err := viper.MergeInConfig()
+		if err != nil {
 			log.Println(err)
 			os.Exit(1)
 		}

--- a/go/cmd/web/web.go
+++ b/go/cmd/web/web.go
@@ -38,6 +38,10 @@ It uses a MySQL and InfluxDB instances to read the metrics that will be displaye
 --web-webhook-config ./config.yaml`,
 		Aliases: []string{"w"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			err := srv.Init()
+			if err != nil {
+				return err
+			}
 			return srv.Run()
 		},
 	}

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -532,7 +532,7 @@ func GetLatestCronJobForMicrobenchmarks(client storage.SQLClient) (gitSha string
 // GetLatestCronJobForMacrobenchmarks will fetch and return the commit sha for which
 // the last cron job for macrobenchmarks was run
 func GetLatestCronJobForMacrobenchmarks(client storage.SQLClient) (gitSha string, err error) {
-	query := "select git_ref from execution where source = \"cron\" and status = \"finished\" and ( type = \"oltp\" or type = \"tpcc\" ) order by started_at desc limit 1"
+	query := "select git_ref from execution where source = \"cron\" and status = \"finished\" and ( type != \"micro\" ) order by started_at desc limit 1"
 	rows, err := client.Select(query)
 	if err != nil {
 		return "", err

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -319,7 +319,6 @@ func (e *Exec) prepareAnsibleForExecution() error {
 	}
 	e.AnsibleConfig.AddExtraVar(ansible.KeyBenchmarkSecretsPath, absSecretsPath)
 	e.AnsibleConfig.AddExtraVar(ansible.KeyExecUUID, e.UUID.String())
-	e.AnsibleConfig.AddExtraVar(ansible.KeyExecSource, e.Source)
 	e.AnsibleConfig.AddExtraVar(ansible.KeyExecutionType, e.TypeOf)
 
 	// vitess related values

--- a/go/infra/ansible/ansible.go
+++ b/go/infra/ansible/ansible.go
@@ -21,15 +21,16 @@ package ansible
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
+	"path"
+
 	"github.com/apenella/go-ansible/pkg/execute"
 	"github.com/apenella/go-ansible/pkg/options"
 	"github.com/apenella/go-ansible/pkg/playbook"
 	"github.com/otiai10/copy"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"path"
 )
 
 const (
@@ -73,9 +74,9 @@ func (c *Config) AddToViper(v *viper.Viper) {
 }
 
 func (c *Config) AddToPersistentCommand(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&c.RootDir, flagAnsibleRoot, "", "Root directory of Ansible")
-	cmd.PersistentFlags().StringSliceVar(&c.InventoryFiles, flagInventoryFiles, []string{}, "List of inventory files used by Ansible")
-	cmd.PersistentFlags().StringSliceVar(&c.PlaybookFiles, flagPlaybookFiles, []string{}, "List of playbook files used by Ansible")
+	cmd.Flags().StringVar(&c.RootDir, flagAnsibleRoot, "", "Root directory of Ansible")
+	cmd.Flags().StringSliceVar(&c.InventoryFiles, flagInventoryFiles, []string{}, "List of inventory files used by Ansible")
+	cmd.Flags().StringSliceVar(&c.PlaybookFiles, flagPlaybookFiles, []string{}, "List of playbook files used by Ansible")
 
 	_ = viper.BindPFlag(flagAnsibleRoot, cmd.Flags().Lookup(flagAnsibleRoot))
 	_ = viper.BindPFlag(flagInventoryFiles, cmd.Flags().Lookup(flagInventoryFiles))

--- a/go/infra/ansible/vars.go
+++ b/go/infra/ansible/vars.go
@@ -33,10 +33,6 @@ const (
 	// current benchmark.
 	KeyExecUUID = "arewefastyet_exec_uuid"
 
-	// KeyExecSource corresponding value in the map is the source (the name) of
-	// trigger that triggered this benchmark.
-	KeyExecSource = "arewefastyet_source"
-
 	// KeyExecutionType corresponding value in the map is the type of execution for
 	// this benchmark.
 	KeyExecutionType = "arewefastyet_execution_type"

--- a/go/infra/ansible/vars.go
+++ b/go/infra/ansible/vars.go
@@ -46,6 +46,11 @@ const (
 	// server.
 	KeyBenchmarkConfigPath = "arewefastyet_configuration_file_path"
 
+	// KeyBenchmarkSecretsPath corresponding value in the map is the path to the secrets
+	// file that will be used to execute the benchmark by arewefastyet inside the benchmarking
+	// server.
+	KeyBenchmarkSecretsPath = "arewefastyet_secrets_file_path"
+
 	// Vitess related keys
 
 	// KeyVitessVersion corresponding value in the map is the git reference of SHA

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -19,6 +19,7 @@
 package server
 
 import (
+	"path"
 	"sync"
 	"time"
 
@@ -96,9 +97,9 @@ func (s *Server) createCrons() error {
 
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
-		"micro": s.microbenchConfigPath,
-		"oltp":  s.macrobenchConfigPathOLTP,
-		"tpcc":  s.macrobenchConfigPathTPCC,
+		"micro": path.Join(s.benchmarkConfigPath, "micro.yaml"),
+		"oltp":  path.Join(s.benchmarkConfigPath, "oltp.yaml"),
+		"tpcc":  path.Join(s.benchmarkConfigPath, "tpcc.yaml"),
 	}
 	return configs
 }

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -19,7 +19,6 @@
 package server
 
 import (
-	"path"
 	"sync"
 	"time"
 
@@ -96,13 +95,7 @@ func (s *Server) createCrons() error {
 }
 
 func (s *Server) getConfigFiles() map[string]string {
-	configs := map[string]string{
-		// "micro":    path.Join(s.benchmarkConfigPath, "micro.yaml"),
-		// "oltp":     path.Join(s.benchmarkConfigPath, "oltp.yaml"),
-		"oltp-set": path.Join(s.benchmarkConfigPath, "oltp-set.yaml"),
-		// "tpcc":     path.Join(s.benchmarkConfigPath, "tpcc.yaml"),
-	}
-	return configs
+	return s.benchmarkConfig
 }
 
 func (s *Server) addToQueue(element *executionQueueElement) {

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -97,9 +97,10 @@ func (s *Server) createCrons() error {
 
 func (s *Server) getConfigFiles() map[string]string {
 	configs := map[string]string{
-		"micro": path.Join(s.benchmarkConfigPath, "micro.yaml"),
-		"oltp":  path.Join(s.benchmarkConfigPath, "oltp.yaml"),
-		"tpcc":  path.Join(s.benchmarkConfigPath, "tpcc.yaml"),
+		// "micro":    path.Join(s.benchmarkConfigPath, "micro.yaml"),
+		// "oltp":     path.Join(s.benchmarkConfigPath, "oltp.yaml"),
+		"oltp-set": path.Join(s.benchmarkConfigPath, "oltp-set.yaml"),
+		// "tpcc":     path.Join(s.benchmarkConfigPath, "tpcc.yaml"),
 	}
 	return configs
 }

--- a/go/server/handlers.go
+++ b/go/server/handlers.go
@@ -130,7 +130,7 @@ func (s *Server) compareHandler(c *gin.Context) {
 	}
 
 	// Compare Macrobenchmarks for the two given SHAs.
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, reference, compare, planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, reference, compare, planner, s.benchmarkTypes)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -162,7 +162,7 @@ func (s *Server) searchHandler(c *gin.Context) {
 		return
 	}
 
-	macros, err := macrobench.GetDetailsArraysFromAllTypes(search, planner, s.dbClient)
+	macros, err := macrobench.GetDetailsArraysFromAllTypes(search, planner, s.dbClient, s.benchmarkTypes)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -369,7 +369,7 @@ func (s *Server) macrobenchmarkResultsHandler(c *gin.Context) {
 	}
 
 	// Compare Macrobenchmarks for the two given SHAs.
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, rightSHA, leftSHA, planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, rightSHA, leftSHA, planner, s.benchmarkTypes)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return
@@ -509,7 +509,7 @@ func (s *Server) v3VsGen4Handler(c *gin.Context) {
 	}
 
 	// Compare Macrobenchmarks for the two planners for the given SHA.
-	macrosMatrices, err := macrobench.ComparePlanners(s.dbClient, sha)
+	macrosMatrices, err := macrobench.ComparePlanners(s.dbClient, sha, s.benchmarkTypes)
 	if err != nil {
 		handleRenderErrors(c, err)
 		return

--- a/go/server/notification.go
+++ b/go/server/notification.go
@@ -59,12 +59,12 @@ func (s *Server) sendNotificationForRegression(leftSource, rightSource, leftRef,
 			return err
 		}
 	} else if benchmarkType == "oltp" || benchmarkType == "tpcc" {
-		macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, leftRef, rightRef, macrobench.PlannerVersion(plannerVersion))
+		macrosMatrices, err := macrobench.CompareMacroBenchmarks(s.dbClient, leftRef, rightRef, macrobench.PlannerVersion(plannerVersion), s.benchmarkTypes)
 		if err != nil {
 			return err
 		}
 
-		macroResults := macrosMatrices[macrobench.Type(benchmarkType)].(macrobench.ComparisonArray)
+		macroResults := macrosMatrices[benchmarkType].(macrobench.ComparisonArray)
 		if len(macroResults) == 0 {
 			return fmt.Errorf("no macrobenchmark result")
 		}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -125,6 +125,10 @@ func (s *Server) isReady() bool {
 }
 
 func (s *Server) Init() error {
+	if !s.isReady() {
+		return errors.New(ErrorIncorrectConfiguration)
+	}
+
 	if s.Mode != "" && !s.Mode.correct() {
 		return errors.New(ErrorIncorrectMode)
 	} else if s.Mode == "" {
@@ -153,7 +157,7 @@ func (s *Server) Init() error {
 		"oltp-set": path.Join(s.benchmarkConfigPath, "oltp-set.yaml"),
 		"tpcc":     path.Join(s.benchmarkConfigPath, "tpcc.yaml"),
 	}
-	for configName, _ := range s.benchmarkConfig {
+	for configName := range s.benchmarkConfig {
 		if configName == "micro" {
 			continue
 		}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -20,12 +20,13 @@ package server
 
 import (
 	"errors"
-	"github.com/google/uuid"
-	"github.com/vitessio/arewefastyet/go/slack"
-	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"html/template"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/vitessio/arewefastyet/go/slack"
+	"github.com/vitessio/arewefastyet/go/storage/psdb"
 
 	"github.com/dustin/go-humanize"
 	"github.com/gin-gonic/gin"
@@ -41,15 +42,13 @@ const (
 	flagStaticPath                           = "web-static-path"
 	flagVitessPath                           = "web-vitess-path"
 	flagMode                                 = "web-mode"
-	flagMicroBenchConfigFile                 = "web-microbench-config"
-	flagMacroBenchConfigFileOLTP             = "web-macrobench-oltp-config"
-	flagMacroBenchConfigFileTPCC             = "web-macrobench-tpcc-config"
 	flagCronSchedule                         = "web-cron-schedule"
 	flagCronSchedulePullRequests             = "web-cron-schedule-pull-requests"
 	flagCronScheduleTags                     = "web-cron-schedule-tags"
 	flagPullRequestLabelTrigger              = "web-pr-label-trigger"
 	flagPullRequestLabelTriggerWithPlannerV3 = "web-pr-label-trigger-planner-v3"
 	flagCronNbRetry                          = "web-cron-nb-retry"
+	flagBenchmarkConfigPath                  = "web-benchmark-config-path"
 )
 
 type Server struct {
@@ -71,9 +70,8 @@ type Server struct {
 	cronSchedulePullRequests string
 	cronScheduleTags         string
 	cronNbRetry              int
-	microbenchConfigPath     string
-	macrobenchConfigPathOLTP string
-	macrobenchConfigPathTPCC string
+
+	benchmarkConfigPath string
 
 	prLabelTrigger   string
 	prLabelTriggerV3 string
@@ -90,9 +88,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().Var(&s.Mode, flagMode, "Specify the mode on which the server will run")
 
 	// execution configuration flags
-	cmd.Flags().StringVar(&s.microbenchConfigPath, flagMicroBenchConfigFile, "", "Path to the configuration file used to execute microbenchmark.")
-	cmd.Flags().StringVar(&s.macrobenchConfigPathOLTP, flagMacroBenchConfigFileOLTP, "", "Path to the configuration file used to execute OLTP macrobenchmark.")
-	cmd.Flags().StringVar(&s.macrobenchConfigPathTPCC, flagMacroBenchConfigFileTPCC, "", "Path to the configuration file used to execute TPCC macrobenchmark.")
+	cmd.Flags().StringVar(&s.benchmarkConfigPath, flagBenchmarkConfigPath, "", "Path to the configuration file folder for the benchmarks.")
 	cmd.Flags().StringVar(&s.cronSchedule, flagCronSchedule, "@midnight", "Execution CRON schedule defaults to every day at midnight. An empty string will result in no CRON.")
 	cmd.Flags().StringVar(&s.cronSchedulePullRequests, flagCronSchedulePullRequests, "*/5 * * * *", "Execution CRON schedule for pull requests benchmarks. An empty string will result in no CRON. Defaults to an execution every 5 minutes.")
 	cmd.Flags().StringVar(&s.cronScheduleTags, flagCronScheduleTags, "*/1 * * * *", "Execution CRON schedule for tags/releases benchmarks. An empty string will result in no CRON. Defaults to an execution every minute.")
@@ -105,9 +101,6 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagStaticPath, cmd.Flags().Lookup(flagStaticPath))
 	_ = viper.BindPFlag(flagVitessPath, cmd.Flags().Lookup(flagVitessPath))
 	_ = viper.BindPFlag(flagMode, cmd.Flags().Lookup(flagMode))
-	_ = viper.BindPFlag(flagMicroBenchConfigFile, cmd.Flags().Lookup(flagMicroBenchConfigFile))
-	_ = viper.BindPFlag(flagMacroBenchConfigFileOLTP, cmd.Flags().Lookup(flagMacroBenchConfigFileOLTP))
-	_ = viper.BindPFlag(flagMacroBenchConfigFileTPCC, cmd.Flags().Lookup(flagMacroBenchConfigFileTPCC))
 	_ = viper.BindPFlag(flagCronSchedule, cmd.Flags().Lookup(flagCronSchedule))
 	_ = viper.BindPFlag(flagCronSchedulePullRequests, cmd.Flags().Lookup(flagCronSchedulePullRequests))
 	_ = viper.BindPFlag(flagCronScheduleTags, cmd.Flags().Lookup(flagCronScheduleTags))
@@ -241,13 +234,10 @@ func (s *Server) prepareGin() {
 
 func Run(port, templatePath, staticPath, localVitessPath string) error {
 	s := Server{
-		port:                     port,
-		templatePath:             templatePath,
-		staticPath:               staticPath,
-		localVitessPath:          localVitessPath,
-		microbenchConfigPath:     "/",
-		macrobenchConfigPathOLTP: "/",
-		macrobenchConfigPathTPCC: "/",
+		port:            port,
+		templatePath:    templatePath,
+		staticPath:      staticPath,
+		localVitessPath: localVitessPath,
 	}
 	return s.Run()
 }

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -85,7 +85,7 @@ func TestServer_isReady(t *testing.T) {
 		s    *Server
 		want bool
 	}{
-		{name: "Server fully ready", s: &Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/", microbenchConfigPath: "micro/config.yaml", macrobenchConfigPathOLTP: "oltp/config.yaml", macrobenchConfigPathTPCC: "tpcc/config.yaml"}, want: true},
+		{name: "Server fully ready", s: &Server{port: "8080", templatePath: "./", staticPath: "./", localVitessPath: "~/"}, want: true},
 		{name: "Missing port", s: &Server{templatePath: "./", staticPath: "./", localVitessPath: "~/"}},
 		{name: "Missing template path", s: &Server{port: "8888", staticPath: "./", localVitessPath: "~/"}},
 		{name: "Missing static path", s: &Server{port: "9999", templatePath: "./", localVitessPath: "~/"}},

--- a/go/server/templates/compare.tmpl
+++ b/go/server/templates/compare.tmpl
@@ -54,7 +54,7 @@ limitations under the License.
                 {{ if .macrobenchmark }}
                     {{ range $key, $val := .macrobenchmark }}
 
-                    <h4>{{ $key.ToUpper }}</h4>
+                    <h4>{{ $key }}</h4>
                     {{ if $val }}
                     <table class="table table-striped table-hover table-sm table-bordered" >
                         <thead>
@@ -161,7 +161,7 @@ limitations under the License.
                     <canvas id="{{$key}}-bar-chart" height="75"></canvas>
                     {{ else if not $val }}
                         <div class="alert alert-warning" role="alert">
-                            No {{ $key.ToUpper }} macro benchmark results. You can <a href="/request_benchmark?s=[{{$referenceSHAs.SHA}},{{ $compareSHAs.SHA }}]&type=macrobench-{{$key}}">request</a> a run.
+                            No {{ $key }} macro benchmark results. You can <a href="/request_benchmark?s=[{{$referenceSHAs.SHA}},{{ $compareSHAs.SHA }}]&type=macrobench-{{$key}}">request</a> a run.
                         </div>
                     {{ end }}
                 {{ end }}

--- a/go/server/templates/macrobench.tmpl
+++ b/go/server/templates/macrobench.tmpl
@@ -71,7 +71,7 @@ limitations under the License.
         {{ range $key, $val := .macrobenchmark }}
 
         <div class="card rounded mb-3">
-            <h4 class="card-header">{{ $key.ToUpper }}</h4>
+            <h4 class="card-header">{{ $key }}</h4>
             <div class="card-body">
             {{ if $val }}
                 <p class="lead">Click <a href="/macrobench/queries/compare?left={{$leftSHA}}&right={{$rightSHA}}&type={{$key}}">here</a> to see the query plans comparison for this benchmark.</p>
@@ -182,7 +182,7 @@ limitations under the License.
                 <canvas id="{{$key}}-bar-chart" height="75"></canvas>
             {{ else if not $val }}
                 <div class="alert alert-warning" role="alert">
-                    No {{ $key.ToUpper }} macro benchmark results. You can <a href="/request_benchmark?s=[{{$.rightSHA}},{{ $.leftSHA }}]&type=macrobench-{{$key}}">request</a> a run.
+                    No {{ $key }} macro benchmark results. You can <a href="/request_benchmark?s=[{{$.rightSHA}},{{ $.leftSHA }}]&type=macrobench-{{$key}}">request</a> a run.
                 </div>
             {{ end }}
             </div>

--- a/go/server/templates/search.tmpl
+++ b/go/server/templates/search.tmpl
@@ -53,7 +53,7 @@ limitations under the License.
                 <h3>Macro benchmarks</h3>
                 {{ if .macrobenchmark }}
                     {{ range $key, $val := .macrobenchmark }}
-                        <h4>{{ $key.ToUpper }}</h4>
+                        <h4>{{ $key }}</h4>
                         <h5>Sysbench</h5>
                         <table class="table table-striped table-hover table-sm table-bordered">
                             <thead>

--- a/go/server/templates/v3VsGen4.tmpl
+++ b/go/server/templates/v3VsGen4.tmpl
@@ -60,7 +60,7 @@ limitations under the License.
         {{ range $key, $val := .macrobenchmark }}
 
         <div class="card rounded mb-3">
-            <h4 class="card-header">{{ $key.ToUpper }}</h4>
+            <h4 class="card-header">{{ $key }}</h4>
             <div class="card-body">
             {{ if $val }}
                 <p class="lead">Click <a href="/macrobench/queries/compare?left={{$sha}}&right={{$sha}}&type={{$key}}&left_planner=V3&right_planner=Gen4Fallback">here</a> to see the query plans comparison for this benchmark.</p>
@@ -169,7 +169,7 @@ limitations under the License.
                 <canvas id="{{$key}}-bar-chart" height="75"></canvas>
                 {{ else if not $val }}
                 <div class="alert alert-warning" role="alert">
-                    No {{ $key.ToUpper }} macro benchmark results. You can <a href="/request_benchmark?s=[{{$.sha}}]&type=macrobench-{{$key}}">request</a> a run.
+                    No {{ $key }} macro benchmark results. You can <a href="/request_benchmark?s=[{{$.sha}}]&type=macrobench-{{$key}}">request</a> a run.
                 </div>
                 {{ end }}
             </div>

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -142,7 +142,7 @@ func (mabcfg Config) insertBenchmarkToSQL(client storage.SQLClient) (newMacroBen
 	if client == nil {
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}
-	query := "INSERT INTO macrobenchmark(exec_uuid, commit, vtgate_planner_version, type) VALUES(NULLIF(?, ''), ?, ?, ?, ?)"
+	query := "INSERT INTO macrobenchmark(exec_uuid, commit, vtgate_planner_version, type) VALUES(NULLIF(?, ''), ?, ?, ?)"
 	res, err := client.Insert(query, mabcfg.execUUID, mabcfg.GitRef, mabcfg.VtgatePlannerVersion, mabcfg.Type.ToUpper().String())
 	if err != nil {
 		return 0, err

--- a/go/tools/macrobench/endtoend/compare_test.go
+++ b/go/tools/macrobench/endtoend/compare_test.go
@@ -19,14 +19,15 @@
 package endtoend
 
 import (
+	"log"
+	"os"
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/viper"
 	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"github.com/vitessio/arewefastyet/go/tools/macrobench"
-	"log"
-	"os"
-	"testing"
 )
 
 var (
@@ -85,7 +86,7 @@ func TestCompareMacroBenchmark(t *testing.T) {
 	if skip != "" {
 		c.Skip(skip)
 	}
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner, nil)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -101,7 +102,7 @@ func BenchmarkCompareMacroBenchmark(b *testing.B) {
 		}
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, reference, compare, planner)
+			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, reference, compare, planner, nil)
 			if err != nil {
 				c.Fatal(err)
 			}

--- a/go/tools/macrobench/endtoend/compare_test.go
+++ b/go/tools/macrobench/endtoend/compare_test.go
@@ -86,11 +86,12 @@ func TestCompareMacroBenchmark(t *testing.T) {
 	if skip != "" {
 		c.Skip(skip)
 	}
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner, nil)
+	types := []string{"OLTP", "TPCC"}
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, "dff8d632908583cae5940b25a962eaa2e6550508", "f7304cd1893accfefee0525910098a8e0e68deec", macrobench.V3Planner, types)
 	if err != nil {
 		c.Fatal(err)
 	}
-	c.Assert(macrosMatrices, qt.HasLen, len(macrobench.Types))
+	c.Assert(macrosMatrices, qt.HasLen, len(types))
 }
 
 func BenchmarkCompareMacroBenchmark(b *testing.B) {
@@ -101,12 +102,13 @@ func BenchmarkCompareMacroBenchmark(b *testing.B) {
 			c.Skip(skip)
 		}
 		b.ReportAllocs()
+		types := []string{"OLTP", "TPCC"}
 		for i := 0; i < b.N; i++ {
-			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, reference, compare, planner, nil)
+			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, reference, compare, planner, types)
 			if err != nil {
 				c.Fatal(err)
 			}
-			c.Assert(macrosMatrices, qt.HasLen, len(macrobench.Types))
+			c.Assert(macrosMatrices, qt.HasLen, len(types))
 		}
 	}
 

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -144,7 +144,7 @@ func Run(mabcfg Config) error {
 }
 
 func handleResults(mabcfg Config, resStr []byte, sqlClient *psdb.Client, metricsClient *influxdb.Client, macrobenchID int) error {
-	err := handleSysBenchResults(resStr, sqlClient, mabcfg.Type, macrobenchID)
+	err := handleSysBenchResults(resStr, sqlClient, macrobenchID)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func handleMetricsResults(client *influxdb.Client, sqlClient *psdb.Client, execU
 	return nil
 }
 
-func handleSysBenchResults(resStr []byte, sqlClient *psdb.Client, macrobenchType Type, macrobenchID int) error {
+func handleSysBenchResults(resStr []byte, sqlClient *psdb.Client, macrobenchID int) error {
 	// Parse results
 	var results []Result
 	err := json.Unmarshal(resStr, &results)
@@ -212,7 +212,7 @@ func handleSysBenchResults(resStr []byte, sqlClient *psdb.Client, macrobenchType
 
 	// Save results
 	if sqlClient != nil {
-		err = results[0].insertToMySQL(macrobenchType, macrobenchID, sqlClient)
+		err = results[0].insertToMySQL(macrobenchID, sqlClient)
 		if err != nil {
 			return err
 		}

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/vitessio/arewefastyet/go/storage"
@@ -252,9 +253,9 @@ func (qps QPS) OtherStr() string {
 }
 
 // GetDetailsArraysFromAllTypes returns a slice of Details based on the given git ref and Types.
-func GetDetailsArraysFromAllTypes(sha string, planner PlannerVersion, dbclient storage.SQLClient) (map[Type]DetailsArray, error) {
-	macros := map[Type]DetailsArray{}
-	for _, mtype := range Types {
+func GetDetailsArraysFromAllTypes(sha string, planner PlannerVersion, dbclient storage.SQLClient, types []string) (map[string]DetailsArray, error) {
+	macros := map[string]DetailsArray{}
+	for _, mtype := range types {
 		macro, err := GetResultsForGitRefAndPlanner(mtype, sha, planner, dbclient)
 		if err != nil {
 			return nil, err
@@ -305,8 +306,8 @@ func GetResultsForLastDays(macroType Type, source string, planner PlannerVersion
 
 // GetResultsForGitRefAndPlanner returns a slice of Details based on the given git ref
 // and macro benchmark Type.
-func GetResultsForGitRefAndPlanner(macroType Type, ref string, planner PlannerVersion, client storage.SQLClient) (macrodetails DetailsArray, err error) {
-	upperMacroType := macroType.ToUpper().String()
+func GetResultsForGitRefAndPlanner(macroType string, ref string, planner PlannerVersion, client storage.SQLClient) (macrodetails DetailsArray, err error) {
+	upperMacroType := strings.ToUpper(macroType)
 	query := "SELECT info.macrobenchmark_id, e.git_ref, e.source, e.finished_at, IFNULL(info.exec_uuid, ''), " +
 		"results.tps, results.latency, results.errors, results.reconnects, results.time, results.threads, " +
 		"results.total_qps, results.reads_qps, results.writes_qps, results.other_qps " +

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -278,7 +278,7 @@ func GetDetailsArraysFromAllTypes(sha string, planner PlannerVersion, dbclient s
 // the *mysql.Client. The query will select only results that were added between now and lastDays.
 func GetResultsForLastDays(macroType Type, source string, planner PlannerVersion, lastDays int, client storage.SQLClient) (macrodetails DetailsArray, err error) {
 	upperMacroType := macroType.ToUpper().String()
-	query := "SELECT info.macrobenchmark_id, info.commit, info.source, info.DateTime, IFNULL(info.exec_uuid, ''), " +
+	query := "SELECT info.macrobenchmark_id, e.git_ref, e.source, e.finished_at, IFNULL(e.uuid, ''), " +
 		"results.tps, results.latency, results.errors, results.reconnects, results.time, results.threads, " +
 		"results.total_qps, results.reads_qps, results.writes_qps, results.other_qps " +
 		"FROM execution AS e, macrobenchmark AS info, macrobenchmark_results AS results " +
@@ -307,7 +307,7 @@ func GetResultsForLastDays(macroType Type, source string, planner PlannerVersion
 // and macro benchmark Type.
 func GetResultsForGitRefAndPlanner(macroType Type, ref string, planner PlannerVersion, client storage.SQLClient) (macrodetails DetailsArray, err error) {
 	upperMacroType := macroType.ToUpper().String()
-	query := "SELECT info.macrobenchmark_id, info.commit, info.source, info.DateTime, IFNULL(info.exec_uuid, ''), " +
+	query := "SELECT info.macrobenchmark_id, e.git_ref, e.source, e.finished_at, IFNULL(info.exec_uuid, ''), " +
 		"results.tps, results.latency, results.errors, results.reconnects, results.time, results.threads, " +
 		"results.total_qps, results.reads_qps, results.writes_qps, results.other_qps " +
 		"FROM execution AS e, macrobenchmark AS info, macrobenchmark_results AS results " +

--- a/go/tools/macrobench/types.go
+++ b/go/tools/macrobench/types.go
@@ -29,14 +29,15 @@ type (
 )
 
 const (
-	OLTP = Type("oltp")
-	TPCC = Type("tpcc")
+	OLTP    = Type("oltp")
+	OLTPSet = Type("oltp-set")
+	TPCC    = Type("tpcc")
 
 	IncorrectMacroBenchmarkType = "incorrect macrobenchmark type"
 )
 
 // Types lists all the macro benchmark types.
-var Types = []Type{OLTP, TPCC}
+var Types = []Type{OLTP, OLTPSet, TPCC}
 
 // Type implements Cobra flag.Value interface.
 func (mbtype *Type) Type() string {

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -17,9 +17,10 @@ limitations under the License.
 package report
 
 import (
-	"github.com/vitessio/arewefastyet/go/storage"
 	"strconv"
 	"strings"
+
+	"github.com/vitessio/arewefastyet/go/storage"
 
 	"github.com/vitessio/arewefastyet/go/storage/influxdb"
 
@@ -74,7 +75,7 @@ type tableCell struct {
 // to read the results. It also takes as an argument the name of the report that will be generated
 func GenerateCompareReport(client storage.SQLClient, metricsClient *influxdb.Client, fromSHA, toSHA, reportFile string) error {
 	// Compare macrobenchmark results for the 2 SHAs
-	macrosMatrices, err := macrobench.CompareMacroBenchmarks(client, fromSHA, toSHA, macrobench.V3Planner)
+	macrosMatrices, err := macrobench.CompareMacroBenchmarks(client, fromSHA, toSHA, macrobench.V3Planner, nil)
 	if err != nil {
 		return err
 	}
@@ -114,7 +115,7 @@ func GenerateCompareReport(client storage.SQLClient, metricsClient *influxdb.Cli
 			macroCompArr := value.(macrobench.ComparisonArray)
 			if len(macroCompArr) > 0 {
 				macroComp := macroCompArr[0]
-				macroTable = append(macroTable, []tableCell{{value: strings.ToUpper(key.String()), styleIndex: 2}})
+				macroTable = append(macroTable, []tableCell{{value: strings.ToUpper(key), styleIndex: 2}})
 				macroTable = append(macroTable, []tableCell{{value: "TPS", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.TPS), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.TPS), styleIndex: 1}})
 				macroTable = append(macroTable, []tableCell{{value: "QPS Reads", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.QPS.Reads), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.QPS.Reads), styleIndex: 1}})
 				macroTable = append(macroTable, []tableCell{{value: "QPS Writes", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.QPS.Writes), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.QPS.Writes), styleIndex: 1}})


### PR DESCRIPTION
This PR refactors how we deal with multiple benchmarks. It is now possible to easily add a new macro benchmark.

The OLTP-SET benchmark is also added.