### PR TITLE
Add git ref discovery and macrobenchmark comparison to the API

### DIFF
--- a/go/server/server.go
+++ b/go/server/server.go
@@ -283,6 +283,8 @@ func (s *Server) Run() error {
 	// API
 	s.router.GET("/api/recent", s.getRecentExecutions)
 	s.router.GET("/api/queue", s.getExecutionsQueue)
+	s.router.GET("/api/vitess/refs", s.getLatestVitessGitRef)
+	s.router.GET("/api/macrobench/compare", s.compareMacrobenchmarks)
 
 	return s.router.Run(":" + s.port)
 }


### PR DESCRIPTION
This PR adds two new API endpoints:
- `/api/vitess/refs`
- `/api/macrobench/compare`

The former returns the list vitess git references are supported by arewefastyet. The data returned is a slice of `Release`:
```go
type (
	Release struct {
		Name       string
		CommitHash string
		Version    Version
		RCnumber   int
	}
	
	Version struct {
		Major, Minor, Patch int
	}
)
```

Regarding the `/api/macrobench/compare`, this new endpoint returns a comparison between two macrobenchmarks. The route takes two parameters in the URL: `rtag` and `ltag`. For instance:
```
http://localhost:9090/api/macrobench/compare?rtag=e94bdf5d469a8a4e0aa8e97657e6dc6cc48d6660&ltag= d0caade2b46addc0e1050c10867e8b187d2a1d03
```

Compares commit `e94bdf5d469a8a4e0aa8e97657e6dc6cc48d6660` with `d0caade2b46addc0e1050c10867e8b187d2a1d03`. The endpoint returns a slice of `CompareMacrobench` object:
```go
type CompareMacrobench struct {
	Type string                `json:"type"`
	Diff macrobench.Comparison `json:"diff"`
}
```