### PR TITLE
Upgrade to Go 1.18.7

### DIFF
--- a/ansible/roles/vitess_build/defaults/main.yml
+++ b/ansible/roles/vitess_build/defaults/main.yml
@@ -11,7 +11,7 @@
 
 ---
 
-golang_gover: '1.18.5'
+golang_gover: '1.18.7'
 golang_hash_linux_amd64:
   '1.13.7': 'sha256:b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3'
   '1.13.11': 'sha256:a4d71ca9e02923fa96669a4b5faf78ee8331b18e7209b09dd87fe763b4838ada'
@@ -25,6 +25,7 @@ golang_hash_linux_amd64:
   '1.18.3': 'sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'
   '1.18.4': 'sha256:c9b099b68d93f5c5c8a8844a89f8db07eaa58270e3a1e01804f17f4cf8df02f5'
   '1.18.5': 'sha256:9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2'
+  '1.18.7': 'sha256:6c967efc22152ce3124fc35cdf50fc686870120c5fd2107234d05d450a6105d8'
 
 vitess_git_repo: "https://github.com/vitessio/vitess.git"
 vitess_git_version: "main"

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -1,4 +1,4 @@
-exec-go-version: "1.18.5"
+exec-go-version: "1.18.7"
 
 web-port: 9090
 web-template-path: ./go/server/templates

--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -1,4 +1,4 @@
-exec-go-version: "1.18.5"
+exec-go-version: "1.18.7"
 
 web-cron-schedule: "@midnight"
 web-cron-schedule-pull-requests: "*/5 * * * *"


### PR DESCRIPTION
This PR upgrades the Go version that arewefastyet uses to `go1.18.7`.