### PR TITLE
Fix configuration error for Ansible file paths

### DIFF
--- a/config/benchmarks/micro.yaml
+++ b/config/benchmarks/micro.yaml
@@ -2,5 +2,5 @@
 exec-type: micro
 
 ## Ansible
-ansible-inventory-files: microbench_inventory.yml
-ansible-playbook-files: microbench.yml
+ansible-inventory-file: microbench_inventory.yml
+ansible-playbook-file: microbench.yml

--- a/config/benchmarks/olap-readonly.yaml
+++ b/config/benchmarks/olap-readonly.yaml
@@ -5,8 +5,8 @@ exec-type: oltp-readonly-olap
 minimum-version: 14
 
 ## Ansible
-ansible-inventory-files: macrobench_sharded_inventory.yml
-ansible-playbook-files: macrobench.yml
+ansible-inventory-file: macrobench_sharded_inventory.yml
+ansible-playbook-file: macrobench.yml
 
 ## Macrobench cmd
 macrobench-sysbench-executable: /usr/local/bin/sysbench

--- a/config/benchmarks/oltp-readonly.yaml
+++ b/config/benchmarks/oltp-readonly.yaml
@@ -5,8 +5,8 @@ exec-type: oltp-readonly
 minimum-version: 14
 
 ## Ansible
-ansible-inventory-files: macrobench_sharded_inventory.yml
-ansible-playbook-files: macrobench.yml
+ansible-inventory-file: macrobench_sharded_inventory.yml
+ansible-playbook-file: macrobench.yml
 
 ## Macrobench cmd
 macrobench-sysbench-executable: /usr/local/bin/sysbench

--- a/config/benchmarks/oltp-set.yaml
+++ b/config/benchmarks/oltp-set.yaml
@@ -5,8 +5,8 @@ exec-type: oltp-set
 minimum-version: 14
 
 ## Ansible
-ansible-inventory-files: macrobench_sharded_inventory.yml
-ansible-playbook-files: macrobench.yml
+ansible-inventory-file: macrobench_sharded_inventory.yml
+ansible-playbook-file: macrobench.yml
 
 ## Macrobench cmd
 macrobench-sysbench-executable: /usr/local/bin/sysbench

--- a/config/benchmarks/oltp.yaml
+++ b/config/benchmarks/oltp.yaml
@@ -2,8 +2,8 @@
 exec-type: oltp
 
 ## Ansible
-ansible-inventory-files: macrobench_sharded_inventory.yml
-ansible-playbook-files: macrobench.yml
+ansible-inventory-file: macrobench_sharded_inventory.yml
+ansible-playbook-file: macrobench.yml
 
 ## Macrobench cmd
 macrobench-sysbench-executable: /usr/local/bin/sysbench

--- a/config/benchmarks/tpcc.yaml
+++ b/config/benchmarks/tpcc.yaml
@@ -2,8 +2,8 @@
 exec-type: tpcc
 
 ## Ansible
-ansible-inventory-files: macrobench_sharded_inventory.yml
-ansible-playbook-files: macrobench.yml
+ansible-inventory-file: macrobench_sharded_inventory.yml
+ansible-playbook-file: macrobench.yml
 
 ## Macrobench cmd
 macrobench-sysbench-executable: /usr/local/bin/sysbench

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -15,7 +15,7 @@ arewefastyet exec [flags]
 
 ```
 arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --planetscale-db-database benchmark --planetscale-db-branch main --planetscale-db-org my-org --planetscale-db-service-token <token> --planetscale-db-service-token-name <token name>
---exec-source config_micro_remote --ansible-inventory-files microbench_inventory.yml --ansible-playbook-files microbench.yml --ansible-root-directory ./ansible/
+--exec-source config_micro_remote --ansible-inventory-file microbench_inventory.yml --ansible-playbook-file microbench.yml --ansible-root-directory ./ansible/
 --equinix-instance-type m2.xlarge.x86 --equinix-token tok --equinix-project-id id
 
 ```
