### PR TITLE
Avoid division by 0 when normalising VTGate query plan results

### DIFF
--- a/go/tools/macrobench/vtgate.go
+++ b/go/tools/macrobench/vtgate.go
@@ -23,10 +23,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/vitessio/arewefastyet/go/storage"
-	"github.com/vitessio/arewefastyet/go/storage/mysql"
 	"net/http"
 	"strings"
+
+	"github.com/vitessio/arewefastyet/go/storage"
+	"github.com/vitessio/arewefastyet/go/storage/mysql"
 )
 
 type VTGateQueryPlanValue struct {
@@ -110,6 +111,9 @@ func CompareVTGateQueryPlans(left, right []VTGateQueryPlan) []VTGateQueryPlanCom
 }
 
 func normalizeVTGateQueryPlan(plan *VTGateQueryPlanValue) {
+	if plan.ExecCount == 0 {
+		return
+	}
 	plan.ExecTime = plan.ExecTime / plan.ExecCount
 }
 


### PR DESCRIPTION
This PR fixes a panic that happens when trying to normalize a query plan that contains values equal to 0. This PR is to unblock the production server from benchmarking new/past commits.

I will investigate why we are getting ExecCount = 0 in some cases.

Here is a trace of the observed panic:
```
panic: runtime error: integer divide by zero

goroutine 1 [running]:
github.com/vitessio/arewefastyet/go/tools/macrobench.normalizeVTGateQueryPlan(...)
```