### PR TITLE
Improve the cleaning phase of vttablet and vtctld

### DIFF
--- a/ansible/roles/vitess_build/tasks/main.yml
+++ b/ansible/roles/vitess_build/tasks/main.yml
@@ -37,6 +37,10 @@
         cd /go/src/vitess.io/vitess
         make build
 
+    - name: Remove Vitess binaries
+      shell: |
+        rm -f /usr/local/bin/vt*
+
     - name: Install Vitess Binaries
       shell: |
         export TMPDIR=/root/tmp

--- a/ansible/roles/vtctld/tasks/clean.yml
+++ b/ansible/roles/vtctld/tasks/clean.yml
@@ -77,4 +77,4 @@
   failed_when: false
 
 - name: remove binary
-  shell: rm -f $(which vtctld)
+  shell: rm -f $(which vtctld vtctl vtctlclient vtctldclient)

--- a/ansible/roles/vttablet/tasks/clean.yml
+++ b/ansible/roles/vttablet/tasks/clean.yml
@@ -37,4 +37,4 @@
     daemon_reload: yes
 
 - name: remove binary
-  shell: rm -f $(which vttablet) $(which mysqlctld)
+  shell: rm -f $(which vttablet mysqlctld mysqlctl)


### PR DESCRIPTION
This PR improves the cleaning phase of VTTablet and VTctld by clearing out the vitess binaries to avoid the following error:

```
$> make install PREFIX=/usr/local VTROOT=/go/src/vitess.io/vitess
Thu Sep 29 02:35:52 UTC 2022: Building source tree
cp: cannot create regular file '/usr/local/bin/vtctlclient': Text file busy
make: *** [Makefile:140: install] Error 1
```