### PR TITLE
Upgrade to `go1.19.4`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
 
       - name: executing remote ssh commands using password
         uses: appleboy/ssh-action@master

--- a/.github/workflows/golang_build.yaml
+++ b/.github/workflows/golang_build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
 
       - name: Build
         run: make

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
 
       - name: Install golangci-lint
         run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.49.0

--- a/.github/workflows/golang_tidy.yaml
+++ b/.github/workflows/golang_tidy.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
 
       # https://github.com/vitessio/vitess/blob/b5177cd4d09f661350137ef46de2bd3e27949d2e/.github/workflows/gomod-tidy.yml#L17-L28
       - name: Run go mod tidy

--- a/.github/workflows/golang_unit_test.yaml
+++ b/.github/workflows/golang_unit_test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
 
       - name: Test
         run: make test

--- a/.github/workflows/verify_cli_documentation.yml
+++ b/.github/workflows/verify_cli_documentation.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
 
       - name: Run gen doc
         run: |

--- a/ansible/roles/vitess_build/defaults/main.yml
+++ b/ansible/roles/vitess_build/defaults/main.yml
@@ -11,10 +11,11 @@
 
 ---
 
-golang_gover: '1.19.3'
+golang_gover: '1.19.4'
 golang_hash_linux_amd64:
   '1.18.7': 'sha256:6c967efc22152ce3124fc35cdf50fc686870120c5fd2107234d05d450a6105d8'
   '1.19.3': 'sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba'
+  '1.19.4': 'sha256:c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8'
 
 vitess_git_repo: "https://github.com/vitessio/vitess.git"
 vitess_git_version: "main"

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -1,4 +1,4 @@
-exec-go-version: "1.19.3"
+exec-go-version: "1.19.4"
 
 web-port: 9090
 web-template-path: ./go/server/templates

--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -1,4 +1,4 @@
-exec-go-version: "1.19.3"
+exec-go-version: "1.19.4"
 
 web-cron-schedule: "@midnight"
 web-cron-schedule-pull-requests: "*/5 * * * *"


### PR DESCRIPTION
This PR changes the go version used in the benchmarks to `go1.19.4`.