### PR TITLE
Addition of a flag to exclude some source from the crons

### DIFF
--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -8,6 +8,7 @@ web-benchmark-config-path: ./config/benchmarks/
 web-pr-label-trigger: '"Benchmark me"'
 web-pr-label-trigger-planner-v3: '"Benchmark me (V3)"'
 web-vitess-path: /tmp
+web-source-exclude-filter: "cron_tags_14.0.0-rc1"
 
 web-cron-schedule: "*/1 * * * *"
 web-cron-schedule-pull-requests: "*/1 * * * *"

--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -8,7 +8,7 @@ web-port: 8080
 web-template-path: /root/arewefastyet/go/server/templates
 web-static-path: /root/arewefastyet/go/server/static
 web-benchmark-config-path: /root/arewefastyet/config/benchmarks/
-
+web-source-exclude-filter: "cron_tags_14.0.0-rc1"
 
 web-pr-label-trigger: '"Benchmark me"'
 web-pr-label-trigger-planner-v3: '"Benchmark me (V3)"'

--- a/docs/arewefastyet_web.md
+++ b/docs/arewefastyet_web.md
@@ -42,6 +42,7 @@ arewefastyet web --db-database benchmark --db-host localhost --db-password <db-p
       --web-port string                          Port used for the HTTP server (default "8080")
       --web-pr-label-trigger string              GitHub Pull Request label that will trigger the execution of new execution. (default "Benchmark me")
       --web-pr-label-trigger-planner-v3 string   GitHub Pull Request label that will trigger the execution of new execution using the V3 planner. (default "Benchmark me (V3)")
+      --web-source-exclude-filter strings        List of execution source to not execute. By default, all sources are ran.
       --web-source-filter strings                List of execution source that should be run. By default, all sources are ran.
       --web-static-path string                   Path to the static directory
       --web-template-path string                 Path to the template directory

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -110,6 +110,9 @@ func (s *Server) addToQueue(element *executionQueueElement) {
 	if len(s.sourceFilter) > 0 && !slices.Contains(s.sourceFilter, element.identifier.Source) {
 		return
 	}
+	if len(s.excludeSourceFilter) > 0 && slices.Contains(s.excludeSourceFilter, element.identifier.Source) {
+		return
+	}
 
 	_, found := queue[element.identifier]
 

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -52,6 +52,7 @@ const (
 	flagCronNbRetry                          = "web-cron-nb-retry"
 	flagBenchmarkConfigPath                  = "web-benchmark-config-path"
 	flagFilterBySource                       = "web-source-filter"
+	flagExcludeFilterBySource                = "web-source-exclude-filter"
 )
 
 type Server struct {
@@ -82,7 +83,8 @@ type Server struct {
 	benchmarkConfig map[string]string
 	benchmarkTypes  []string
 
-	sourceFilter []string
+	sourceFilter        []string
+	excludeSourceFilter []string
 
 	// Mode used to run the server.
 	Mode
@@ -104,6 +106,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.prLabelTrigger, flagPullRequestLabelTrigger, "Benchmark me", "GitHub Pull Request label that will trigger the execution of new execution.")
 	cmd.Flags().StringVar(&s.prLabelTriggerV3, flagPullRequestLabelTriggerWithPlannerV3, "Benchmark me (V3)", "GitHub Pull Request label that will trigger the execution of new execution using the V3 planner.")
 	cmd.Flags().StringSliceVar(&s.sourceFilter, flagFilterBySource, nil, "List of execution source that should be run. By default, all sources are ran.")
+	cmd.Flags().StringSliceVar(&s.excludeSourceFilter, flagExcludeFilterBySource, nil, "List of execution source to not execute. By default, all sources are ran.")
 
 	_ = viper.BindPFlag(flagPort, cmd.Flags().Lookup(flagPort))
 	_ = viper.BindPFlag(flagTemplatePath, cmd.Flags().Lookup(flagTemplatePath))
@@ -117,6 +120,7 @@ func (s *Server) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagPullRequestLabelTrigger, cmd.Flags().Lookup(flagPullRequestLabelTrigger))
 	_ = viper.BindPFlag(flagPullRequestLabelTriggerWithPlannerV3, cmd.Flags().Lookup(flagPullRequestLabelTriggerWithPlannerV3))
 	_ = viper.BindPFlag(flagFilterBySource, cmd.Flags().Lookup(flagFilterBySource))
+	_ = viper.BindPFlag(flagExcludeFilterBySource, cmd.Flags().Lookup(flagExcludeFilterBySource))
 
 	s.slackConfig.AddToCommand(cmd)
 	if s.dbCfg == nil {


### PR DESCRIPTION
This PR adds a new flag to the server to exclude certain sources from the list of benchmarks we execute in the cron. `"cron_tags_14.0.0-rc1"` is removed as it does not build due to incorrect flags.