### PR TITLE
add list of macrobenchmark fields to API

### DIFF
--- a/go/server/api.go
+++ b/go/server/api.go
@@ -164,3 +164,22 @@ func (s *Server) compareMacrobenchmarks(c *gin.Context) {
 
 	c.JSON(http.StatusOK, cmpMacros)
 }
+
+func (s *Server) sendMacroBenchmarkComparisonFields(c *gin.Context) {
+	c.JSON(http.StatusOK, []string{
+		"total",
+		"reads",
+		"writes",
+		"other",
+		"tps",
+		"latency",
+		"errors",
+		"reconnects",
+		"time",
+		"threads",
+		"TotalComponentsCPUTime",
+		"ComponentsCPUTime",
+		"TotalComponentsMemStatsAllocBytes",
+		"ComponentsMemStatsAllocBytes",
+	})
+}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -285,7 +285,7 @@ func (s *Server) Run() error {
 	s.router.GET("/api/queue", s.getExecutionsQueue)
 	s.router.GET("/api/vitess/refs", s.getLatestVitessGitRef)
 	s.router.GET("/api/macrobench/compare", s.compareMacrobenchmarks)
-
+	s.router.GET("/api/macrobench/compare/fields", s.sendMacroBenchmarkComparisonFields)
 	return s.router.Run(":" + s.port)
 }
 


### PR DESCRIPTION
This PR adds a route to the API to return the list of fields used by the macrobenchmark comparison.