### PR TITLE
Remove deprecated vtctld flags and add `v16` support

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.7.9'
+        python-version: '3.10.9'
 
     - name: Update pip
       run: |

--- a/ansible/roles/vtctld/templates/cell@.service.j2
+++ b/ansible/roles/vtctld/templates/cell@.service.j2
@@ -10,7 +10,7 @@ WorkingDirectory={{vitess_root}}
 Type=oneshot
 User={{vitess_user}}
 ExecStart=/bin/bash -c 'vtctl \
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
 		-topo_implementation ${TOPO_IMPLEMENTATION} \
 		-topo_global_root ${TOPO_GLOBAL_ROOT} \
 		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \

--- a/ansible/roles/vtctld/templates/vtctld@.service.j2
+++ b/ansible/roles/vtctld/templates/vtctld@.service.j2
@@ -16,7 +16,7 @@ WorkingDirectory={{vitess_root}}
 User={{vitess_user}}
 ExecStartPre=/bin/bash -c "${TOPO_PREPARE_COMMAND}"
 ExecStart=/bin/bash -c 'vtctld \
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
 		-cell %i \
 		-service_map "grpc-vtctl" \
 		-enable_realtime_stats \
@@ -32,9 +32,6 @@ ExecStart=/bin/bash -c 'vtctld \
 	{% else %}
 		--cell %i \
 		--service_map "grpc-vtctl" \
-		--enable_realtime_stats \
-		--workflow_manager_init \
-		--workflow_manager_use_election \
 		--log_dir ${VTROOT}/tmp \
 		--port ${VTCTLD_PORT} \
 		--grpc_port ${GRPC_PORT} \

--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -18,7 +18,7 @@ GRPC_PORT='{{gateway.grpc_port | default(vtgate_grpc_port)}}'
 CELL={{ cell }}
 ADDITIONAL_CELLS=""
 EXTRA_VTGATE_FLAGS="\
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
     	-planner_version {{ vitess_planner_version }} \
 		-vschema_ddl_authorized_users \"%\" \
 		-vtgate-config-terse-errors \

--- a/ansible/roles/vtgate/templates/vtgate@.service.j2
+++ b/ansible/roles/vtgate/templates/vtgate@.service.j2
@@ -23,7 +23,7 @@ LimitNPROC=infinity
 LimitNOFILE=infinity
 LimitMEMLOCK=infinity
 ExecStart=/bin/bash -c 'vtgate \
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" %}
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
 		-service_map "grpc-vtgateservice" \
 		-alsologtostderr \
 		-enable_buffer \

--- a/ansible/roles/vttablet/templates/vttablet.conf.j2
+++ b/ansible/roles/vttablet/templates/vttablet.conf.j2
@@ -28,7 +28,7 @@ EXTRA_VTTABLET_FLAGS="--alsologtostderr \
     --queryserver-config-max-result-size=100000 \
     --queryserver-config-pool-size={{ tablet.connection_pool_size | default(vttablet_connection_pool_size) }} \
     --queryserver-config-stream-pool-size={{ tablet.stream_pool_size | default(vttablet_stream_pool_size) }} \
-	{% if vitess_version_name != "latest" %}
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_15" %}
     	--client-found-rows-pool-size={{ tablet.found_rows_pool_size | default(vttablet_found_rows_pool_size) }} \
     	--binlog_use_v3_resharding_mode=true \
 	{% endif %}

--- a/ansible/roles/vttablet/templates/vttablet@.service.j2
+++ b/ansible/roles/vttablet/templates/vttablet@.service.j2
@@ -26,31 +26,31 @@ ExecStart=/bin/bash -c 'vttablet \
 	--db_dba_user=vt_dba \
 	--db_filtered_user=vt_filtered \
 	--db_repl_user=vt_repl \
-    --tablet_hostname "$(hostname -I | cut -d \" \" -f 1)" \
-    --service_map "grpc-queryservice,grpc-tabletmanager,grpc-updatestream" \
-    --queryserver-config-passthrough-dmls \
-	{% if vitess_version_name != "latest" %}
-    	--enable-autocommit \
-    	--binlog_use_v3_resharding_mode \
+  --tablet_hostname "$(hostname -I | cut -d \" \" -f 1)" \
+  --service_map "grpc-queryservice,grpc-tabletmanager,grpc-updatestream" \
+  --queryserver-config-passthrough-dmls \
+	{% if vitess_version_name != "latest" and vitess_version_name != "v_15" %}
+    --enable-autocommit \
+    --binlog_use_v3_resharding_mode \
 	{% endif %}
-    --enable_replication_reporter \
-    --health_check_interval 5s \
-    --alsologtostderr \
-    --init_keyspace ${KEYSPACE} \
-    --init_shard ${SHARD} \
-    --init_db_name_override=${KEYSPACE} \
-    --init_tablet_type ${TABLET_TYPE} \
-    --mycnf_socket_file=${VTROOT}/socket/mysql%i.sock \
-    --mycnf_mysql_port=${MYSQL_PORT} \
-    --mysqlctl_socket=${VTROOT}/socket/mysqlctl%i.sock \
-    --port ${TABLET_PORT} \
-    --grpc_port ${GRPC_PORT} \
-    --tablet-path ${CELL}-%i \
-    --log_dir ${VTROOT}/tmp/vttablet-%i \
-    --topo_implementation ${TOPO_IMPLEMENTATION} \
-    --topo_global_root ${TOPO_GLOBAL_ROOT} \
-    --topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-    ${EXTRA_VTTABLET_FLAGS}'
+  --enable_replication_reporter \
+  --health_check_interval 5s \
+  --alsologtostderr \
+  --init_keyspace ${KEYSPACE} \
+  --init_shard ${SHARD} \
+  --init_db_name_override=${KEYSPACE} \
+  --init_tablet_type ${TABLET_TYPE} \
+  --mycnf_socket_file=${VTROOT}/socket/mysql%i.sock \
+  --mycnf_mysql_port=${MYSQL_PORT} \
+  --mysqlctl_socket=${VTROOT}/socket/mysqlctl%i.sock \
+  --port ${TABLET_PORT} \
+  --grpc_port ${GRPC_PORT} \
+  --tablet-path ${CELL}-%i \
+  --log_dir ${VTROOT}/tmp/vttablet-%i \
+  --topo_implementation ${TOPO_IMPLEMENTATION} \
+  --topo_global_root ${TOPO_GLOBAL_ROOT} \
+  --topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+  ${EXTRA_VTTABLET_FLAGS}'
 
 [Install]
 WantedBy=vitess-cluster.target


### PR DESCRIPTION
This PR removes several flags that were used in vtctld even though they were recently removed from Vitess. And it adds support for the upcoming v16 release.