### PR TITLE
Add `minimum-version` to benchmark configuration

### DIFF
--- a/config/benchmarks/olap-readonly.yaml
+++ b/config/benchmarks/olap-readonly.yaml
@@ -1,6 +1,9 @@
 ## Exec Config
 exec-type: oltp-readonly-olap
 
+## Minimum Vitess version on which the benchmark should be executed
+minimum-version: 14
+
 ## Ansible
 ansible-inventory-files: macrobench_sharded_inventory.yml
 ansible-playbook-files: macrobench.yml

--- a/config/benchmarks/oltp-readonly.yaml
+++ b/config/benchmarks/oltp-readonly.yaml
@@ -1,6 +1,9 @@
 ## Exec Config
 exec-type: oltp-readonly
 
+## Minimum Vitess version on which the benchmark should be executed
+minimum-version: 14
+
 ## Ansible
 ansible-inventory-files: macrobench_sharded_inventory.yml
 ansible-playbook-files: macrobench.yml

--- a/config/benchmarks/oltp-set.yaml
+++ b/config/benchmarks/oltp-set.yaml
@@ -1,6 +1,9 @@
 ## Exec Config
 exec-type: oltp-set
 
+## Minimum Vitess version on which the benchmark should be executed
+minimum-version: 14
+
 ## Ansible
 ansible-inventory-files: macrobench_sharded_inventory.yml
 ansible-playbook-files: macrobench.yml

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/slack-go/slack v0.8.1
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/jwalterweatherman v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
@@ -58,7 +59,6 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
-	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/spf13/jwalterweatherman"
 	"github.com/vitessio/arewefastyet/go/storage"
 	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"github.com/vitessio/arewefastyet/go/tools/git"
