### PR TITLE
[Refactor] Redesign status page for improved responsiveness

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://kit.fontawesome.com/053006010f.js" crossorigin="anonymous"></script>
     <title>Vite + React</title>
   </head>
   <body>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.2",
-        "react-spinners": "^0.13.8"
+        "react-spinners": "^0.13.8",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
@@ -3347,6 +3348,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "4.3.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
@@ -5751,6 +5760,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vite": {
       "version": "4.3.9",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",
-    "react-spinners": "^0.13.8"
+    "react-spinners": "^0.13.8",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",

--- a/website/src/components/ExecutionQueue/ExeQueue.jsx
+++ b/website/src/components/ExecutionQueue/ExeQueue.jsx
@@ -16,15 +16,16 @@ limitations under the License.
 
 import React from 'react';
 
+import '../ExecutionQueue/exeQueue.css'
 
 const ExeQueue = ({data}) => {
     return (
-        <tr>
-            <td><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0, 6)}</a></td>
-            <td>{data.source}</td>
-            <td>{data.type_of}</td>
-            <td>{data.pull_nb}</td>
-        </tr>
+        <div className='queue__data flex'>
+            <span className='sha'><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></span>
+            <span className='width--11em'>{data.source}</span>
+            <span className='width--11em'>{data.type_of}</span>
+            <span className='width--5em'>{data.pull_nb}</span>
+        </div>
     );
 };
 

--- a/website/src/components/ExecutionQueue/exeQueue.css
+++ b/website/src/components/ExecutionQueue/exeQueue.css
@@ -1,0 +1,9 @@
+.queue__data{
+    justify-content: space-around;
+    border-bottom: #B5ADAD 1px solid;
+    padding: 20px 3px;
+}
+
+.sha{
+    min-width: 6em;
+}

