### PR TITLE
Remove `fields` API and init empty map fields

### DIFF
--- a/go/server/api.go
+++ b/go/server/api.go
@@ -164,22 +164,3 @@ func (s *Server) compareMacrobenchmarks(c *gin.Context) {
 
 	c.JSON(http.StatusOK, cmpMacros)
 }
-
-func (s *Server) sendMacroBenchmarkComparisonFields(c *gin.Context) {
-	c.JSON(http.StatusOK, []string{
-		"total",
-		"reads",
-		"writes",
-		"other",
-		"tps",
-		"latency",
-		"errors",
-		"reconnects",
-		"time",
-		"threads",
-		"TotalComponentsCPUTime",
-		"ComponentsCPUTime",
-		"TotalComponentsMemStatsAllocBytes",
-		"ComponentsMemStatsAllocBytes",
-	})
-}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -285,7 +285,6 @@ func (s *Server) Run() error {
 	s.router.GET("/api/queue", s.getExecutionsQueue)
 	s.router.GET("/api/vitess/refs", s.getLatestVitessGitRef)
 	s.router.GET("/api/macrobench/compare", s.compareMacrobenchmarks)
-	s.router.GET("/api/macrobench/compare/fields", s.sendMacroBenchmarkComparisonFields)
 	return s.router.Run(":" + s.port)
 }
 

--- a/go/tools/macrobench/compare.go
+++ b/go/tools/macrobench/compare.go
@@ -21,6 +21,7 @@ package macrobench
 import (
 	"fmt"
 
+	"github.com/vitessio/arewefastyet/go/exec/metrics"
 	"github.com/vitessio/arewefastyet/go/storage"
 )
 
@@ -43,6 +44,29 @@ func CompareMacroBenchmarks(client storage.SQLClient, reference, compare string,
 	macrosMatrixes := map[string]ComparisonArray{}
 	for _, mtype := range types {
 		macrosMatrixes[mtype] = CompareDetailsArrays(macros[reference][mtype], macros[compare][mtype])
+		if macrosMatrixes[mtype] == nil {
+			emptyExecMetrics := metrics.ExecutionMetrics{
+				ComponentsCPUTime: map[string]float64{
+					"vtgate":   0,
+					"vttablet": 0,
+				},
+				ComponentsMemStatsAllocBytes: map[string]float64{
+					"vtgate":   0,
+					"vttablet": 0,
+				},
+			}
+			macrosMatrixes[mtype] = ComparisonArray{
+				Comparison{
+					DiffMetrics: emptyExecMetrics,
+					Reference: Details{
+						Metrics:     emptyExecMetrics,
+					},
+					Compare: Details{
+						Metrics:     emptyExecMetrics,
+					},
+				},
+			}
+		}
 	}
 	return macrosMatrixes, nil
 }

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -133,7 +133,7 @@ func CompareDetailsArrays(references, compares DetailsArray) (compared Compariso
 			cmp.Diff.Latency = (compareResult.Latency - referenceResult.Latency) / referenceResult.Latency * 100
 			cmp.Diff.Reconnects = (compareResult.Reconnects - referenceResult.Reconnects) / referenceResult.Reconnects * 100
 			cmp.Diff.Errors = (compareResult.Errors - referenceResult.Errors) / referenceResult.Errors * 100
-			cmp.Diff.Time = int(float64(compareResult.Time) - (float64(referenceResult.Time)) / float64(referenceResult.Time) * 100)
+			cmp.Diff.Time = int(float64(compareResult.Time) - (float64(referenceResult.Time))/float64(referenceResult.Time)*100)
 			cmp.Diff.Threads = (compareResult.Threads - referenceResult.Threads) / referenceResult.Threads * 100
 			awftmath.CheckForNaN(&cmp.Diff, 0)
 			awftmath.CheckForNaN(&cmp.Diff.QPS, 0)


### PR DESCRIPTION
This PR removes the `fields` endpoint from the API as it turns out to not be super useful. And it initialize the `nil` map fields of the execution metrics.