### PR TITLE
Use `left` and `right` indicator instead of `reference`/`compare` in the API and backend code

### DIFF
--- a/go/tools/macrobench/compare.go
+++ b/go/tools/macrobench/compare.go
@@ -58,10 +58,10 @@ func CompareMacroBenchmarks(client storage.SQLClient, reference, compare string,
 			macrosMatrixes[mtype] = ComparisonArray{
 				Comparison{
 					DiffMetrics: emptyExecMetrics,
-					Reference: Details{
+					Right: Details{
 						Metrics:     emptyExecMetrics,
 					},
-					Compare: Details{
+					Left: Details{
 						Metrics:     emptyExecMetrics,
 					},
 				},

--- a/go/tools/macrobench/compare.go
+++ b/go/tools/macrobench/compare.go
@@ -27,9 +27,9 @@ import (
 
 // CompareMacroBenchmarks takes in 3 arguments, the database, and 2 SHAs. It reads from the database, the macrobenchmark
 // results for the 2 SHAs and compares them. The result is a map with the key being the macrobenchmark name.
-func CompareMacroBenchmarks(client storage.SQLClient, reference, compare string, planner PlannerVersion, types []string) (map[string]ComparisonArray, error) {
+func CompareMacroBenchmarks(client storage.SQLClient, right, left string, planner PlannerVersion, types []string) (map[string]ComparisonArray, error) {
 	// Get macro benchmarks from all the different types
-	SHAs := []string{reference, compare}
+	SHAs := []string{right, left}
 	var err error
 	macros := map[string]map[string]DetailsArray{}
 	for _, sha := range SHAs {
@@ -43,7 +43,7 @@ func CompareMacroBenchmarks(client storage.SQLClient, reference, compare string,
 	}
 	macrosMatrixes := map[string]ComparisonArray{}
 	for _, mtype := range types {
-		macrosMatrixes[mtype] = CompareDetailsArrays(macros[reference][mtype], macros[compare][mtype])
+		macrosMatrixes[mtype] = CompareDetailsArrays(macros[right][mtype], macros[left][mtype])
 		if macrosMatrixes[mtype] == nil {
 			emptyExecMetrics := metrics.ExecutionMetrics{
 				ComponentsCPUTime: map[string]float64{

--- a/go/tools/macrobench/endtoend/compare_test.go
+++ b/go/tools/macrobench/endtoend/compare_test.go
@@ -113,14 +113,14 @@ func TestCompareMacroBenchmark(t *testing.T) {
 func BenchmarkCompareMacroBenchmark(b *testing.B) {
 	c := qt.New(b)
 
-	run := func(b *testing.B, planner macrobench.PlannerVersion, reference, compare string) {
+	run := func(b *testing.B, planner macrobench.PlannerVersion, right, left string) {
 		if skip != "" {
 			c.Skip(skip)
 		}
 		b.ReportAllocs()
 		types := []string{"OLTP", "TPCC"}
 		for i := 0; i < b.N; i++ {
-			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, reference, compare, planner, types)
+			macrosMatrices, err := macrobench.CompareMacroBenchmarks(dbClient, right, left, planner, types)
 			if err != nil {
 				c.Fatal(err)
 			}

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -84,8 +84,8 @@ type (
 	// Comparison contains two Details and their difference in a
 	// Result field.
 	Comparison struct {
-		Reference, Compare Details
-		Diff               Result
+		Right, Left Details
+		Diff        Result
 		DiffMetrics        metrics.ExecutionMetrics
 	}
 
@@ -117,14 +117,14 @@ func CompareDetailsArrays(references, compares DetailsArray) (compared Compariso
 	for i := 0; i < int(math.Max(float64(len(references)), float64(len(compares)))); i++ {
 		var cmp Comparison
 		if i < len(references) {
-			cmp.Reference = references[i]
+			cmp.Right = references[i]
 		}
 		if i < len(compares) {
-			cmp.Compare = compares[i]
+			cmp.Left = compares[i]
 		}
-		if cmp.Compare.GitRef != "" && cmp.Reference.GitRef != "" {
-			compareResult := cmp.Compare.Result
-			referenceResult := cmp.Reference.Result
+		if cmp.Left.GitRef != "" && cmp.Right.GitRef != "" {
+			compareResult := cmp.Left.Result
+			referenceResult := cmp.Right.Result
 			cmp.Diff.QPS.Total = (referenceResult.QPS.Total - compareResult.QPS.Total) / compareResult.QPS.Total * 100
 			cmp.Diff.QPS.Reads = (referenceResult.QPS.Reads - compareResult.QPS.Reads) / compareResult.QPS.Reads * 100
 			cmp.Diff.QPS.Writes = (referenceResult.QPS.Writes - compareResult.QPS.Writes) / compareResult.QPS.Writes * 100
@@ -137,7 +137,7 @@ func CompareDetailsArrays(references, compares DetailsArray) (compared Compariso
 			cmp.Diff.Threads = (compareResult.Threads - referenceResult.Threads) / referenceResult.Threads * 100
 			awftmath.CheckForNaN(&cmp.Diff, 0)
 			awftmath.CheckForNaN(&cmp.Diff.QPS, 0)
-			cmp.DiffMetrics = metrics.CompareTwo(cmp.Compare.Metrics, cmp.Reference.Metrics)
+			cmp.DiffMetrics = metrics.CompareTwo(cmp.Left.Metrics, cmp.Right.Metrics)
 		}
 		compared = append(compared, cmp)
 	}

--- a/go/tools/macrobench/results_test.go
+++ b/go/tools/macrobench/results_test.go
@@ -19,9 +19,10 @@
 package macrobench
 
 import (
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/vitessio/arewefastyet/go/exec/metrics"
-	"testing"
 )
 
 func TestMacroBenchmarkResultsArray_mergeMedian(t *testing.T) {
@@ -171,8 +172,8 @@ func TestCompareDetailsArrays(t *testing.T) {
 			},
 		}, wantCompared: ComparisonArray{
 			Comparison{
-				Reference:   *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
-				Compare:     *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Right:       *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Left:        *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 				Diff:        resultOfFifty,
 				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},
@@ -189,14 +190,14 @@ func TestCompareDetailsArrays(t *testing.T) {
 			},
 		}, wantCompared: ComparisonArray{
 			Comparison{
-				Reference:   *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
-				Compare:     *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Right:       *newDetails(*newBenchmarkID(1, "webhook", nil), "11bbAAA", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Left:        *newDetails(*newBenchmarkID(2, "webhook", nil), "11bbAAA", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 				Diff:        resultOfFifty,
 				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},
 			Comparison{
-				Reference:   *newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
-				Compare:     *newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Right:       *newDetails(*newBenchmarkID(4, "webhook", nil), "f78gh1p", resultOfTwo, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
+				Left:        *newDetails(*newBenchmarkID(3, "api_call", nil), "f78gh1p", resultOfOne, metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}}),
 				Diff:        *newResult(*newQPS(50, 50, 50, 50), 50, -100, -100, 50, 50, 50),
 				DiffMetrics: metrics.ExecutionMetrics{ComponentsCPUTime: map[string]float64{}, ComponentsMemStatsAllocBytes: map[string]float64{}},
 			},

--- a/go/tools/microbench/compare.go
+++ b/go/tools/microbench/compare.go
@@ -20,14 +20,15 @@ package microbench
 
 import (
 	"fmt"
+
 	"github.com/vitessio/arewefastyet/go/storage"
 )
 
 // Compare takes in 3 arguments, the database, and 2 SHAs. It reads from the database, the microbenchmark
 // results for the 2 SHAs and compares them. The result is a comparison array.
-func Compare(client storage.SQLClient, reference string, compare string) (ComparisonArray, error) {
+func Compare(client storage.SQLClient, right string, left string) (ComparisonArray, error) {
 	// compare micro benchmarks
-	SHAs := []string{reference, compare}
+	SHAs := []string{right, left}
 	micros := map[string]DetailsArray{}
 	for _, sha := range SHAs {
 		micro, err := GetResultsForGitRef(sha, client)
@@ -36,7 +37,7 @@ func Compare(client storage.SQLClient, reference string, compare string) (Compar
 		}
 		micros[sha] = micro.ReduceSimpleMedianByName()
 	}
-	microsMatrix := MergeDetails(micros[reference], micros[compare])
+	microsMatrix := MergeDetails(micros[right], micros[left])
 	// The result of the merge will be sorted by the package name and then the benchmark name
 	return microsMatrix, nil
 }

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -115,16 +115,16 @@ func GenerateCompareReport(client storage.SQLClient, metricsClient *influxdb.Cli
 			if len(macroCompArr) > 0 {
 				macroComp := macroCompArr[0]
 				macroTable = append(macroTable, []tableCell{{value: strings.ToUpper(key), styleIndex: 2}})
-				macroTable = append(macroTable, []tableCell{{value: "TPS", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.TPS), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.TPS), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "QPS Reads", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.QPS.Reads), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.QPS.Reads), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "QPS Writes", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.QPS.Writes), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.QPS.Writes), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "QPS Total", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.QPS.Total), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.QPS.Total), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "QPS Others", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.QPS.Other), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.QPS.Other), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "Latency", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.Latency), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.Latency), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "Errors", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.Errors), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.Errors), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "Reconnects", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.Reconnects), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.Reconnects), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "Time", styleIndex: 0}, {value: strconv.Itoa(macroComp.Reference.Result.Time), styleIndex: 1}, {value: strconv.Itoa(macroComp.Compare.Result.Time), styleIndex: 1}})
-				macroTable = append(macroTable, []tableCell{{value: "Threads", styleIndex: 0}, {value: convertFloatToString(macroComp.Reference.Result.Threads), styleIndex: 1}, {value: convertFloatToString(macroComp.Compare.Result.Threads), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "TPS", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.TPS), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.TPS), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "QPS Reads", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.QPS.Reads), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.QPS.Reads), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "QPS Writes", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.QPS.Writes), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.QPS.Writes), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "QPS Total", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.QPS.Total), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.QPS.Total), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "QPS Others", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.QPS.Other), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.QPS.Other), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "Latency", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.Latency), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.Latency), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "Errors", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.Errors), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.Errors), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "Reconnects", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.Reconnects), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.Reconnects), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "Time", styleIndex: 0}, {value: strconv.Itoa(macroComp.Right.Result.Time), styleIndex: 1}, {value: strconv.Itoa(macroComp.Left.Result.Time), styleIndex: 1}})
+				macroTable = append(macroTable, []tableCell{{value: "Threads", styleIndex: 0}, {value: convertFloatToString(macroComp.Right.Result.Threads), styleIndex: 1}, {value: convertFloatToString(macroComp.Left.Result.Threads), styleIndex: 1}})
 			}
 		}
 		// write the table to pdf


### PR DESCRIPTION
This PR changes the labels `reference` and `compare` to `right` and `left`. The previous names were misleading.