### PR TITLE
Use `slice` instead of map for the execution queue

### DIFF
--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -9,8 +9,8 @@ web-pr-label-trigger: '"Benchmark me"'
 web-pr-label-trigger-planner-v3: '"Benchmark me (V3)"'
 web-vitess-path: /tmp
 web-mode: "development"
-web-cron-schedule: "*/1 1 1 1 1"
-web-cron-schedule-pull-requests: "1 1 1 1 1"
-web-cron-schedule-tags: "*/1 1 1 1 1"
+web-cron-schedule: "*/1 * * * *"
+web-cron-schedule-pull-requests: "*/1 * * * *"
+web-cron-schedule-tags: "*/1 * * * *"
 
 ansible-root-directory: "./ansible/"

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -78,10 +78,10 @@ func (s *Server) getExecutionsQueue(c *gin.Context) {
 			continue
 		}
 		recentExecs = append(recentExecs, RecentExecutions{
-			Source: e.identifier.Source,
-			GitRef: e.identifier.GitRef,
-			TypeOf: e.identifier.BenchmarkType,
-			PullNb: e.identifier.PullNb,
+			Source: e.Identifier.Source,
+			GitRef: e.Identifier.GitRef,
+			TypeOf: e.Identifier.BenchmarkType,
+			PullNb: e.Identifier.PullNb,
 		})
 	}
 	sort.Slice(recentExecs, func(i, j int) bool {

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -163,8 +163,8 @@ func (s *Server) createBranchElementWithComparisonOnPreviousAndRelease(config be
 		// creating an execution queue element for the latest benchmark with SourceCron as source
 		// this will not be executed since the benchmark already exist, we still create the element in order to compare
 		previousElement := s.createSimpleExecutionQueueElement(config, source, previousGitRef, configType, plannerVersion, false, 0, version)
-		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.identifier)
-		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.identifier)
+		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.Identifier)
+		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.Identifier)
 		elements = append(elements, previousElement)
 	}
 
@@ -172,8 +172,8 @@ func (s *Server) createBranchElementWithComparisonOnPreviousAndRelease(config be
 		// creating an execution queue element for the latest release (comparing branch with the latest release)
 		// this will probably not be executed the benchmark should already exist, we still create it to compare main once its benchmark is over
 		lastReleaseElement := s.createSimpleExecutionQueueElement(config, exec.SourceTag+lastRelease.Name, lastRelease.CommitHash, configType, plannerVersion, false, 0, lastRelease.Version)
-		lastReleaseElement.compareWith = append(lastReleaseElement.compareWith, newExecutionElement.identifier)
-		newExecutionElement.compareWith = append(newExecutionElement.compareWith, lastReleaseElement.identifier)
+		lastReleaseElement.compareWith = append(lastReleaseElement.compareWith, newExecutionElement.Identifier)
+		newExecutionElement.compareWith = append(newExecutionElement.compareWith, lastReleaseElement.Identifier)
 		elements = append(elements, lastReleaseElement)
 	}
 	return elements
@@ -239,13 +239,13 @@ func (s *Server) createPullRequestElementWithBaseComparison(config benchmarkConf
 	var elements []*executionQueueElement
 
 	newExecutionElement := s.createSimpleExecutionQueueElement(config, exec.SourcePullRequest, ref, configType, string(plannerVersion), true, pullNb, gitVersion)
-	newExecutionElement.identifier.PullBaseRef = previousGitRef
+	newExecutionElement.Identifier.PullBaseRef = previousGitRef
 	elements = append(elements, newExecutionElement)
 
 	if previousGitRef != "" {
 		previousElement := s.createSimpleExecutionQueueElement(config, exec.SourcePullRequestBase, previousGitRef, configType, string(plannerVersion), false, pullNb, gitVersion)
-		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.identifier)
-		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.identifier)
+		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.Identifier)
+		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.Identifier)
 		elements = append(elements, previousElement)
 	}
 	return elements
@@ -298,7 +298,7 @@ func (s *Server) createSimpleExecutionQueueElement(config benchmarkConfig, sourc
 		config:       config,
 		retry:        s.cronNbRetry,
 		notifyAlways: notify,
-		identifier: executionIdentifier{
+		Identifier: executionIdentifier{
 			GitRef:         ref,
 			Source:         source,
 			BenchmarkType:  configType,

--- a/go/server/templates/status.tmpl
+++ b/go/server/templates/status.tmpl
@@ -46,22 +46,22 @@ limitations under the License.
               </tr>
             </thead>
             <tbody>
-              {{ range $key, $elem := .queue }}
+          {{ range $elem := .queue }}
 				  {{ if not $elem.Executing }}
 					  <tr>
 						<td class="text-center">
-						  <a target="_blank" href="https://github.com/vitessio/vitess/commit/{{$key.GitRef}}">{{ first8Letters $key.GitRef }}</a>
+						  <a target="_blank" href="https://github.com/vitessio/vitess/commit/{{$elem.Identifier.GitRef}}">{{ first8Letters $elem.Identifier.GitRef }}</a>
 						</td>
-						<td class="text-center">{{ $key.Source }}</td>
-						<td class="text-center">{{ $key.BenchmarkType }}</td>
+						<td class="text-center">{{ $elem.Identifier.Source }}</td>
+						<td class="text-center">{{ $elem.Identifier.BenchmarkType }}</td>
 						<td class="text-center">
-						  {{ if gt $key.PullNb 0 }}
-							<a href="https://github.com/vitessio/vitess/pull/{{$key.PullNb}}">{{ $key.PullNb }}</a>
+						  {{ if gt $elem.Identifier.PullNb 0 }}
+							<a href="https://github.com/vitessio/vitess/pull/{{$elem.Identifier.PullNb}}">{{ $elem.Identifier.PullNb }}</a>
 						  {{ else }}
-							{{ $key.PullNb }}
+							{{ $elem.Identifier.PullNb }}
 						  {{ end }}
 						</td>
-						<td class="text-center">{{ $key.PlannerVersion }}</td>
+						<td class="text-center">{{ $elem.Identifier.PlannerVersion }}</td>
 					  </tr>
 				  {{ end }}
               {{ end }}


### PR DESCRIPTION
This PR changes the execution queue from a map to a slice in order to have an ordered data list.