### PR TITLE
Set the golang bin path when deploying new changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
           script: |
+            export PATH=/usr/local/go/bin:$PATH
             cd $HOME/arewefastyet
             git reset --hard FETCH_HEAD
             git clean -fd


### PR DESCRIPTION
This PR fixes an issue that happens when trying to deploy new changes with the deploy workflow. The issue can be seen in https://github.com/vitessio/arewefastyet/actions/runs/3141082170/jobs/5103135373, the go build command fails because the go binary cannot be located.