### PR TITLE
Fix `ApplyVSchema`, clean up flag optimization and disable benchmarks on v14

### DIFF
--- a/ansible/create_cluster.yml
+++ b/ansible/create_cluster.yml
@@ -76,14 +76,8 @@
         force: true
 
     - name: Apply VSchema
-      when: vitess_version_name == 'latest'
       shell: |
         vtctlclient --server {{ groups['vtctld'][0] }}:15999 ApplyVSchema -- --vschema="$(cat /tmp/vschema_sysbench.json)" main
-
-    - name: Apply VSchema
-      when: vitess_version_name != 'latest'
-      shell: |
-        vtctlclient -server {{ groups['vtctld'][0] }}:15999 ApplyVSchema -vschema="$(cat /tmp/vschema_sysbench.json)" main
 
     - name: Print go version
       debug: msg="VSchema is applied."

--- a/ansible/roles/vtctld/templates/cell@.service.j2
+++ b/ansible/roles/vtctld/templates/cell@.service.j2
@@ -10,21 +10,12 @@ WorkingDirectory={{vitess_root}}
 Type=oneshot
 User={{vitess_user}}
 ExecStart=/bin/bash -c 'vtctl \
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
-		-topo_implementation ${TOPO_IMPLEMENTATION} \
-		-topo_global_root ${TOPO_GLOBAL_ROOT} \
-		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-		AddCellInfo \
-		-root ${CELL_ROOT} \
-		-server_address ${CELL_TOPO_SERVER} \
-	{% else %}
 		--topo_implementation ${TOPO_IMPLEMENTATION} \
 		--topo_global_root ${TOPO_GLOBAL_ROOT} \
 		--topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
 		AddCellInfo -- \
 		--root ${CELL_ROOT} \
 		--server_address ${CELL_TOPO_SERVER} \
-	{% endif %}
     %i || /bin/true'
 RemainAfterExit=true
 StandardOutput=journal

--- a/ansible/roles/vtctld/templates/vtctld@.service.j2
+++ b/ansible/roles/vtctld/templates/vtctld@.service.j2
@@ -16,20 +16,6 @@ WorkingDirectory={{vitess_root}}
 User={{vitess_user}}
 ExecStartPre=/bin/bash -c "${TOPO_PREPARE_COMMAND}"
 ExecStart=/bin/bash -c 'vtctld \
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
-		-cell %i \
-		-service_map "grpc-vtctl" \
-		-enable_realtime_stats \
-		-workflow_manager_init \
-		-workflow_manager_use_election \
-		-enable_queries \
-		-log_dir ${VTROOT}/tmp \
-		-port ${VTCTLD_PORT} \
-		-grpc_port ${GRPC_PORT} \
-		-topo_implementation ${TOPO_IMPLEMENTATION} \
-		-topo_global_root ${TOPO_GLOBAL_ROOT} \
-		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-	{% else %}
 		--cell %i \
 		--service_map "grpc-vtctl" \
 		--log_dir ${VTROOT}/tmp \
@@ -38,7 +24,6 @@ ExecStart=/bin/bash -c 'vtctld \
 		--topo_implementation ${TOPO_IMPLEMENTATION} \
 		--topo_global_root ${TOPO_GLOBAL_ROOT} \
 		--topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-	{% endif %}
     ${EXTRA_VTCTLD_FLAGS}'
 
 [Install]

--- a/ansible/roles/vtgate/templates/vtgate.conf.j2
+++ b/ansible/roles/vtgate/templates/vtgate.conf.j2
@@ -18,15 +18,6 @@ GRPC_PORT='{{gateway.grpc_port | default(vtgate_grpc_port)}}'
 CELL={{ cell }}
 ADDITIONAL_CELLS=""
 EXTRA_VTGATE_FLAGS="\
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
-    	-planner_version {{ vitess_planner_version }} \
-		-vschema_ddl_authorized_users \"%\" \
-		-vtgate-config-terse-errors \
-		-gate_query_cache_size {{ vtgate_query_cache_size }} \
-		-tablet_types_to_wait REPLICA \
-		{{gateway.extra_flags|default("")}} \
-		{{extra_vtgate_flags|default("")}} \
-	{% else %}
 		--planner-version {{ vitess_planner_version }} \
 		--vschema_ddl_authorized_users \"%\" \
 		--vtgate-config-terse-errors \
@@ -34,5 +25,4 @@ EXTRA_VTGATE_FLAGS="\
 		--tablet_types_to_wait REPLICA \
 		{{gateway.extra_flags|default("")}} \
 		{{extra_vtgate_flags|default("")}} \
