### PR TITLE
Add route to compare microbenchmarks through the API

### DIFF
--- a/go/server/server.go
+++ b/go/server/server.go
@@ -285,6 +285,8 @@ func (s *Server) Run() error {
 	s.router.GET("/api/queue", s.getExecutionsQueue)
 	s.router.GET("/api/vitess/refs", s.getLatestVitessGitRef)
 	s.router.GET("/api/macrobench/compare", s.compareMacrobenchmarks)
+	s.router.GET("/api/microbench/compare", s.compareMicrobenchmarks)
+
 	return s.router.Run(":" + s.port)
 }
 

--- a/go/server/templates/microbench.tmpl
+++ b/go/server/templates/microbench.tmpl
@@ -103,24 +103,24 @@ limitations under the License.
                     <tr>
                         <td>{{ $val.PkgName }}</td>
                         <td><a href="/microbench/{{ $val.Name }}?subBenchmarkName={{ $val.SubBenchmarkName }}">{{ $val.SubBenchmarkName }}</a></td>
-                        <td class="text-right">{{ $val.Last.OpsStr }}</td>
-                        <td class="text-right">{{ $val.Current.OpsStr }}</td>
+                        <td class="text-right">{{ $val.Left.OpsStr }}</td>
+                        <td class="text-right">{{ $val.Right.OpsStr }}</td>
                         <td class="text-right {{if le $val.Diff.Ops -5.0 }} bg-danger {{ else if ge $val.Diff.Ops 5.0 }} bg-success {{ end }}">{{ formatFloat $val.Diff.Ops }}</td>
 
-                        <td class="text-right">{{ $val.Last.NSPerOpToDurationStr }}</td>
-                        <td class="text-right">{{ $val.Current.NSPerOpToDurationStr }}</td>
+                        <td class="text-right">{{ $val.Left.NSPerOpToDurationStr }}</td>
+                        <td class="text-right">{{ $val.Right.NSPerOpToDurationStr }}</td>
                         <td class="text-right {{if le $val.Diff.NSPerOp -10.0 }} bg-danger {{ else if ge $val.Diff.NSPerOp 10.0 }} bg-success {{ end }}">{{ formatFloat $val.Diff.NSPerOp }}</td>
 
-                        <td class="text-right">{{ $val.Last.BytesPerOpStr }}</td>
-                        <td class="text-right">{{ $val.Current.BytesPerOpStr }}</td>
+                        <td class="text-right">{{ $val.Left.BytesPerOpStr }}</td>
+                        <td class="text-right">{{ $val.Right.BytesPerOpStr }}</td>
                         <td class="text-right {{if le $val.Diff.BytesPerOp -10.0 }} bg-danger {{ else if ge $val.Diff.BytesPerOp 10.0 }} bg-success {{ end }}">{{ formatFloat $val.Diff.BytesPerOp }}</td>
 
-                        <td class="text-right">{{ $val.Last.MBPerSecStr }}</td>
-                        <td class="text-right">{{ $val.Current.MBPerSecStr }}</td>
+                        <td class="text-right">{{ $val.Left.MBPerSecStr }}</td>
+                        <td class="text-right">{{ $val.Right.MBPerSecStr }}</td>
                         <td class="text-right {{if le $val.Diff.MBPerSec -10.0 }} bg-danger {{ else if ge $val.Diff.MBPerSec 10.0 }} bg-success {{ end }}">{{ formatFloat $val.Diff.MBPerSec }}</td>
 
-                        <td class="text-right">{{ $val.Last.AllocsPerOpStr }}</td>
-                        <td class="text-right">{{ $val.Current.AllocsPerOpStr }}</td>
+                        <td class="text-right">{{ $val.Left.AllocsPerOpStr }}</td>
+                        <td class="text-right">{{ $val.Right.AllocsPerOpStr }}</td>
                         <td class="text-right {{if le $val.Diff.AllocsPerOp -10.0 }} bg-danger {{ else if ge $val.Diff.AllocsPerOp 10.0 }} bg-success {{ end }}">{{ formatFloat $val.Diff.AllocsPerOp }}</td>
                     </tr>
                 {{end}}

--- a/go/tools/microbench/results_test.go
+++ b/go/tools/microbench/results_test.go
@@ -209,7 +209,7 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewDetails(*NewBenchmarkId("pkg1", "bench1", "bench1-pkg1"), "", "", *NewResult(0, 5.00, 0, 0, 0)),
 			},
 		}, want: ComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: Result{NSPerOp: 1.00}, Last: Result{NSPerOp: 5.00}, Diff: Result{NSPerOp: 400}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Right: Result{NSPerOp: 1.00}, Left: Result{NSPerOp: 5.00}, Diff: Result{NSPerOp: 400}},
 		}},
 
 		// tc2