@@ -23,8 +23,8 @@ arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --pla
 ### Options
 
 ```
-      --ansible-inventory-files strings      List of inventory files used by Ansible
-      --ansible-playbook-files strings       List of playbook files used by Ansible
+      --ansible-inventory-file string        Inventory file used by Ansible
+      --ansible-playbook-file string         Playbook file used by Ansible
       --ansible-root-directory string        Root directory of Ansible
       --exec-git-ref string                  Git reference on which the benchmarks will run.
       --exec-go-version string               Defines the golang version that will be used by this execution. (default "1.17")

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -27,7 +27,7 @@ arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-
       --influx-username string                     Username used to connect to InfluxDB.
       --macrobench-exec-uuid string                UUID of the parent execution, an empty string will set to NULL.
       --macrobench-git-ref string                  Git SHA referring to the macro benchmark.
-      --macrobench-skip-steps strings              Slice of sysbench steps to skip.
+      --macrobench-skip-steps string               Slice of sysbench steps to skip.
       --macrobench-sysbench-executable string      Path to the sysbench binary.
       --macrobench-type Type                       Type of macro benchmark.
       --macrobench-vtgate-planner-version string   Vtgate planner version running on Vitess

--- a/go/cmd/exec/exec.go
+++ b/go/cmd/exec/exec.go
@@ -38,7 +38,7 @@ func ExecCmd() *cobra.Command {
 		Long: `Execute a task based on the given terraform and ansible configuration.
 It handles the creation, configuration, and cleanup of the infrastructure.`,
 		Example: `arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --planetscale-db-database benchmark --planetscale-db-branch main --planetscale-db-org my-org --planetscale-db-service-token <token> --planetscale-db-service-token-name <token name>
