### PR TITLE
Fix benchmark configuration copy

### DIFF
--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -180,13 +180,18 @@ func NewExecWithConfig(path string) (*Exec, error) {
 		return nil, err
 	}
 
-	viper.SetConfigFile(path)
-	err = viper.MergeInConfig()
+	nv := viper.New()
+	err = nv.MergeConfigMap(viper.AllSettings())
+	if err != nil {
+		return nil, err
+	}
+	nv.SetConfigFile(path)
+	err = nv.MergeInConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	err = e.AddToViper(viper.GetViper())
+	err = e.AddToViper(nv)
 	if err != nil {
 		return nil, err
 	}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -171,12 +171,12 @@ func (s *Server) Init() error {
 	}
 
 	s.benchmarkConfig = map[string]benchmarkConfig{
-		"micro":         {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New()},
-		"oltp":          {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
-		"oltp-set":      {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
-		"readonly-oltp": {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
-		"readonly-olap": {file: path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"), v: viper.New()},
-		"tpcc":          {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
+		"micro":              {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New()},
+		"oltp":               {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
+		"oltp-set":           {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
+		"oltp-readonly":      {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
+		"oltp-readonly-olap": {file: path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"), v: viper.New()},
+		"tpcc":               {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
 	}
 	for configName, config := range s.benchmarkConfig {
 		config.v.SetConfigFile(config.file)


### PR DESCRIPTION
This PR fixes an issue that happened when assigning a viper configuration to a new execution. We used to change the main viper configuration always and assign the execution configuration to it. This PR creates a brand new configuration and assign the main + the execution configuration to it. This way the "merged" configuration is only used by this new execution.