@@ -179,6 +180,10 @@ func NewExecWithConfig(config *viper.Viper, path string) (*Exec, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// config.MergeConfigMap calls `jwalterweatherman` and logs whenever there are mismatches
+	// between the two configuration, we want to discard those logs.
+	jwalterweatherman.SetLogOutput(io.Discard)
 
 	err = config.MergeConfigMap(viper.AllSettings())
 	if err != nil {

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -174,23 +174,22 @@ func NewExec() (*Exec, error) {
 
 // NewExecWithConfig will create a new Exec using the NewExec method, and will
 // use viper.Viper to apply the configuration located at pathConfig.
-func NewExecWithConfig(pathConfig string) (*Exec, error) {
+func NewExecWithConfig(config *viper.Viper, path string) (*Exec, error) {
 	e, err := NewExec()
 	if err != nil {
 		return nil, err
 	}
 
-	viper.SetConfigFile(pathConfig)
-	err = viper.MergeInConfig()
+	err = config.MergeConfigMap(viper.AllSettings())
 	if err != nil {
 		return nil, err
 	}
 
-	err = e.AddToViper(viper.GetViper())
+	err = e.AddToViper(config)
 	if err != nil {
 		return nil, err
 	}
-	e.configPath = pathConfig
+	e.configPath = path
 	return e, nil
 }
 

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -29,7 +29,7 @@ import (
 
 type (
 	executionQueueElement struct {
-		config                  string
+		config                  benchmarkConfig
 		retry                   int
 		identifier              executionIdentifier
 		compareWith             []executionIdentifier
@@ -97,7 +97,7 @@ func (s *Server) createCrons() error {
 	return nil
 }
 
-func (s *Server) getConfigFiles() map[string]string {
+func (s *Server) getConfigFiles() map[string]benchmarkConfig {
 	return s.benchmarkConfig
 }
 

--- a/go/server/cron_execution.go
+++ b/go/server/cron_execution.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vitessio/arewefastyet/go/exec"
 )
 
-func (s *Server) executeSingle(config string, identifier executionIdentifier) (err error) {
+func (s *Server) executeSingle(config benchmarkConfig, identifier executionIdentifier) (err error) {
 	var e *exec.Exec
 	defer func() {
 		if e != nil {
@@ -40,7 +40,7 @@ func (s *Server) executeSingle(config string, identifier executionIdentifier) (e
 		}
 	}()
 
-	e, err = exec.NewExecWithConfig(config)
+	e, err = exec.NewExecWithConfig(config.v, config.file)
 
 	if err != nil {
 		nErr := fmt.Errorf(fmt.Sprintf("new exec error: %v", err))

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -72,7 +72,7 @@ func (s *Server) mainBranchCronHandler() ([]*executionQueueElement, error) {
 
 	// We compare main with the previous hash of main and with the latest release
 	for configType, config := range configs {
-		if minVersion := config.v.GetInt("minimum-version"); minVersion > currVersion.Major {
+		if minVersion := config.v.GetInt(keyMinimumVitessVersion); minVersion > currVersion.Major {
 			continue
 		}
 		if configType == "micro" {
@@ -121,7 +121,7 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 		currVersion.Patch += 1
 
 		for configType, config := range configs {
-			if minVersion := config.v.GetInt("minimum-version"); minVersion > currVersion.Major {
+			if minVersion := config.v.GetInt(keyMinimumVitessVersion); minVersion > currVersion.Major {
 				continue
 			}
 
@@ -168,7 +168,7 @@ func (s *Server) createBranchElementWithComparisonOnPreviousAndRelease(config be
 		elements = append(elements, previousElement)
 	}
 
-	if lastRelease != nil && config.v.GetInt("minimum-version") <= lastRelease.Version.Major {
+	if lastRelease != nil && config.v.GetInt(keyMinimumVitessVersion) <= lastRelease.Version.Major {
 		// creating an execution queue element for the latest release (comparing branch with the latest release)
 		// this will probably not be executed the benchmark should already exist, we still create it to compare main once its benchmark is over
 		lastReleaseElement := s.createSimpleExecutionQueueElement(config, exec.SourceTag+lastRelease.Name, lastRelease.CommitHash, configType, plannerVersion, false, 0, lastRelease.Version)
@@ -212,7 +212,7 @@ func (s *Server) pullRequestsCronHandler() {
 				continue
 			}
 			for configType, config := range configs {
-				if minVersion := config.v.GetInt("minimum-version"); minVersion > currVersion.Major {
+				if minVersion := config.v.GetInt(keyMinimumVitessVersion); minVersion > currVersion.Major {
 					continue
 				}
 
@@ -275,7 +275,7 @@ func (s *Server) tagsCronHandler() {
 	for _, release := range releases {
 		source := exec.SourceTag + release.Name
 		for configType, config := range configs {
-			if minVersion := config.v.GetInt("minimum-version"); minVersion > release.Version.Major {
+			if minVersion := config.v.GetInt(keyMinimumVitessVersion); minVersion > release.Version.Major {
 				continue
 			}
 			if configType == "micro" {

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -68,11 +68,11 @@ func (s *Server) mainBranchCronHandler() ([]*executionQueueElement, error) {
 	if err != nil {
 		return nil, err
 	}
-	currVesion := git.Version{Major: lastRelease.Version.Major + 1}
+	currVersion := git.Version{Major: lastRelease.Version.Major + 1}
 
 	// We compare main with the previous hash of main and with the latest release
-	for configType, configFile := range configs {
-		if configFile == "" {
+	for configType, config := range configs {
+		if minVersion := config.v.GetInt("minimum-version"); minVersion > currVersion.Major {
 			continue
 		}
 		if configType == "micro" {
@@ -81,7 +81,7 @@ func (s *Server) mainBranchCronHandler() ([]*executionQueueElement, error) {
 				slog.Warn(err.Error())
 				continue
 			}
-			elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, "", exec.SourceCron, lastRelease, currVesion)...)
+			elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(config, ref, configType, previousGitRef, "", exec.SourceCron, lastRelease, currVersion)...)
 		} else {
 			for _, version := range git.GetPlannerVersions() {
 				_, previousGitRef, err := exec.GetPreviousFromSourceMacrobenchmark(s.dbClient, exec.SourceCron, configType, string(version), ref)
@@ -89,7 +89,7 @@ func (s *Server) mainBranchCronHandler() ([]*executionQueueElement, error) {
 					slog.Warn(err.Error())
 					continue
 				}
-				elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, string(version), exec.SourceCron, lastRelease, currVesion)...)
+				elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(config, ref, configType, previousGitRef, string(version), exec.SourceCron, lastRelease, currVersion)...)
 			}
 		}
 	}
@@ -117,13 +117,14 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 			continue
 		}
 
-		currVesion := lastPatchRelease.Version
-		currVesion.Patch += 1
+		currVersion := lastPatchRelease.Version
+		currVersion.Patch += 1
 
-		for configType, configFile := range configs {
-			if configFile == "" {
+		for configType, config := range configs {
+			if minVersion := config.v.GetInt("minimum-version"); minVersion > currVersion.Major {
 				continue
 			}
+
 			if configType == "micro" {
 				_, previousGitRef, err := exec.GetPreviousFromSourceMicrobenchmark(s.dbClient, source, ref)
 				if err != nil {
@@ -131,7 +132,7 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 					continue
 				}
 
-				elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, "", source, lastPatchRelease, currVesion)...)
+				elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(config, ref, configType, previousGitRef, "", source, lastPatchRelease, currVersion)...)
 			} else {
 				versions := git.GetPlannerVersions()
 
@@ -142,7 +143,7 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 						continue
 					}
 
-					elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, string(version), source, lastPatchRelease, currVesion)...)
+					elements = append(elements, s.createBranchElementWithComparisonOnPreviousAndRelease(config, ref, configType, previousGitRef, string(version), source, lastPatchRelease, currVersion)...)
 				}
 			}
 		}
@@ -150,27 +151,27 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 	return elements, nil
 }
 
-func (s *Server) createBranchElementWithComparisonOnPreviousAndRelease(configFile, ref, configType, previousGitRef, plannerVersion, source string, lastRelease *git.Release, version git.Version) []*executionQueueElement {
+func (s *Server) createBranchElementWithComparisonOnPreviousAndRelease(config benchmarkConfig, ref, configType, previousGitRef, plannerVersion, source string, lastRelease *git.Release, version git.Version) []*executionQueueElement {
 	var elements []*executionQueueElement
 
 	// creating a benchmark for the latest commit on the branch with SourceCron as a source
 	// this benchmark will be compared with the previous benchmark on branch with the given source, and with the latest release
-	newExecutionElement := s.createSimpleExecutionQueueElement(source, configFile, ref, configType, plannerVersion, false, 0, version)
+	newExecutionElement := s.createSimpleExecutionQueueElement(config, source, ref, configType, plannerVersion, false, 0, version)
 	elements = append(elements, newExecutionElement)
 
 	if previousGitRef != "" {
 		// creating an execution queue element for the latest benchmark with SourceCron as source
 		// this will not be executed since the benchmark already exist, we still create the element in order to compare
-		previousElement := s.createSimpleExecutionQueueElement(source, configFile, previousGitRef, configType, plannerVersion, false, 0, version)
+		previousElement := s.createSimpleExecutionQueueElement(config, source, previousGitRef, configType, plannerVersion, false, 0, version)
 		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.identifier)
 		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.identifier)
 		elements = append(elements, previousElement)
 	}
 
-	if lastRelease != nil {
+	if lastRelease != nil && config.v.GetInt("minimum-version") <= lastRelease.Version.Major {
 		// creating an execution queue element for the latest release (comparing branch with the latest release)
 		// this will probably not be executed the benchmark should already exist, we still create it to compare main once its benchmark is over
-		lastReleaseElement := s.createSimpleExecutionQueueElement(exec.SourceTag+lastRelease.Name, configFile, lastRelease.CommitHash, configType, plannerVersion, false, 0, lastRelease.Version)
+		lastReleaseElement := s.createSimpleExecutionQueueElement(config, exec.SourceTag+lastRelease.Name, lastRelease.CommitHash, configType, plannerVersion, false, 0, lastRelease.Version)
 		lastReleaseElement.compareWith = append(lastReleaseElement.compareWith, newExecutionElement.identifier)
 		newExecutionElement.compareWith = append(newExecutionElement.compareWith, lastReleaseElement.identifier)
 		elements = append(elements, lastReleaseElement)
@@ -210,19 +211,20 @@ func (s *Server) pullRequestsCronHandler() {
 				slog.Warn(err)
 				continue
 			}
-			for configType, configFile := range configs {
-				if configFile == "" {
+			for configType, config := range configs {
+				if minVersion := config.v.GetInt("minimum-version"); minVersion > currVersion.Major {
 					continue
 				}
+
 				if configType == "micro" {
-					elements = append(elements, s.createPullRequestElementWithBaseComparison(configFile, ref, configType, previousGitRef, "", pullNb, currVersion)...)
+					elements = append(elements, s.createPullRequestElementWithBaseComparison(config, ref, configType, previousGitRef, "", pullNb, currVersion)...)
 				} else {
 					versions := []macrobench.PlannerVersion{macrobench.V3Planner}
 					if labelInfo.useGen4 {
 						versions = []macrobench.PlannerVersion{macrobench.Gen4Planner}
 					}
 					for _, version := range versions {
-						elements = append(elements, s.createPullRequestElementWithBaseComparison(configFile, ref, configType, previousGitRef, version, pullNb, currVersion)...)
+						elements = append(elements, s.createPullRequestElementWithBaseComparison(config, ref, configType, previousGitRef, version, pullNb, currVersion)...)
 					}
 				}
 			}
@@ -233,15 +235,15 @@ func (s *Server) pullRequestsCronHandler() {
 	}
 }
 
-func (s *Server) createPullRequestElementWithBaseComparison(configFile, ref, configType, previousGitRef string, plannerVersion macrobench.PlannerVersion, pullNb int, gitVersion git.Version) []*executionQueueElement {
+func (s *Server) createPullRequestElementWithBaseComparison(config benchmarkConfig, ref, configType, previousGitRef string, plannerVersion macrobench.PlannerVersion, pullNb int, gitVersion git.Version) []*executionQueueElement {
 	var elements []*executionQueueElement
 
-	newExecutionElement := s.createSimpleExecutionQueueElement(exec.SourcePullRequest, configFile, ref, configType, string(plannerVersion), true, pullNb, gitVersion)
+	newExecutionElement := s.createSimpleExecutionQueueElement(config, exec.SourcePullRequest, ref, configType, string(plannerVersion), true, pullNb, gitVersion)
 	newExecutionElement.identifier.PullBaseRef = previousGitRef
 	elements = append(elements, newExecutionElement)
 
 	if previousGitRef != "" {
-		previousElement := s.createSimpleExecutionQueueElement(exec.SourcePullRequestBase, configFile, previousGitRef, configType, string(plannerVersion), false, pullNb, gitVersion)
+		previousElement := s.createSimpleExecutionQueueElement(config, exec.SourcePullRequestBase, previousGitRef, configType, string(plannerVersion), false, pullNb, gitVersion)
 		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.identifier)
 		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.identifier)
 		elements = append(elements, previousElement)
@@ -272,16 +274,16 @@ func (s *Server) tagsCronHandler() {
 	// We add single executions for the tags, we do not compare them against anything
 	for _, release := range releases {
 		source := exec.SourceTag + release.Name
-		for configType, configFile := range configs {
-			if configFile == "" {
+		for configType, config := range configs {
+			if minVersion := config.v.GetInt("minimum-version"); minVersion > release.Version.Major {
 				continue
 			}
 			if configType == "micro" {
-				elements = append(elements, s.createSimpleExecutionQueueElement(source, configFile, release.CommitHash, configType, "", true, 0, release.Version))
+				elements = append(elements, s.createSimpleExecutionQueueElement(config, source, release.CommitHash, configType, "", true, 0, release.Version))
 			} else {
 				versions := git.GetPlannerVersions()
 				for _, version := range versions {
-					elements = append(elements, s.createSimpleExecutionQueueElement(source, configFile, release.CommitHash, configType, string(version), true, 0, release.Version))
+					elements = append(elements, s.createSimpleExecutionQueueElement(config, source, release.CommitHash, configType, string(version), true, 0, release.Version))
 				}
 			}
 		}
@@ -291,9 +293,9 @@ func (s *Server) tagsCronHandler() {
 	}
 }
 
-func (s *Server) createSimpleExecutionQueueElement(source, configFile, ref, configType, plannerVersion string, notify bool, pullNb int, version git.Version) *executionQueueElement {
+func (s *Server) createSimpleExecutionQueueElement(config benchmarkConfig, source, ref, configType, plannerVersion string, notify bool, pullNb int, version git.Version) *executionQueueElement {
 	return &executionQueueElement{
-		config:       configFile,
+		config:       config,
 		retry:        s.cronNbRetry,
 		notifyAlways: notify,
 		identifier: executionIdentifier{

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -171,12 +171,12 @@ func (s *Server) Init() error {
 	}
 
 	s.benchmarkConfig = map[string]benchmarkConfig{
-		// "micro":         {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New()},
-		// "oltp":          {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
-		// "oltp-set":      {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
-		// "readonly-oltp": {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
+		"micro":         {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New()},
+		"oltp":          {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
+		"oltp-set":      {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
+		"readonly-oltp": {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
 		"readonly-olap": {file: path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"), v: viper.New()},
-		// "tpcc":          {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
+		"tpcc":          {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
 	}
 	for configName, config := range s.benchmarkConfig {
 		config.v.SetConfigFile(config.file)

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -53,7 +53,17 @@ const (
 	flagBenchmarkConfigPath                  = "web-benchmark-config-path"
 	flagFilterBySource                       = "web-source-filter"
 	flagExcludeFilterBySource                = "web-source-exclude-filter"
+
+	// keyMinimumVitessVersion is used to define on which minimum Vitess version a given
+	// benchmark should be run. Only the major version is counted. This key/value is located
+	// in the benchmarks' configuration files.
+	keyMinimumVitessVersion = "minimum-version"
 )
+
+type benchmarkConfig struct {
+	file string
+	v    *viper.Viper
+}
 
 type Server struct {
 	port         string
@@ -80,7 +90,7 @@ type Server struct {
 	prLabelTrigger   string
 	prLabelTriggerV3 string
 
-	benchmarkConfig map[string]string
+	benchmarkConfig map[string]benchmarkConfig
 	benchmarkTypes  []string
 
 	sourceFilter        []string
@@ -160,15 +170,19 @@ func (s *Server) Init() error {
 		return err
 	}
 
-	s.benchmarkConfig = map[string]string{
-		"micro":         path.Join(s.benchmarkConfigPath, "micro.yaml"),
-		"oltp":          path.Join(s.benchmarkConfigPath, "oltp.yaml"),
-		"oltp-set":      path.Join(s.benchmarkConfigPath, "oltp-set.yaml"),
-		"readonly-oltp": path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"),
-		"readonly-olap": path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"),
-		"tpcc":          path.Join(s.benchmarkConfigPath, "tpcc.yaml"),
+	s.benchmarkConfig = map[string]benchmarkConfig{
+		// "micro":         {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New()},
+		// "oltp":          {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
+		// "oltp-set":      {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
+		// "readonly-oltp": {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
+		"readonly-olap": {file: path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"), v: viper.New()},
+		// "tpcc":          {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
 	}
-	for configName := range s.benchmarkConfig {
+	for configName, config := range s.benchmarkConfig {
+		config.v.SetConfigFile(config.file)
+		if err := config.v.ReadInConfig(); err != nil {
+			slog.Error(err)
+		}
 		if configName == "micro" {
 			continue
 		}


### PR DESCRIPTION
This PR adds the field `minimum-version` to the configuration file of a benchmark. The value of this field will tell us on which minimum **major** version of Vitess the given benchmark should run.

```yaml
minimum-version: 14 # -> will run only on v14.0.0 and above
```