### PR TITLE
Remove old arewefastyet repository folder

### DIFF
--- a/ansible/macrobench_sharded_inventory.yml
+++ b/ansible/macrobench_sharded_inventory.yml
@@ -18,7 +18,7 @@ all:
         partition: nvme0n1p1
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
-    arewefastyet_git_version: "HEAD"
+    arewefastyet_git_version: "main"
     macrobenchmark_vschema_oltp: "./vitess-benchmark/sysbench.json"
     macrobenchmark_vschema_tpcc: "./vitess-benchmark/tpcc_vschema.json"
     cell: local

--- a/ansible/macrobench_unsharded_inventory.yml
+++ b/ansible/macrobench_unsharded_inventory.yml
@@ -18,7 +18,7 @@ all:
         partition: nvme0n1p1
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
-    arewefastyet_git_version: "HEAD"
+    arewefastyet_git_version: "main"
     macrobenchmark_vschema: "./vitess-benchmark/sysbench.json"
     cell: local
     keyspace: main

--- a/ansible/microbench_inventory.yml
+++ b/ansible/microbench_inventory.yml
@@ -23,5 +23,5 @@ all:
         DEVICE_IP_0:
   vars:
     arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
-    arewefastyet_git_version: "HEAD"
+    arewefastyet_git_version: "main"
     microbenchmarks_vitess_package: "./go/..."

--- a/ansible/roles/macrobench/tasks/main.yml
+++ b/ansible/roles/macrobench/tasks/main.yml
@@ -14,6 +14,11 @@
   become: yes
   become_user: root
   block:
+    - name: Remove old arewefastyet
+      shell: |
+        rm -Rf /go/src/github.com/vitessio/arewefastyet
+      changed_when: false
+
     - name: git clone arewefastyet
       git:
         repo: "{{ arewefastyet_git_repo }}"

--- a/ansible/roles/microbench/defaults/main.yml
+++ b/ansible/roles/microbench/defaults/main.yml
@@ -10,5 +10,5 @@
 # limitations under the License.
 
 arewefastyet_git_repo: "https://github.com/vitessio/arewefastyet.git"
-arewefastyet_git_version: "master"
+arewefastyet_git_version: "main"
 arewefastyet_exec_uuid: ""

--- a/ansible/roles/microbench/tasks/main.yml
+++ b/ansible/roles/microbench/tasks/main.yml
@@ -19,6 +19,11 @@
   become: yes
   become_user: root
   block:
+    - name: Remove old arewefastyet
+      shell: |
+        rm -Rf /go/src/github.com/vitessio/arewefastyet
+      changed_when: false
+
     - name: git clone arewefastyet
       git:
         repo: "{{ arewefastyet_git_repo }}"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/slack-go/slack v0.8.1
 	github.com/spf13/cobra v1.1.3
-	github.com/spf13/jwalterweatherman v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
@@ -59,6 +58,7 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -29,7 +29,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/spf13/jwalterweatherman"
 	"github.com/vitessio/arewefastyet/go/storage"
 	"github.com/vitessio/arewefastyet/go/storage/psdb"
 	"github.com/vitessio/arewefastyet/go/tools/git"
@@ -175,22 +174,19 @@ func NewExec() (*Exec, error) {
 
 // NewExecWithConfig will create a new Exec using the NewExec method, and will
 // use viper.Viper to apply the configuration located at pathConfig.
-func NewExecWithConfig(config *viper.Viper, path string) (*Exec, error) {
+func NewExecWithConfig(path string) (*Exec, error) {
 	e, err := NewExec()
 	if err != nil {
 		return nil, err
 	}
 
-	// config.MergeConfigMap calls `jwalterweatherman` and logs whenever there are mismatches
-	// between the two configuration, we want to discard those logs.
-	jwalterweatherman.SetLogOutput(io.Discard)
-
-	err = config.MergeConfigMap(viper.AllSettings())
+	viper.SetConfigFile(path)
+	err = viper.MergeInConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	err = e.AddToViper(config)
+	err = e.AddToViper(viper.GetViper())
 	if err != nil {
 		return nil, err
 	}

--- a/go/server/cron_execution.go
+++ b/go/server/cron_execution.go
@@ -40,7 +40,7 @@ func (s *Server) executeSingle(config benchmarkConfig, identifier executionIdent
 		}
 	}()
 
-	e, err = exec.NewExecWithConfig(config.v, config.file)
+	e, err = exec.NewExecWithConfig(config.file)
 
 	if err != nil {
 		nErr := fmt.Errorf(fmt.Sprintf("new exec error: %v", err))


### PR DESCRIPTION
This PR removes the previous arewefastyet repository from the disk before cloning it. It ensures we always get the most up to date version of arewefastyet.