### PR TITLE
Set the vschema in the configuration of the benchmarks

### DIFF
--- a/ansible/create_cluster.yml
+++ b/ansible/create_cluster.yml
@@ -68,21 +68,12 @@
         name: vtctld
         tasks_from: ensure
 
-    - name: Get VSchema for OLTP
+    - name: Get VSchema
       copy:
-        src: "{{ macrobenchmark_vschema_oltp }}"
+        src: "{{ vitess_vschema_path }}"
         dest: /tmp/vschema_sysbench.json
         mode: '0644'
         force: true
-      when: arewefastyet_execution_type == 'oltp'
-
-    - name: Get VSchema for TPCC
-      copy:
-        src: "{{ macrobenchmark_vschema_tpcc }}"
-        dest: /tmp/vschema_sysbench.json
-        mode: '0644'
-        force: true
-      when: arewefastyet_execution_type == 'tpcc'
 
     - name: Apply VSchema
       when: vitess_version_name == 'latest'

--- a/config/benchmarks/olap-readonly.yaml
+++ b/config/benchmarks/olap-readonly.yaml
@@ -1,5 +1,6 @@
 ## Exec Config
 exec-type: oltp-readonly-olap
+exec-schema: "./vitess-benchmark/sysbench.json"
 
 ## Minimum Vitess version on which the benchmark should be executed
 minimum-version: 14

--- a/config/benchmarks/oltp-readonly.yaml
+++ b/config/benchmarks/oltp-readonly.yaml
@@ -1,5 +1,6 @@
 ## Exec Config
 exec-type: oltp-readonly
+exec-schema: "./vitess-benchmark/sysbench.json"
 
 ## Minimum Vitess version on which the benchmark should be executed
 minimum-version: 14

--- a/config/benchmarks/oltp-set.yaml
+++ b/config/benchmarks/oltp-set.yaml
@@ -1,5 +1,6 @@
 ## Exec Config
 exec-type: oltp-set
+exec-schema: "./vitess-benchmark/sysbench.json"
 
 ## Minimum Vitess version on which the benchmark should be executed
 minimum-version: 14

--- a/config/benchmarks/oltp.yaml
+++ b/config/benchmarks/oltp.yaml
@@ -5,6 +5,8 @@ exec-type: oltp
 ansible-inventory-file: macrobench_sharded_inventory.yml
 ansible-playbook-file: macrobench.yml
 
+exec-schema: "./vitess-benchmark/sysbench.json"
+
 ## Macrobench cmd
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: oltp_read_write

--- a/config/benchmarks/tpcc.yaml
+++ b/config/benchmarks/tpcc.yaml
@@ -1,5 +1,6 @@
 ## Exec configuration
 exec-type: tpcc
+exec-schema: "./vitess-benchmark/tpcc_vschema.json"
 
 ## Ansible
 ansible-inventory-file: macrobench_sharded_inventory.yml

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -30,6 +30,7 @@ arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --pla
       --exec-go-version string               Defines the golang version that will be used by this execution. (default "1.17")
       --exec-pull-nb int                     Defines the number of the pull request against which to execute.
       --exec-root-dir string                 Path to the root directory of exec.
+      --exec-schema string                   Path to the VSchema for this benchmark.
       --exec-server-address string           The IP address of the server on which the benchmark will be executed.
       --exec-source string                   Name of the source that triggered the execution.
       --exec-type string                     Defines the execution type (oltp, tpcc, micro).

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -33,6 +33,7 @@ const (
 	flagGolangVersion        = "exec-go-version"
 	flagServerAddress        = "exec-server-address"
 	flagVitessConfig         = "exec-vitess-config"
+	flagVitessSchema         = "exec-schema"
 )
 
 func (e *Exec) AddToViper(v *viper.Viper) (err error) {
@@ -45,6 +46,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	_ = v.UnmarshalKey(flagGolangVersion, &e.GolangVersion)
 	_ = v.UnmarshalKey(flagServerAddress, &e.ServerAddress)
 	_ = v.UnmarshalKey(flagVitessConfig, &e.rawVitessConfig)
+	_ = v.UnmarshalKey(flagVitessSchema, &e.vitessSchemaPath)
 
 	e.AnsibleConfig.AddToViper(v)
 	e.configDB.AddToViper(v)
@@ -61,6 +63,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&e.PullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
 	cmd.Flags().StringVar(&e.GolangVersion, flagGolangVersion, "1.17", "Defines the golang version that will be used by this execution.")
 	cmd.Flags().StringVar(&e.ServerAddress, flagServerAddress, "", "The IP address of the server on which the benchmark will be executed.")
+	cmd.Flags().StringVar(&e.vitessSchemaPath, flagVitessSchema, "", "Path to the VSchema for this benchmark.")
 
 	_ = viper.BindPFlag(flagRootExec, cmd.Flags().Lookup(flagRootExec))
 	_ = viper.BindPFlag(flagGitRefExec, cmd.Flags().Lookup(flagGitRefExec))
@@ -69,6 +72,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagExecPullNB, cmd.Flags().Lookup(flagExecPullNB))
 	_ = viper.BindPFlag(flagGolangVersion, cmd.Flags().Lookup(flagGolangVersion))
 	_ = viper.BindPFlag(flagServerAddress, cmd.Flags().Lookup(flagServerAddress))
+	_ = viper.BindPFlag(flagVitessSchema, cmd.Flags().Lookup(flagVitessSchema))
 
 	e.AnsibleConfig.AddToPersistentCommand(cmd)
 	e.statsRemoteDBConfig.AddToCommand(cmd)

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -139,6 +139,8 @@ type Exec struct {
 	// in vitessConfig is then used when adding extra vars to Ansible.
 	rawVitessConfig rawSingleVitessVersionConfig
 	vitessConfig    vitessConfig
+
+	vitessSchemaPath string
 }
 
 const (
@@ -372,6 +374,7 @@ func (e *Exec) prepareAnsibleForExecution() error {
 	}
 	e.AnsibleConfig.AddExtraVar(ansible.KeyVtgatePlanner, e.VtgatePlannerVersion)
 	e.AnsibleConfig.AddExtraVar(ansible.KeyVitessVersionName, e.VitessVersionName)
+	e.AnsibleConfig.AddExtraVar(ansible.KeyVitessSchema, e.vitessSchemaPath)
 	e.vitessConfig.addToAnsible(&e.AnsibleConfig)
 
 	// runtime related values

--- a/go/infra/ansible/vars.go
+++ b/go/infra/ansible/vars.go
@@ -49,6 +49,9 @@ const (
 
 	// Vitess related keys
 
+	// KeyVitessSchema is the path to the Vitess VSchema that will be used for this benchmark.
+	KeyVitessSchema = "vitess_vschema_path"
+
 	// KeyVitessVersion corresponding value in the map is the git reference of SHA
 	// which benchmarks will be executed.
 	KeyVitessVersion = "vitess_git_version"


### PR DESCRIPTION
This PR fixes an issue that was observed when running a `TPCC` benchmark and then the `SET` benchmarks. They were failing due to the VSchema not being here. This PR adds the VSchema information directly inside the benchmark configuration file.