---exec-source config_micro_remote --ansible-inventory-files microbench_inventory.yml --ansible-playbook-files microbench.yml --ansible-root-directory ./ansible/
+--exec-source config_micro_remote --ansible-inventory-file microbench_inventory.yml --ansible-playbook-file microbench.yml --ansible-root-directory ./ansible/
 --equinix-instance-type m2.xlarge.x86 --equinix-token tok --equinix-project-id id
 `,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/go/infra/ansible/files.go
+++ b/go/infra/ansible/files.go
@@ -48,23 +48,21 @@ func insertMetaSliceToFile(values []string, file, root, token string) error {
 	return nil
 }
 
-func insetMetaSliceToFiles(values, files []string, root, token string) error {
-	for _, file := range files {
-		err := insertMetaSliceToFile(values, file, root, token)
-		if err != nil {
-			return err
-		}
+func insetMetaSliceToFiles(values []string, file string, root, token string) error {
+	err := insertMetaSliceToFile(values, file, root, token)
+	if err != nil {
+		return err
 	}
 	return nil
 }
 
 func AddIPsToFiles(IPs []string, c Config) error {
-	err := insetMetaSliceToFiles(IPs, c.PlaybookFiles, c.RootDir, tokenDeviceIP)
+	err := insetMetaSliceToFiles(IPs, c.PlaybookFile, c.RootDir, tokenDeviceIP)
 	if err != nil {
 		return err
 	}
 
-	err = insetMetaSliceToFiles(IPs, c.InventoryFiles, c.RootDir, tokenDeviceIP)
+	err = insetMetaSliceToFiles(IPs, c.InventoryFile, c.RootDir, tokenDeviceIP)
 	if err != nil {
 		return err
 	}

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -54,9 +54,9 @@ type Config struct {
 	// This key value map stores the value of each CLI parameters.
 	M map[string]string
 
-	// SkipSteps is a slice of string that is used to skip some of
+	// SkipSteps is a list of strings (separated by a comma) that is used to skip some of
 	// sysbench steps.
-	SkipSteps []string
+	SkipSteps string
 
 	// Type will be used to differentiate macro benchmarks.
 	Type Type
@@ -107,7 +107,7 @@ func (mabcfg *Config) AddToCommand(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "Path to the workload used by sysbench.")
 	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "Path to the sysbench binary.")
-	cmd.Flags().StringSliceVar(&mabcfg.SkipSteps, flagSkipSteps, []string{}, "Slice of sysbench steps to skip.")
+	cmd.Flags().StringVar(&mabcfg.SkipSteps, flagSkipSteps, "", "Slice of sysbench steps to skip.")
 	cmd.Flags().Var(&mabcfg.Type, flagType, "Type of macro benchmark.")
 	cmd.Flags().StringVar(&mabcfg.VtgatePlannerVersion, flagVtgatePlannerVersion, "", "Vtgate planner version running on Vitess")
 	cmd.Flags().StringVar(&mabcfg.GitRef, flagGitRef, "", "Git SHA referring to the macro benchmark.")

--- a/go/tools/macrobench/steps.go
+++ b/go/tools/macrobench/steps.go
@@ -18,6 +18,8 @@
 
 package macrobench
 
+import "strings"
+
 type step struct {
 	Name         string
 	SysbenchName string
@@ -37,11 +39,12 @@ var (
 	}
 )
 
-func skipSteps(steps []step, skip []string) (newSteps []step) {
+func skipSteps(steps []step, skip string) (newSteps []step) {
+	skips := strings.Split(skip, ",")
 	newSteps = []step{}
 	for _, step := range steps {
 		add := true
-		for _, skipStep := range skip {
+		for _, skipStep := range skips {
 			if step.Name == skipStep {
 				add = false
 				break

--- a/go/tools/macrobench/steps_test.go
+++ b/go/tools/macrobench/steps_test.go
@@ -19,8 +19,10 @@
 package macrobench
 
 import (
-	qt "github.com/frankban/quicktest"
+	"fmt"
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 func Test_skipSteps(t *testing.T) {
@@ -30,19 +32,19 @@ func Test_skipSteps(t *testing.T) {
 
 	type args struct {
 		steps []step
-		skip  []string
+		skip  string
 	}
 	tests := []struct {
 		name         string
 		args         args
 		wantNewSteps []step
 	}{
-		{name: "No skip step", args: args{steps: []step{prepare, warmup, run}, skip: []string{}}, wantNewSteps: []step{prepare, warmup, run}},
-		{name: "Skip prepare", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepPrepare}}, wantNewSteps: []step{warmup, run}},
-		{name: "Skip warm up", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepWarmUp}}, wantNewSteps: []step{prepare, run}},
-		{name: "Skip run", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepRun}}, wantNewSteps: []step{prepare, warmup}},
-		{name: "Skip prepare and run", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepPrepare, stepRun}}, wantNewSteps: []step{warmup}},
-		{name: "Skip all", args: args{steps: []step{prepare, warmup, run}, skip: []string{stepPrepare, stepWarmUp, stepRun}}, wantNewSteps: []step{}},
+		{name: "No skip step", args: args{steps: []step{prepare, warmup, run}}, wantNewSteps: []step{prepare, warmup, run}},
+		{name: "Skip prepare", args: args{steps: []step{prepare, warmup, run}, skip: stepPrepare}, wantNewSteps: []step{warmup, run}},
+		{name: "Skip warm up", args: args{steps: []step{prepare, warmup, run}, skip: stepWarmUp}, wantNewSteps: []step{prepare, run}},
+		{name: "Skip run", args: args{steps: []step{prepare, warmup, run}, skip: stepRun}, wantNewSteps: []step{prepare, warmup}},
+		{name: "Skip prepare and run", args: args{steps: []step{prepare, warmup, run}, skip: fmt.Sprintf("%s,%s", stepPrepare, stepRun)}, wantNewSteps: []step{warmup}},
+		{name: "Skip all", args: args{steps: []step{prepare, warmup, run}, skip: fmt.Sprintf("%s,%s,%s", stepPrepare, stepWarmUp, stepRun)}, wantNewSteps: []step{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes an error where the `ansible-inventory-file` and `ansible-playbook-file` configuration were not merged correctly. Since those configuration are used only with string instead of a slice of strings, I have changed them to be a `string` instead of a `[]string`.