@@ -223,8 +223,8 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewDetails(*NewBenchmarkId("pkg1", "bench2", "bench2-pkg1"), "", "", *NewResult(0, 89.00, 0, 0, 0)),
 			},
 		}, want: ComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp: 400}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp: -9.183673469387756}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Right: *NewResult(0, 1.00, 0, 0, 0), Left: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp: 400}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Right: *NewResult(0, 98.00, 0, 0, 0), Left: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp: -9.183673469387756}},
 		}},
 
 		// tc3
@@ -240,9 +240,9 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewDetails(*NewBenchmarkId("pkg1", "bench3", "bench3-pkg1"), "ppbb", "", *NewResult(0, 56.00, 0, 0, 0)),
 			},
 		}, want: ComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Current: *NewResult(0, 58.00, 0, 0, 0), Last: *NewResult(0, 56.00, 0, 0, 0), Diff: Result{NSPerOp: -3.4482758620689653}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp:  400}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp:  -9.183673469387756}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Right: *NewResult(0, 58.00, 0, 0, 0), Left: *NewResult(0, 56.00, 0, 0, 0), Diff: Result{NSPerOp: -3.4482758620689653}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Right: *NewResult(0, 1.00, 0, 0, 0), Left: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp: 400}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Right: *NewResult(0, 98.00, 0, 0, 0), Left: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp: -9.183673469387756}},
 		}},
 
 		// tc4
@@ -264,12 +264,12 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "ppbb", "", *NewResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: ComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Current: *NewResult(0, 58.00, 0, 0, 0), Last: *NewResult(0, 56.00, 0, 0, 0), Diff: Result{NSPerOp:  -3.4482758620689653}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp:  400}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp: -9.183673469387756}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, Current: *NewResult(0, 3.50, 0, 0, 0), Last: *NewResult(0, 6.00, 0, 0, 0), Diff: Result{NSPerOp:  71.42857142857143}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, Current: *NewResult(0, 5.00, 0, 0, 0), Last: *NewResult(0, 4.20, 0, 0, 0), Diff: Result{NSPerOp:  -15.999999999999998}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, Current: *NewResult(0, 2385.00, 0, 0, 0), Last: *NewResult(0, 2560.00, 0, 0, 0), Diff: Result{NSPerOp:  7.337526205450734}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Right: *NewResult(0, 58.00, 0, 0, 0), Left: *NewResult(0, 56.00, 0, 0, 0), Diff: Result{NSPerOp: -3.4482758620689653}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Right: *NewResult(0, 1.00, 0, 0, 0), Left: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp: 400}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Right: *NewResult(0, 98.00, 0, 0, 0), Left: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp: -9.183673469387756}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, Right: *NewResult(0, 3.50, 0, 0, 0), Left: *NewResult(0, 6.00, 0, 0, 0), Diff: Result{NSPerOp: 71.42857142857143}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, Right: *NewResult(0, 5.00, 0, 0, 0), Left: *NewResult(0, 4.20, 0, 0, 0), Diff: Result{NSPerOp: -15.999999999999998}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, Right: *NewResult(0, 2385.00, 0, 0, 0), Left: *NewResult(0, 2560.00, 0, 0, 0), Diff: Result{NSPerOp: 7.337526205450734}},
 		}},
 
 		// tc5
