### PR TITLE
Skip benchmarks on `cron_tags_14.0.4`

### DIFF
--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -8,7 +8,7 @@ web-port: 8080
 web-template-path: /root/arewefastyet/go/server/templates
 web-static-path: /root/arewefastyet/go/server/static
 web-benchmark-config-path: /root/arewefastyet/config/benchmarks/
-web-source-exclude-filter: "cron_tags_14.0.0-rc1"
+web-source-exclude-filter: "cron_tags_14.0.0-rc1,cron_tags_14.0.4"
 web-mode: "production"
 
 web-pr-label-trigger: '"Benchmark me"'


### PR DESCRIPTION
This PR skips, for now, the benchmarks made on `cron_tags_14.0.4`. They constantly fail due to compilation issue with `go1.19`.