--- a/website/src/components/ExecutionQueue/exeQueue.css
+++ b/website/src/components/ExecutionQueue/exeQueue.css
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .queue__data{
     justify-content: space-around;
     border-bottom: #B5ADAD 1px solid;

--- a/website/src/components/PreviousExeResponsive/PreviousExeRes.jsx
+++ b/website/src/components/PreviousExeResponsive/PreviousExeRes.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import moment from 'moment';
+
+import '../PreviousExeResponsive/previousExeRes.css'
+
+const PreviousExeRes = ({data}) => {
+
+    // Create a Moment object from the given date string
+    const startedDate = moment(data.started_at)
+    const finishedDate = moment(data.finished_at)
+    
+    // Format the date using the format method of Moment.js
+    // Here, we use 'DD/MM/YYYY HH:mm:ss' as the desired format
+    const formattedStartedDate = startedDate.format('MM/DD/YYYY HH:mm')
+    const formattedFinishedDate = finishedDate.format('MM/DD/YYYY HH:mm')
+
+    return (
+        <>
+        <tr className='previousExeRes' >
+            <td colSpan="5" >
+                <span className='previousExeRes__containter'>
+                    <span className='previousExeRes__span'>UUID <i className="fa-solid fa-arrow-right"></i> {data.uuid.slice(0, 8)} <br/><br/></span>
+                    <span className='previousExeRes__span'>SHA <i className="fa-solid fa-arrow-right"></i> <a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a> <br/><br/></span>
+                    <span className='previousExeRes__span'>Strated <i className="fa-solid fa-arrow-right"></i> {formattedStartedDate} <br/><br/></span>
+                    <span className='previousExeRes__span'>Finished <i className="fa-solid fa-arrow-right"></i> {formattedFinishedDate} <br/><br/></span>
+                    <span className='previousExeRes__span'>Type <i className="fa-solid fa-arrow-right"></i> {data.type_of} <br/><br/></span>
+                    <span className='previousExeRes__span'>PR <i className="fa-solid fa-arrow-right"></i> {data.pull_nb} <br/><br/></span>
+                    <span className='previousExeRes__span'>Go version <i className="fa-solid fa-arrow-right"></i> {data.golang_version} <br/><br/></span>
+
+                </span>
+            </td>
+        </tr>
+        
+        </>
+    );
+};
+
+export default PreviousExeRes;

--- a/website/src/components/PreviousExeResponsive/PreviousExeRes.jsx
+++ b/website/src/components/PreviousExeResponsive/PreviousExeRes.jsx
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import React from 'react';
 import moment from 'moment';
 

--- a/website/src/components/PreviousExeResponsive/previousExeRes.css
+++ b/website/src/components/PreviousExeResponsive/previousExeRes.css
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .previousExeRes{
     text-align: start;
     height: 200px;

--- a/website/src/components/PreviousExeResponsive/previousExeRes.css
+++ b/website/src/components/PreviousExeResponsive/previousExeRes.css
@@ -1,0 +1,34 @@
+.previousExeRes{
+    text-align: start;
+    height: 200px;
+    width: 100%;
+    background: none;
+    
+}
+.previousExeRes td{
+    padding-top: 20px;
+}
+
+.previousExeRes__span{
+    padding-left: 20px;
+}
+.previousExeRes__containter{
+    width: 100%;
+    padding-top: 20px;
+}
+
+
+.previousExeRes__td{
+    display: grid;
+    grid-column: span;
+}
+
+.fa-arrow-right{
+    color: rgb(248, 107, 37);
+}
+
+@media only screen and (min-width: 1225px) {
+    .previousExeRes{
+        display: none;
+    }
+}

--- a/website/src/components/PreviousExecutions/PreviousExe.jsx
+++ b/website/src/components/PreviousExecutions/PreviousExe.jsx
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, {useState} from 'react';
 import moment from 'moment';
 
 import '../PreviousExecutions/previousexe.css'
 
-const PreviousExe = ({data}) => {
+const PreviousExe = ({data, handleClick}) => {
         /*BACKGROUND STATUS*/ 
 
     const getStatusClass = (status) => {
@@ -43,19 +43,23 @@ const PreviousExe = ({data}) => {
           // Here, we use 'DD/MM/YYYY HH:mm:ss' as the desired format
           const formattedStartedDate = startedDate.format('MM/DD/YYYY HH:mm')
           const formattedFinishedDate = finishedDate.format('MM/DD/YYYY HH:mm')
+          
 
+          
+          
     return (
 
-        <tr>
-            <td>{data.uuid.slice(0, 8)}</td>
-            <td><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></td>
-            <td>{data.source}</td>
-            <td>{formattedStartedDate}</td>
-            <td>{formattedFinishedDate}</td>
-            <td>{data.type_of}</td>
-            <td className='tdPR'>{data.pull_nb}</td>
-            <td>{data.golang_version}</td>
+        <tr className='previousExetd'>
+            <td className='hiddenResponsiveMobile'>{data.uuid.slice(0, 8)}</td>
+            <td className='hiddenResponsiveMobile'><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></td>
+            <td className='tdSource'>{data.source}</td>
+            <td className='hiddenResponsiveMobile'>{formattedStartedDate}</td>
+            <td className='hiddenResponsiveMobile'>{formattedFinishedDate}</td>
+            <td className='hiddenResponsiveMobile'>{data.type_of}</td>
+            <td className='tdPR hiddenResponsiveMobile'>{data.pull_nb}</td>
+            <td className='hiddenResponsiveMobile'>{data.golang_version}</td>
             <td ><span className={`data ${getStatusClass(data.status)} tdStatus`}>{data.status}</span></td>
+            <td  className='tdInfos hiddenResponsiveDesktop '><i id={data.uuid} onClick={handleClick} className='fa-sharp fa-solid fa-circle-info'></i></td>
         </tr>
         
     );

--- a/website/src/components/PreviousExecutions/PreviousExe.jsx
+++ b/website/src/components/PreviousExecutions/PreviousExe.jsx
@@ -19,7 +19,7 @@ import moment from 'moment';
 
 import '../PreviousExecutions/previousexe.css'
 
-const PreviousExe = ({data, handleClick}) => {
+const PreviousExe = ({data, className}) => {
         /*BACKGROUND STATUS*/ 
 
     const getStatusClass = (status) => {
@@ -49,18 +49,17 @@ const PreviousExe = ({data, handleClick}) => {
           
     return (
 
-        <tr className='previousExetd'>
-            <td className='hiddenResponsiveMobile'>{data.uuid.slice(0, 8)}</td>
-            <td className='hiddenResponsiveMobile'><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></td>
-            <td className='tdSource'>{data.source}</td>
-            <td className='hiddenResponsiveMobile'>{formattedStartedDate}</td>
-            <td className='hiddenResponsiveMobile'>{formattedFinishedDate}</td>
-            <td className='hiddenResponsiveMobile'>{data.type_of}</td>
-            <td className='tdPR hiddenResponsiveMobile'>{data.pull_nb}</td>
-            <td className='hiddenResponsiveMobile'>{data.golang_version}</td>
-            <td ><span className={`data ${getStatusClass(data.status)} tdStatus`}>{data.status}</span></td>
-            <td  className='tdInfos hiddenResponsiveDesktop '><i id={data.uuid} onClick={handleClick} className='fa-sharp fa-solid fa-circle-info'></i></td>
-        </tr>
+        <div className={`previousExe__data flex ${className}`}>
+          <span className='previousExe__data__6em '>{data.uuid.slice(0, 8)}</span>
+          <span className='previousExe__data__6em'><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></span>
+          <span className='tdSource previousExe__data__11em'>{data.source}</span>
+          <span className='tdSource previousExe__data__11em'>{formattedStartedDate}</span>
+          <span className='tdSource previousExe__data__11em'>{formattedFinishedDate}</span>
+          <span className='previousExe__data__11em'>{data.type_of}</span>
+          <span className='previousExe__PR'>{data.pull_nb}</span>
+          <span className='previousExe__data__6em'>{data.golang_version}</span>
+          <span  className={`data ${getStatusClass(data.status)} spanStatus previousExe__data__6em`}>{data.status}</span>
+        </div>
         
     );
 };

--- a/website/src/components/PreviousExecutions/PreviousExe.jsx
+++ b/website/src/components/PreviousExecutions/PreviousExe.jsx
@@ -50,15 +50,15 @@ const PreviousExe = ({data, className}) => {
     return (
 
         <div className={`previousExe__data flex ${className}`}>
-          <span className='previousExe__data__6em '>{data.uuid.slice(0, 8)}</span>
-          <span className='previousExe__data__6em'><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></span>
-          <span className='tdSource previousExe__data__11em'>{data.source}</span>
-          <span className='tdSource previousExe__data__11em'>{formattedStartedDate}</span>
-          <span className='tdSource previousExe__data__11em'>{formattedFinishedDate}</span>
-          <span className='previousExe__data__11em'>{data.type_of}</span>
-          <span className='previousExe__PR'>{data.pull_nb}</span>
-          <span className='previousExe__data__6em'>{data.golang_version}</span>
-          <span  className={`data ${getStatusClass(data.status)} spanStatus previousExe__data__6em`}>{data.status}</span>
+          <span className='width--6em '>{data.uuid.slice(0, 8)}</span>
+          <span className='width--6em'><a target='_blank' href={`https://github.com/vitessio/vitess/commit/${data.git_ref}`}>{data.git_ref.slice(0,6)}</a></span>
+          <span className='tdSource width--11em'>{data.source}</span>
+          <span className='tdSource width--11em'>{formattedStartedDate}</span>
+          <span className='tdSource width--11em'>{formattedFinishedDate}</span>
+          <span className='width--11em'>{data.type_of}</span>
+          <span className='width--5em'>{data.pull_nb}</span>
+          <span className='width--6em'>{data.golang_version}</span>
+          <span  className={`data ${getStatusClass(data.status)} spanStatus width--6em`}>{data.status}</span>
         </div>
         
     );

--- a/website/src/components/PreviousExecutions/previousexe.css
+++ b/website/src/components/PreviousExecutions/previousexe.css
@@ -14,12 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.previousExetd td{
-    padding: 20px 0px;
+.previousExe__data{
+    justify-content: space-between;
     text-align: center;
+    border-bottom: #B5ADAD 1px solid;
+    padding: 20px 3px;
 }
 
-.tdPR{
+
+.previousExe__data__6em{
+    width: 6em;
+}
+
+.previousExe__data__11em{
+    width: 11em;
+}
+
+
+.previousExe__PR{
     min-width: 5em;
 }
 
@@ -30,15 +42,12 @@ a{
 
 
 
-.tdStatus{
+.spanStatus{
     padding: 3px 20px;
     border-radius: 20px;
     
 }
 
-.tdInfos{
-    font-size: 1.5rem;
-}
 
 
 .finished {

--- a/website/src/components/PreviousExecutions/previousexe.css
+++ b/website/src/components/PreviousExecutions/previousexe.css
@@ -22,18 +22,7 @@ limitations under the License.
 }
 
 
-.previousExe__data__6em{
-    width: 6em;
-}
 
-.previousExe__data__11em{
-    width: 11em;
-}
-
-
-.previousExe__PR{
-    min-width: 5em;
-}
 
 a{
     text-decoration: none;

--- a/website/src/components/PreviousExecutions/previousexe.css
+++ b/website/src/components/PreviousExecutions/previousexe.css
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-td{
+.previousExetd td{
     padding: 20px 0px;
     text-align: center;
 }
@@ -36,6 +36,10 @@ a{
     
 }
 
+.tdInfos{
+    font-size: 1.5rem;
+}
+
 
 .finished {
     background-color: green;
@@ -51,3 +55,12 @@ a{
     background-color: grey;
 }
 
+
+
+/* MEDIA QUERIES FOR TABLETS */
+@media only screen and (max-width: 1225px) {
+    .tdSource{
+        max-width: 5em;
+        word-wrap:break-word ;
+    }
+}

--- a/website/src/pages/Status/Status.jsx
+++ b/website/src/pages/Status/Status.jsx
@@ -18,12 +18,12 @@ import React from 'react';
 import { useState, useEffect } from 'react';
 import RingLoader from "react-spinners/RingLoader";
 import { v4 as uuidv4 } from 'uuid';
-import './status.css';
+
 
 import PreviousExe from '../../components/PreviousExecutions/PreviousExe';
 import ExeQueue from '../../components/ExecutionQueue/ExeQueue';
 import PreviousExeRes from '../../components/PreviousExeResponsive/PreviousExeRes';
-
+import './status.css';
 
 
 

--- a/website/src/pages/Status/Status.jsx
+++ b/website/src/pages/Status/Status.jsx
@@ -84,83 +84,68 @@ const Status = () => {
             </article>
             <figure className='line'></figure>
             
-            {isLoading ? (
+             {isLoading ? (
               <div className='loadingSpinner'>
                 <RingLoader loading={isLoading} color='#E77002' size={300}/>
                 </div>
-            ): (
-                <>
+            ): ( 
+                  <>
+                      {/* EXECUTION QUEUE  */}
 
-
-                      {/* EXECUTION QUEUE */}
-
-              
-                  {dataQueue.length > 0 ?(
+                
+                  {/* {dataQueue.length > 0 ?( */}
                     <>
                       <article className='queue'>
                         <h3>Executions Queue</h3>
-                        <table>
-                          <thead>
-                            <tr>
-                              <th>SHA</th>
-                              <th>Source</th>
-                              <th>Type</th>
-                              <th>Pull Request</th>
-                            </tr>
-                          </thead>
-                          <tbody>
+                        <div className='queue__top flex'>
+                            <span>SHA</span>
+                            <span>Source</span>
+                            <span>Type</span>
+                            <span>Pull Request</span>
+                        </div>
+                        <figure className='queue__top__line'></figure>
                               {dataQueue.map((queue,index) => {
                                 return (
                                   <ExeQueue data={queue} key={index}/>
                                 )
                               })}
-                          </tbody>
-                        </table>
+                          
                       </article>
                       <figure className='line'></figure>
                   </>
-                    ) : null}
-                
-              
-                  {/*PREVIOUS EXECUTIONS*/}
-                
-                {dataPreviousExe.length > 0 ? (
+                    {/* ) : null } */}
+                  
+                  
+
+                    {/* PREVIOUS EXECUTIONS */}
+
                   <article className='previousExe'>
-                  <h3>Previous Execution</h3>
-                  <table>
-                      <thead className='previousExe__thead'>
-                          <tr className='previousExe__thead__tr '>
-                              <th className='hiddenResponsiveMobile'>UUID</th>
-                              <th className='hiddenResponsiveMobile'>SHA</th>
-                              <th>Source</th>
-                              <th className='hiddenResponsiveMobile'>Started</th>
-                              <th className='hiddenResponsiveMobile'>Finished</th>
-                              <th className='hiddenResponsiveMobile'>Type</th>
-                              <th className='hiddenResponsiveMobile'>PR</th>
-                              <th className='hiddenResponsiveMobile'>Go Version</th>
-                              <th>Status</th>
-                              <th className='hiddenResponsiveDesktop'>More</th>
-                          </tr>
-                      </thead>
-                      <tbody>
-                      {dataPreviousExe.map((previousExe, index) => {
-                          return (
-                            <React.Fragment key={uuidv4()}>
-                              <PreviousExe data={previousExe} key={index} handleClick={() => handleClick(index)}/>
-                              {selectedButtonIndex === index && <PreviousExeRes data={previousExe} key={uuidv4()} />}
-                            </React.Fragment>
-                          );
-                        })}
-                      </tbody>
-                  </table>
-              </article>
+                    <h3> Previous Executions</h3>
+                    <div className='previousExe__top flex'>
+                      <span className='previousExe__top__6em'>UUID</span>
+                      <span className='previousExe__top__6em'>SHA</span>
+                      <span className='previousExe__top__11em'>Source</span>
+                      <span className='previousExe__top__11em'>Started</span>
+                      <span className='previousExe__top__11em'>Finished</span>
+                      <span className='previousExe__top__11em'>Type</span>
+                      <span className='previousExe__top__5em'>PR</span>
+                      <span className='previousExe__top__6em'>Go version</span>
+                      <span className='previousExe__top__6em'>Status</span>
+                    </div>
+                    <figure className='previousExe__top__line'></figure>
+                    
+                          {dataPreviousExe.map((previousExe, index) => {
+                                const isEvenIndex = index % 2 === 0;
+                                const backgroundGrey = isEvenIndex ? 'grey-background' : '';
 
-                ): null}
-                
-             </>
+                                return ( 
+                                  <PreviousExe data={previousExe} key={index} className={backgroundGrey}/>
+                                )})}
 
-             )}
-            {error ? <div className='apiError'>{error}</div> : null}
+                    </article>
+                  </>
+              )}
+
               
         </div>
         

--- a/website/src/pages/Status/Status.jsx
+++ b/website/src/pages/Status/Status.jsx
@@ -18,12 +18,13 @@ import React from 'react';
 import { useState, useEffect } from 'react';
 import RingLoader from "react-spinners/RingLoader";
 import { v4 as uuidv4 } from 'uuid';
-
-import './status.css'
+import './status.css';
 
 import PreviousExe from '../../components/PreviousExecutions/PreviousExe';
 import ExeQueue from '../../components/ExecutionQueue/ExeQueue';
 import PreviousExeRes from '../../components/PreviousExeResponsive/PreviousExeRes';
+
+
 
 
 
@@ -93,15 +94,15 @@ const Status = () => {
                       {/* EXECUTION QUEUE  */}
 
                 
-                  {/* {dataQueue.length > 0 ?( */}
+                  {dataQueue.length > 0 ?(
                     <>
                       <article className='queue'>
                         <h3>Executions Queue</h3>
                         <div className='queue__top flex'>
-                            <span>SHA</span>
-                            <span>Source</span>
-                            <span>Type</span>
-                            <span>Pull Request</span>
+                            <span className='width--6em'>SHA</span>
+                            <span className='width--11em'> Source</span>
+                            <span className='width--11em'>Type</span>
+                            <span className='width--5em'>Pull Request</span>
                         </div>
                         <figure className='queue__top__line'></figure>
                               {dataQueue.map((queue,index) => {
@@ -113,39 +114,42 @@ const Status = () => {
                       </article>
                       <figure className='line'></figure>
                   </>
-                    {/* ) : null } */}
+                    ) : null }
                   
                   
 
                     {/* PREVIOUS EXECUTIONS */}
-
-                  <article className='previousExe'>
-                    <h3> Previous Executions</h3>
-                    <div className='previousExe__top flex'>
-                      <span className='previousExe__top__6em'>UUID</span>
-                      <span className='previousExe__top__6em'>SHA</span>
-                      <span className='previousExe__top__11em'>Source</span>
-                      <span className='previousExe__top__11em'>Started</span>
-                      <span className='previousExe__top__11em'>Finished</span>
-                      <span className='previousExe__top__11em'>Type</span>
-                      <span className='previousExe__top__5em'>PR</span>
-                      <span className='previousExe__top__6em'>Go version</span>
-                      <span className='previousExe__top__6em'>Status</span>
-                    </div>
-                    <figure className='previousExe__top__line'></figure>
-                    
-                          {dataPreviousExe.map((previousExe, index) => {
-                                const isEvenIndex = index % 2 === 0;
-                                const backgroundGrey = isEvenIndex ? 'grey-background' : '';
-
-                                return ( 
-                                  <PreviousExe data={previousExe} key={index} className={backgroundGrey}/>
-                                )})}
-
-                    </article>
+                  
+                  {dataPreviousExe.length > 0 ?(
+                      <article className='previousExe'>
+                      <h3> Previous Executions</h3>
+                      <div className='previousExe__top flex'>
+                        <span className='width--6em'>UUID</span>
+                        <span className='width--6em'>SHA</span>
+                        <span className='width--11em'>Source</span>
+                        <span className='width--11em'>Started</span>
+                        <span className='width--11em'>Finished</span>
+                        <span className='width--11em'>Type</span>
+                        <span className='width--5em'>PR</span>
+                        <span className='width--6em'>Go version</span>
+                        <span className='width--6em'>Status</span>
+                      </div>
+                      <figure className='previousExe__top__line'></figure>
+                      
+                            {dataPreviousExe.map((previousExe, index) => {
+                                  const isEvenIndex = index % 2 === 0;
+                                  const backgroundGrey = isEvenIndex ? 'grey--background' : '';
+  
+                                  return ( 
+                                    <PreviousExe data={previousExe} key={index} className={backgroundGrey}/>
+                                  )})}
+  
+                      </article>
+                  ) : null }
+                  
                   </>
               )}
-
+                 {error ? <div className='apiError'>{error}</div> : null}
               
         </div>
         

--- a/website/src/pages/Status/Status.jsx
+++ b/website/src/pages/Status/Status.jsx
@@ -17,12 +17,13 @@ limitations under the License.
 import React from 'react';
 import { useState, useEffect } from 'react';
 import RingLoader from "react-spinners/RingLoader";
-
+import { v4 as uuidv4 } from 'uuid';
 
 import './status.css'
 
 import PreviousExe from '../../components/PreviousExecutions/PreviousExe';
 import ExeQueue from '../../components/ExecutionQueue/ExeQueue';
+import PreviousExeRes from '../../components/PreviousExeResponsive/PreviousExeRes';
 
 
 
@@ -33,6 +34,7 @@ const Status = () => {
   const [dataQueue, setDataQueue] = useState([]);
   const [dataPreviousExe, setDataPreviousExe] = useState([]);
   const [error, setError] = useState(null);
+  const [selectedButtonIndex, setSelectedButtonIndex] = useState(null);
 
   
   useEffect(() => {
@@ -57,8 +59,11 @@ const Status = () => {
     fetchData();
   }, []);
   
-  
 
+  const handleClick = (index) => {
+    setSelectedButtonIndex((prevIndex) => (prevIndex === index ? null : index));
+  };
+  
 
     return (
         <div className='status'>
@@ -125,23 +130,27 @@ const Status = () => {
                   <table>
                       <thead className='previousExe__thead'>
                           <tr className='previousExe__thead__tr '>
-                              <th>UUID</th>
-                              <th>SHA</th>
+                              <th className='hiddenResponsiveMobile'>UUID</th>
+                              <th className='hiddenResponsiveMobile'>SHA</th>
                               <th>Source</th>
-                              <th>Started</th>
-                              <th>Finished</th>
-                              <th>Type</th>
-                              <th>PR</th>
-                              <th>Go Version</th>
+                              <th className='hiddenResponsiveMobile'>Started</th>
+                              <th className='hiddenResponsiveMobile'>Finished</th>
+                              <th className='hiddenResponsiveMobile'>Type</th>
+                              <th className='hiddenResponsiveMobile'>PR</th>
+                              <th className='hiddenResponsiveMobile'>Go Version</th>
                               <th>Status</th>
+                              <th className='hiddenResponsiveDesktop'>More</th>
                           </tr>
                       </thead>
                       <tbody>
-                          {dataPreviousExe.map((previousExe,index) => {
-                            return (
-                              <PreviousExe data={previousExe} key={index}/>
-                            )
-                          })}
+                      {dataPreviousExe.map((previousExe, index) => {
+                          return (
+                            <React.Fragment key={uuidv4()}>
+                              <PreviousExe data={previousExe} key={index} handleClick={() => handleClick(index)}/>
+                              {selectedButtonIndex === index && <PreviousExeRes data={previousExe} key={uuidv4()} />}
+                            </React.Fragment>
+                          );
+                        })}
                       </tbody>
                   </table>
               </article>

--- a/website/src/pages/Status/status.css
+++ b/website/src/pages/Status/status.css
@@ -24,7 +24,7 @@ limitations under the License.
 
 .status__top{
     margin-top: 100px;
-    
+    align-items: center;
     
     
 }
@@ -82,11 +82,19 @@ tr{
     border-bottom: 1px #B5ADAD solid;
 }
 
+.bodyCotainer{
+    display: block;
+    width: 100%;
+}
+
 
     /*PREVIOUS EXECUTIONS*/
 
 .previousExe{
     color: white;
+}
+.hiddenResponsiveDesktop{
+    display: none;
 }
 
      /* EXECUTION QUEUE */
@@ -110,4 +118,46 @@ tr{
     margin-top: 200px;
     text-align: center;
     font-size: 3rem;
+}
+
+
+ /* MEDIA QUERIES FOR TABLETS */
+ @media only screen and (max-width: 1225px) {
+    .status{
+        padding: 0px 20px 50px 20px;
+    }
+    .status__top__text h2{
+        font-size: 4rem;
+    }
+    .statusStats{
+        width: 300px;
+
+    }
+    .hiddenResponsiveMobile{
+        display: none;
+    }
+    .hiddenResponsiveDesktop{
+        display: block;
+    }
+
+ }
+
+
+  /* MEDIA QUERIES FOR MOBILE */
+@media only screen and (max-width: 767px){
+    .status__top{
+        flex-direction: column;
+        justify-content: center;
+    }
+    .status__top__text{
+        width: 100%;
+        margin-right: 0px;
+        text-align: center;
+    }
+    .statusStats{
+        width: 300px;
+        height: 300px;
+        margin-top: 50px;
+
+    }
 }

--- a/website/src/pages/Status/status.css
+++ b/website/src/pages/Status/status.css
@@ -62,6 +62,19 @@ limitations under the License.
     text-align: center;
 }
 
+.width--5em{
+    width: 5em;
+}
+
+.width--6em{
+    width: 6em;
+}
+
+.width--11em{
+    width: 11em;
+}
+
+
 
 
     /*PREVIOUS EXECUTIONS*/
@@ -81,19 +94,8 @@ limitations under the License.
     
 }
 
-.previousExe__top__5em{
-    width: 5em;
-}
 
-.previousExe__top__6em{
-    width: 6em;
-}
-
-.previousExe__top__11em{
-    width: 11em;
-}
-
-.grey-background{
+.grey--background{
     background-color: #343A40;
 }
 
@@ -102,6 +104,7 @@ limitations under the License.
 .queue{
     color: white;
     margin-bottom: 200px;
+    text-align: center;
 }
 .queue__top__line{
     border: #B5ADAD 1px solid;

--- a/website/src/pages/Status/status.css
+++ b/website/src/pages/Status/status.css
@@ -62,30 +62,6 @@ limitations under the License.
     text-align: center;
 }
 
-    /*STATUS TABLE*/
-
-.status th{
-    font-weight: 200;
-    padding-bottom: 10px;
-}
-
-.status table{
-    width: 100%;
-    border-collapse: collapse;
-}
-
-tr:nth-child(even) {
-    background-color: #343A40; /* Background color for even rows. */
-}
-
-tr{
-    border-bottom: 1px #B5ADAD solid;
-}
-
-.bodyCotainer{
-    display: block;
-    width: 100%;
-}
 
 
     /*PREVIOUS EXECUTIONS*/
@@ -93,8 +69,32 @@ tr{
 .previousExe{
     color: white;
 }
-.hiddenResponsiveDesktop{
-    display: none;
+.previousExe__top{
+    justify-content: space-between;
+}
+.previousExe__top__line{
+    border: #B5ADAD 1px solid;
+    margin-top: 10px;
+}
+.previousExe__top span{
+    text-align: center;
+    
+}
+
+.previousExe__top__5em{
+    width: 5em;
+}
+
+.previousExe__top__6em{
+    width: 6em;
+}
+
+.previousExe__top__11em{
+    width: 11em;
+}
+
+.grey-background{
+    background-color: #343A40;
 }
 
      /* EXECUTION QUEUE */
@@ -102,6 +102,13 @@ tr{
 .queue{
     color: white;
     margin-bottom: 200px;
+}
+.queue__top__line{
+    border: #B5ADAD 1px solid;
+    margin-top: 10px;
+}
+.queue__top{
+    justify-content: space-around;
 }
 
     /* SPINNER */


### PR DESCRIPTION
I redesigned the status page and its components from scratch, but this time I didn't use a table because the responsiveness wasn't optimized. Instead, I recreated the page for the desktop version by manually creating my own table using <div> elements and controlling their widths.