### PR TITLE
enable settings pool for oltp-set benchmark

### DIFF
--- a/config/benchmarks/oltp-set.yaml
+++ b/config/benchmarks/oltp-set.yaml
@@ -37,3 +37,8 @@ macrobench_warmup_report-interval: 10
 macrobench_run_time: 600
 macrobench_run_report_json: true
 macrobench_run_verbosity: 0
+
+# Vitess Extra Flags
+exec-vitess-config:
+  15: # will match >= v15.0.0 and override the flags defined in < 15.0.0
+    vttablet: --queryserver-enable-settings-pool=true


### PR DESCRIPTION
This PR enables settings pool for oltp-set benchmark for 15.0 onwards 