@@ -289,12 +289,12 @@ func TestMergeMicroBenchmarkDetails(t *testing.T) {
 				*NewDetails(*NewBenchmarkId("pkg2", "bench1", "bench1-pkg2"), "ppbb", "", *NewResult(0, 4.20, 0, 0, 0)),
 			},
 		}, want: ComparisonArray{
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Current: *NewResult(0, 58.00, 0, 0, 0), Last: *NewResult(0, 56.00, 0, 0, 0), Diff: Result{NSPerOp:  -3.4482758620689653}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Current: *NewResult(0, 1.00, 0, 0, 0), Last: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp:  400}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Current: *NewResult(0, 98.00, 0, 0, 0), Last: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp:  -9.183673469387756}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, Current: *NewResult(0, 3.50, 0, 0, 0), Last: *NewResult(0, 0, 0, 0, 0), Diff: Result{NSPerOp:  -0}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, Current: *NewResult(0, 5.00, 0, 0, 0), Last: *NewResult(0, 4.20, 0, 0, 0), Diff: Result{NSPerOp:  -15.999999999999998}},
-			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, Current: *NewResult(0, 2385.00, 0, 0, 0), Last: *NewResult(0, 0.00, 0, 0, 0), Diff: Result{NSPerOp:  -0}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench3", SubBenchmarkName: "bench3-pkg1"}, Right: *NewResult(0, 58.00, 0, 0, 0), Left: *NewResult(0, 56.00, 0, 0, 0), Diff: Result{NSPerOp: -3.4482758620689653}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench1", SubBenchmarkName: "bench1-pkg1"}, Right: *NewResult(0, 1.00, 0, 0, 0), Left: *NewResult(0, 5.00, 0, 0, 0), Diff: Result{NSPerOp: 400}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg1", Name: "bench2", SubBenchmarkName: "bench2-pkg1"}, Right: *NewResult(0, 98.00, 0, 0, 0), Left: *NewResult(0, 89.00, 0, 0, 0), Diff: Result{NSPerOp: -9.183673469387756}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench2", SubBenchmarkName: "bench2-pkg2"}, Right: *NewResult(0, 3.50, 0, 0, 0), Left: *NewResult(0, 0, 0, 0, 0), Diff: Result{NSPerOp: -0}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg2", Name: "bench1", SubBenchmarkName: "bench1-pkg2"}, Right: *NewResult(0, 5.00, 0, 0, 0), Left: *NewResult(0, 4.20, 0, 0, 0), Diff: Result{NSPerOp: -15.999999999999998}},
+			{BenchmarkId: BenchmarkId{PkgName: "pkg3", Name: "bench1", SubBenchmarkName: "bench1-pkg3"}, Right: *NewResult(0, 2385.00, 0, 0, 0), Left: *NewResult(0, 0.00, 0, 0, 0), Diff: Result{NSPerOp: -0}},
 		}},
 	}
 	for _, tt := range tests {

--- a/go/tools/report/compare_report.go
+++ b/go/tools/report/compare_report.go
@@ -145,11 +145,11 @@ func GenerateCompareReport(client storage.SQLClient, metricsClient *influxdb.Cli
 		// range over all the microbenchmarks
 		for _, microComp := range microsMatrix {
 			microTable = append(microTable, []tableCell{{value: microComp.PkgName + "." + microComp.SubBenchmarkName, styleIndex: 2}})
-			microTable = append(microTable, []tableCell{{value: "Ops", styleIndex: 0}, {value: convertFloatToString(microComp.Current.Ops), styleIndex: 1}, {value: convertFloatToString(microComp.Last.Ops), styleIndex: 1}})
-			microTable = append(microTable, []tableCell{{value: "NSPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Current.NSPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Last.NSPerOp), styleIndex: 1}})
-			microTable = append(microTable, []tableCell{{value: "MBPerSec", styleIndex: 0}, {value: convertFloatToString(microComp.Current.MBPerSec), styleIndex: 1}, {value: convertFloatToString(microComp.Last.MBPerSec), styleIndex: 1}})
-			microTable = append(microTable, []tableCell{{value: "BytesPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Current.BytesPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Last.BytesPerOp), styleIndex: 1}})
-			microTable = append(microTable, []tableCell{{value: "AllocsPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Current.AllocsPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Last.AllocsPerOp), styleIndex: 1}})
+			microTable = append(microTable, []tableCell{{value: "Ops", styleIndex: 0}, {value: convertFloatToString(microComp.Right.Ops), styleIndex: 1}, {value: convertFloatToString(microComp.Left.Ops), styleIndex: 1}})
+			microTable = append(microTable, []tableCell{{value: "NSPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Right.NSPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Left.NSPerOp), styleIndex: 1}})
+			microTable = append(microTable, []tableCell{{value: "MBPerSec", styleIndex: 0}, {value: convertFloatToString(microComp.Right.MBPerSec), styleIndex: 1}, {value: convertFloatToString(microComp.Left.MBPerSec), styleIndex: 1}})
+			microTable = append(microTable, []tableCell{{value: "BytesPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Right.BytesPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Left.BytesPerOp), styleIndex: 1}})
+			microTable = append(microTable, []tableCell{{value: "AllocsPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Right.AllocsPerOp), styleIndex: 1}, {value: convertFloatToString(microComp.Left.AllocsPerOp), styleIndex: 1}})
 			microTable = append(microTable, []tableCell{{value: "Ratio of NSPerOp", styleIndex: 0}, {value: convertFloatToString(microComp.Diff.NSPerOp), styleIndex: 1}})
 		}
 		// write the table to pdf


### PR DESCRIPTION
This PR adds the `/api/microbench/compare` route to the API to enable comparison of microbenchmarks.