### PR TITLE
Creation of the API for the 'query plan' page

### DIFF
--- a/go/server/server.go
+++ b/go/server/server.go
@@ -287,6 +287,7 @@ func (s *Server) Run() error {
 	s.router.GET("/api/macrobench/compare", s.compareMacrobenchmarks)
 	s.router.GET("/api/microbench/compare", s.compareMicrobenchmarks)
 	s.router.GET("/api/search", s.searchBenchmarck)
+	s.router.GET("/api/macrobench/compare/queries", s.queriesCompareMacrobenchmarks)
 
 	return s.router.Run(":" + s.port)
 }

--- a/go/tools/macrobench/vtgate.go
+++ b/go/tools/macrobench/vtgate.go
@@ -19,7 +19,6 @@
 package macrobench
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -72,10 +71,10 @@ func CompareVTGateQueryPlans(left, right []VTGateQueryPlan) []VTGateQueryPlanCom
 		for j, rightPlan := range right {
 			if rightPlan.Key == plan.Key {
 				switch instructionRight := rightPlan.Value.Instructions.(type) {
-				case []byte:
+				case string:
 					switch instructionLeft := plan.Value.Instructions.(type) {
-					case []byte:
-						newCompare.SamePlan = bytes.Equal(instructionLeft, instructionRight)
+					case string:
+						newCompare.SamePlan = instructionLeft == instructionRight
 					}
 				}
 				newCompare.Right = &right[j]
@@ -227,7 +226,11 @@ func GetVTGateSelectQueryPlansWithFilter(gitRef string, macroType Type, planner 
 		if err != nil {
 			return nil, err
 		}
-
+		switch p := plan.Value.Instructions.(type) {
+		case []byte:
+			plan.Value.Instructions = string(p)
+		}
+		
 		// Remove all comments from the query
 		// This prevents the query from not match across two versions
 		// of Vitess where we changed query hints and added comments


### PR DESCRIPTION
This pull request adds validation and error handling to the queriesCompareMacrobenchmarks function in the Server struct.

Validation is performed for the leftGitRef, rightGitRef, and macroType parameters. If any of these parameters are missing, a JSON response with a 400 (Bad Request) error code is returned, indicating that the required parameters are missing.

Additionally, error handling is added when calling the macrobench.GetVTGateSelectQueryPlansWithFilter functions. If an error occurs while retrieving the query plans, a JSON response with a 500 (Internal Server Error) error code is returned, containing the error message returned by the function, and the error is also logged.

Finally, the macrobench.CompareVTGateQueryPlans function is used to compare the obtained query plans. The result of the comparison is returned in a JSON response with a 200 (OK) status code.

These modifications add improved robustness and more efficient error handling when executing the queriesCompareMacrobenchmarks function.