-	{% endif %}
 "

--- a/ansible/roles/vtgate/templates/vtgate@.service.j2
+++ b/ansible/roles/vtgate/templates/vtgate@.service.j2
@@ -23,24 +23,6 @@ LimitNPROC=infinity
 LimitNOFILE=infinity
 LimitMEMLOCK=infinity
 ExecStart=/bin/bash -c 'vtgate \
-	{% if vitess_version_name != "latest" and vitess_version_name != "v_14" and vitess_version_name != "v_15" %}
-		-service_map "grpc-vtgateservice" \
-		-alsologtostderr \
-		-enable_buffer \
-		-buffer_size=${VTGATE_BUFFER_SIZE} \
-		-buffer_max_failover_duration ${VTGATE_BUFFER_DURATION} \
-		-cell ${CELL} \
-		-cells_to_watch ${CELL}${ADDITIONAL_CELLS} \
-		-mysql_server_port ${MYSQL_PORT} \
-		-mysql_server_socket_path ${VTROOT}/socket/gateway-%i.sock \
-		-grpc_port ${GRPC_PORT} \
-		-port ${VTGATE_PORT} \
-		-mysql_auth_server_impl none \
-		-topo_global_root ${TOPO_GLOBAL_ROOT} \
-		-topo_implementation ${TOPO_IMPLEMENTATION} \
-		-topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
-		-log_dir ${VTROOT}/tmp/vtgate-%i \
-	{% else %}
 		--service_map "grpc-vtgateservice" \
 		--alsologtostderr \
 		--enable_buffer \
@@ -57,7 +39,6 @@ ExecStart=/bin/bash -c 'vtgate \
 		--topo_implementation ${TOPO_IMPLEMENTATION} \
 		--topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
 		--log_dir ${VTROOT}/tmp/vtgate-%i \
-	{% endif %}
     ${EXTRA_VTGATE_FLAGS}'
 
 [Install]

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -8,10 +8,9 @@ web-benchmark-config-path: ./config/benchmarks/
 web-pr-label-trigger: '"Benchmark me"'
 web-pr-label-trigger-planner-v3: '"Benchmark me (V3)"'
 web-vitess-path: /tmp
-web-source-exclude-filter: "cron_tags_14.0.0-rc1"
 web-mode: "development"
-web-cron-schedule: "*/1 * * * *"
-web-cron-schedule-pull-requests: "*/1 * * * *"
+web-cron-schedule: "*/1 * 1 * 1"
+web-cron-schedule-pull-requests: "*/1 * 1 * 1"
 web-cron-schedule-tags: "*/1 * * * *"
 
 ansible-root-directory: "./ansible/"

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -140,7 +140,7 @@ func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 
 	// We take the 2 latest major release
 	// TODO: @Florent: use the three latest major releases once v17 is out
-	minimumRelease := allReleases[len(allReleases)-1].Version.Major - 2
+	minimumRelease := allReleases[0].Version.Major - 1
 	for _, release := range allReleases {
 		if release.Version.Major >= minimumRelease {
 			latestReleases = append(latestReleases, release)
@@ -204,8 +204,11 @@ func GetLatestVitessReleaseBranchCommitHash(repoDir string) ([]*Release, error) 
 		return nil, err
 	}
 	var latestReleaseBranches []*Release
+	// We take the 2 latest major release
+	// TODO: @Florent: use the three latest major releases once v17 is out
+	minimumRelease := res[0].Version.Major - 1
 	for _, release := range res {
-		if release.Version.Major >= 12 {
+		if release.Version.Major >= minimumRelease {
 			latestReleaseBranches = append(latestReleaseBranches, release)
 		}
 	}

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -137,8 +137,12 @@ func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 		return nil, err
 	}
 	var latestReleases []*Release
+
+	// We take the 2 latest major release
+	// TODO: @Florent: use the three latest major releases once v17 is out
+	minimumRelease := allReleases[len(allReleases)-1].Version.Major - 2
 	for _, release := range allReleases {
-		if release.Version.Major >= 12 {
+		if release.Version.Major >= minimumRelease {
 			latestReleases = append(latestReleases, release)
 		}
 	}


### PR DESCRIPTION
This Pull Request fixes an issue on `v15` benchmarks around `ApplyVSchema` where the step was failing due to an incorrect flag.

This PR also disables benchmarks on v14 as they have been failing for some time due to incompatible Golang versions being used.