### PR TITLE
removed the dbconfig flag in mysqlctld service

### DIFF
--- a/ansible/roles/vttablet/templates/mysqlctld@.service.j2
+++ b/ansible/roles/vttablet/templates/mysqlctld@.service.j2
@@ -22,7 +22,7 @@ OOMScoreAdjust=-1000
 ExecStart=/bin/bash -c 'mysqlctld \
      --alsologtostderr \
      --log_dir ${VTROOT}/tmp/vttablet-%i \
-     --db-config-dba-uname=vt_dba \
+     --db_dba_user=vt_dba \
      --db_charset=utf8 \
      --tablet_uid %i \
      --mysql_port=${MYSQL_PORT} \


### PR DESCRIPTION
This PR removes a deprecated flag that was preventing the mysqlctld service from starting up. The issue was visible in vttablet's logs as the mysql data directory was not created:

```
F1010 07:25:56.488927 1116548 vttablet.go:172] mycnf read failed: open /vt/vt/vt_1001/my.cnf: no such file or directory
```