### PR TITLE
Add Benchmark Statistics API Endpoint and Retrieval Functionality

### DIFF
--- a/go/exec/status.go
+++ b/go/exec/status.go
@@ -29,34 +29,32 @@ const (
 	StatusFinished = "finished"
 )
 
-type benchmarkStats struct {
-	Benchmark_total    int
-	Benchmark_finished int
-	Benchmark_30Days   int
+type BenchmarkStats struct {
+	Total    int
+	Finished int
+	Last30Days   int
 }
 
-func GetBenchmarkStats(client storage.SQLClient) (benchmarkStats, error) {
-	rows, err := client.Select(`
-        SELECT
+func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
+	rows, err := client.Select(`SELECT
             (SELECT COUNT(uuid) FROM execution) AS count_status,
             (SELECT COUNT(*) FROM execution WHERE status = 'finished') AS count_finished,
             (SELECT COUNT(*) FROM execution WHERE started_at >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)) AS count_all
         FROM
             execution
-		LIMIT 1;
-    `)
+		LIMIT 1;`)
 
 	if err != nil {
-		return benchmarkStats{}, err
+		return BenchmarkStats{}, err
 	}
 
 	defer rows.Close()
 
-	var res benchmarkStats
+	var res BenchmarkStats
 	if rows.Next() {
-		err := rows.Scan(&res.Benchmark_total, &res.Benchmark_finished, &res.Benchmark_30Days)
+		err := rows.Scan(&res.Total, &res.Finished, &res.Last30Days)
 		if err != nil {
-			return benchmarkStats{}, err
+			return BenchmarkStats{}, err
 		}
 	}
 	return res, nil

--- a/go/exec/status.go
+++ b/go/exec/status.go
@@ -30,18 +30,18 @@ const (
 )
 
 type BenchmarkStats struct {
-	Total    int
-	Finished int
-	Last30Days   int
+	Total      int
+	Finished   int
+	Last30Days int
 }
 
 func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
-	rows, err := client.Select(`SELECT
-            (SELECT COUNT(uuid) FROM execution) AS count_status,
-            (SELECT COUNT(*) FROM execution WHERE status = 'finished') AS count_finished,
-            (SELECT COUNT(*) FROM execution WHERE started_at >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)) AS count_all
-        FROM
-            execution
+	rows, err := client.Select(`SELECT 
+			(SELECT COUNT(uuid) FROM execution) AS count_status,
+			(SELECT COUNT(*) FROM execution WHERE status = 'finished') AS count_finished,
+			(SELECT COUNT(*) FROM execution WHERE started_at >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)) AS count_all
+		FROM
+			execution
 		LIMIT 1;`)
 
 	if err != nil {

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -287,7 +287,6 @@ func (s *Server) getPullRequestInfo(c *gin.Context) {
 
 }
 
-
 type cronSingleSummary struct {
 	Name string
 	Data []macrobench.CronSummary
@@ -328,4 +327,14 @@ func (s *Server) getCron(c *gin.Context) {
 		data[i].Metrics = m
 	}
 	c.JSON(http.StatusOK, data)
+}
+
+func (s *Server) getStatusStats(c *gin.Context) {
+	stats, err := exec.GetBenchmarkStats(s.dbClient)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
+		slog.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, stats)
 }

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -304,6 +304,7 @@ func (s *Server) Run() error {
 	s.router.GET("/api/pr/info/:nb", s.getPullRequestInfo)
 	s.router.GET("/api/cron/summary", s.getCronSummary)
 	s.router.GET("/api/cron", s.getCron)
+	s.router.GET("/api/status/stats", s.getStatusStats)
 
 	return s.router.Run(":" + s.port)
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.1.4",
         "moment": "^2.29.4",
         "react": "^18.2.0",
+        "react-countup": "^6.4.2",
         "react-dom": "^18.2.0",
         "react-json-pretty": "^2.2.0",
         "react-router-dom": "^6.11.2",
@@ -47,7 +48,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
       "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -60,7 +60,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -72,7 +71,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
       "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -81,7 +79,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
       "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
-      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -111,7 +108,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
       "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -126,7 +122,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
       "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.5",
@@ -145,7 +140,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
       "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -154,7 +148,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
       "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/types": "^7.22.5"
@@ -167,7 +160,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -179,7 +171,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
       "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -191,7 +182,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
       "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.5",
@@ -219,7 +209,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -231,7 +220,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
       "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -243,7 +231,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
       "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -252,7 +239,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -261,7 +247,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
       "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -270,7 +255,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
       "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/traverse": "^7.22.5",
@@ -284,7 +268,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -298,7 +281,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
       "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -340,7 +322,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
       "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/parser": "^7.22.5",
@@ -354,7 +335,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
       "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/generator": "^7.22.5",
@@ -375,7 +355,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
       "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -386,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.12.tgz",
-      "integrity": "sha512-LIxaNIQfkFZbTLb4+cX7dozHlAbAshhFE5PKdro0l+FnCpx1GDJaQ2WMcqm+ToXKMt8p8Uojk/MFRuGyz3V5Sw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.14.tgz",
+      "integrity": "sha512-blODaaL+lngG5bdK/t4qZcQvq2BBqrABmYwqPPcS5VRxrCSGHb9R/rA3fqxh7R18I7WU4KKv+NYkt22FDfalcg==",
       "cpu": [
         "arm"
       ],
@@ -402,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.12.tgz",
-      "integrity": "sha512-BMAlczRqC/LUt2P97E4apTBbkvS9JTJnp2DKFbCwpZ8vBvXVbNdqmvzW/OsdtI/+mGr+apkkpqGM8WecLkPgrA==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.14.tgz",
+      "integrity": "sha512-rZ2v+Luba5/3D6l8kofWgTnqE+qsC/L5MleKIKFyllHTKHrNBMqeRCnZI1BtRx8B24xMYxeU32iIddRQqMsOsg==",
       "cpu": [
         "arm64"
       ],
@@ -418,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.12.tgz",
-      "integrity": "sha512-zU5MyluNsykf5cOJ0LZZZjgAHbhPJ1cWfdH1ZXVMXxVMhEV0VZiZXQdwBBVvmvbF28EizeK7obG9fs+fpmS0eQ==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.14.tgz",
+      "integrity": "sha512-qSwh8y38QKl+1Iqg+YhvCVYlSk3dVLk9N88VO71U4FUjtiSFylMWK3Ugr8GC6eTkkP4Tc83dVppt2n8vIdlSGg==",
       "cpu": [
         "x64"
       ],
@@ -434,9 +413,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.12.tgz",
-      "integrity": "sha512-zUZMep7YONnp6954QOOwEBwFX9svlKd3ov6PkxKd53LGTHsp/gy7vHaPGhhjBmEpqXEXShi6dddjIkmd+NgMsA==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.14.tgz",
+      "integrity": "sha512-9Hl2D2PBeDYZiNbnRKRWuxwHa9v5ssWBBjisXFkVcSP5cZqzZRFBUWEQuqBHO4+PKx4q4wgHoWtfQ1S7rUqJ2Q==",
       "cpu": [
         "arm64"
       ],
@@ -450,9 +429,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.12.tgz",
-      "integrity": "sha512-ohqLPc7i67yunArPj1+/FeeJ7AgwAjHqKZ512ADk3WsE3FHU9l+m5aa7NdxXr0HmN1bjDlUslBjWNbFlD9y12Q==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.14.tgz",
+      "integrity": "sha512-ZnI3Dg4ElQ6tlv82qLc/UNHtFsgZSKZ7KjsUNAo1BF1SoYDjkGKHJyCrYyWjFecmXpvvG/KJ9A/oe0H12odPLQ==",
       "cpu": [
         "x64"
       ],
@@ -466,9 +445,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.12.tgz",
-      "integrity": "sha512-GIIHtQXqgeOOqdG16a/A9N28GpkvjJnjYMhOnXVbn3EDJcoItdR58v/pGN31CHjyXDc8uCcRnFWmqaJt24AYJg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.14.tgz",
+      "integrity": "sha512-h3OqR80Da4oQCIa37zl8tU5MwHQ7qgPV0oVScPfKJK21fSRZEhLE4IIVpmcOxfAVmqjU6NDxcxhYaM8aDIGRLw==",
       "cpu": [
         "arm64"
       ],
@@ -482,9 +461,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.12.tgz",
-      "integrity": "sha512-zK0b9a1/0wZY+6FdOS3BpZcPc1kcx2G5yxxfEJtEUzVxI6n/FrC2Phsxj/YblPuBchhBZ/1wwn7AyEBUyNSa6g==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.14.tgz",
+      "integrity": "sha512-ha4BX+S6CZG4BoH9tOZTrFIYC1DH13UTCRHzFc3GWX74nz3h/N6MPF3tuR3XlsNjMFUazGgm35MPW5tHkn2lzQ==",
       "cpu": [
         "x64"
       ],
@@ -498,9 +477,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.12.tgz",
-      "integrity": "sha512-y75OijvrBE/1XRrXq1jtrJfG26eHeMoqLJ2dwQNwviwTuTtHGCojsDO6BJNF8gU+3jTn1KzJEMETytwsFSvc+Q==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.14.tgz",
+      "integrity": "sha512-5+7vehI1iqru5WRtJyU2XvTOvTGURw3OZxe3YTdE9muNNIdmKAVmSHpB3Vw2LazJk2ifEdIMt/wTWnVe5V98Kg==",
       "cpu": [
         "arm"
       ],
@@ -514,9 +493,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.12.tgz",
-      "integrity": "sha512-JKgG8Q/LL/9sw/iHHxQyVMoQYu3rU3+a5Z87DxC+wAu3engz+EmctIrV+FGOgI6gWG1z1+5nDDbXiRMGQZXqiw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.14.tgz",
+      "integrity": "sha512-IXORRe22In7U65NZCzjwAUc03nn8SDIzWCnfzJ6t/8AvGx5zBkcLfknI+0P+hhuftufJBmIXxdSTbzWc8X/V4w==",
       "cpu": [
         "arm64"
       ],
@@ -530,9 +509,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.12.tgz",
-      "integrity": "sha512-yoRIAqc0B4lDIAAEFEIu9ttTRFV84iuAl0KNCN6MhKLxNPfzwCBvEMgwco2f71GxmpBcTtn7KdErueZaM2rEvw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.14.tgz",
+      "integrity": "sha512-BfHlMa0nibwpjG+VXbOoqJDmFde4UK2gnW351SQ2Zd4t1N3zNdmUEqRkw/srC1Sa1DRBE88Dbwg4JgWCbNz/FQ==",
       "cpu": [
         "ia32"
       ],
@@ -546,9 +525,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.12.tgz",
-      "integrity": "sha512-qYgt3dHPVvf/MgbIBpJ4Sup/yb9DAopZ3a2JgMpNKIHUpOdnJ2eHBo/aQdnd8dJ21X/+sS58wxHtA9lEazYtXQ==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.14.tgz",
+      "integrity": "sha512-j2/Ex++DRUWIAaUDprXd3JevzGtZ4/d7VKz+AYDoHZ3HjJzCyYBub9CU1wwIXN+viOP0b4VR3RhGClsvyt/xSw==",
       "cpu": [
         "loong64"
       ],
@@ -562,9 +541,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.12.tgz",
-      "integrity": "sha512-wHphlMLK4ufNOONqukELfVIbnGQJrHJ/mxZMMrP2jYrPgCRZhOtf0kC4yAXBwnfmULimV1qt5UJJOw4Kh13Yfg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.14.tgz",
+      "integrity": "sha512-qn2+nc+ZCrJmiicoAnJXJJkZWt8Nwswgu1crY7N+PBR8ChBHh89XRxj38UU6Dkthl2yCVO9jWuafZ24muzDC/A==",
       "cpu": [
         "mips64el"
       ],
@@ -578,9 +557,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.12.tgz",
-      "integrity": "sha512-TeN//1Ft20ZZW41+zDSdOI/Os1bEq5dbvBvYkberB7PHABbRcsteeoNVZFlI0YLpGdlBqohEpjrn06kv8heCJg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.14.tgz",
+      "integrity": "sha512-aGzXzd+djqeEC5IRkDKt3kWzvXoXC6K6GyYKxd+wsFJ2VQYnOWE954qV2tvy5/aaNrmgPTb52cSCHFE+Z7Z0yg==",
       "cpu": [
         "ppc64"
       ],
@@ -594,9 +573,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.12.tgz",
-      "integrity": "sha512-AgUebVS4DoAblBgiB2ACQ/8l4eGE5aWBb8ZXtkXHiET9mbj7GuWt3OnsIW/zX+XHJt2RYJZctbQ2S/mDjbp0UA==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.14.tgz",
+      "integrity": "sha512-8C6vWbfr0ygbAiMFLS6OPz0BHvApkT2gCboOGV76YrYw+sD/MQJzyITNsjZWDXJwPu9tjrFQOVG7zijRzBCnLw==",
       "cpu": [
         "riscv64"
       ],
@@ -610,9 +589,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.12.tgz",
-      "integrity": "sha512-dJ3Rb3Ei2u/ysSXd6pzleGtfDdc2MuzKt8qc6ls8vreP1G3B7HInX3i7gXS4BGeVd24pp0yqyS7bJ5NHaI9ing==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.14.tgz",
+      "integrity": "sha512-G/Lf9iu8sRMM60OVGOh94ZW2nIStksEcITkXdkD09/T6QFD/o+g0+9WVyR/jajIb3A0LvBJ670tBnGe1GgXMgw==",
       "cpu": [
         "s390x"
       ],
@@ -626,9 +605,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.12.tgz",
-      "integrity": "sha512-OrNJMGQbPaVyHHcDF8ybNSwu7TDOfX8NGpXCbetwOSP6txOJiWlgQnRymfC9ocR1S0Y5PW0Wb1mV6pUddqmvmQ==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.14.tgz",
+      "integrity": "sha512-TBgStYBQaa3EGhgqIDM+ECnkreb0wkcKqL7H6m+XPcGUoU4dO7dqewfbm0mWEQYH3kzFHrzjOFNpSAVzDZRSJw==",
       "cpu": [
         "x64"
       ],
@@ -642,9 +621,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.12.tgz",
-      "integrity": "sha512-55FzVCAiwE9FK8wWeCRuvjazNRJ1QqLCYGZVB6E8RuQuTeStSwotpSW4xoRGwp3a1wUsaVCdYcj5LGCASVJmMg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.14.tgz",
+      "integrity": "sha512-stvCcjyCQR2lMTroqNhAbvROqRjxPEq0oQ380YdXxA81TaRJEucH/PzJ/qsEtsHgXlWFW6Ryr/X15vxQiyRXVg==",
       "cpu": [
         "x64"
       ],
@@ -658,9 +637,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.12.tgz",
-      "integrity": "sha512-qnluf8rfb6Y5Lw2tirfK2quZOBbVqmwxut7GPCIJsM8lc4AEUj9L8y0YPdLaPK0TECt4IdyBdBD/KRFKorlK3g==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.14.tgz",
+      "integrity": "sha512-apAOJF14CIsN5ht1PA57PboEMsNV70j3FUdxLmA2liZ20gEQnfTG5QU0FhENo5nwbTqCB2O3WDsXAihfODjHYw==",
       "cpu": [
         "x64"
       ],
@@ -674,9 +653,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.12.tgz",
-      "integrity": "sha512-+RkKpVQR7bICjTOPUpkTBTaJ4TFqQBX5Ywyd/HSdDkQGn65VPkTsR/pL4AMvuMWy+wnXgIl4EY6q4mVpJal8Kg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.14.tgz",
+      "integrity": "sha512-fYRaaS8mDgZcGybPn2MQbn1ZNZx+UXFSUoS5Hd2oEnlsyUcr/l3c6RnXf1bLDRKKdLRSabTmyCy7VLQ7VhGdOQ==",
       "cpu": [
         "x64"
       ],
@@ -690,9 +669,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.12.tgz",
-      "integrity": "sha512-GNHuciv0mFM7ouzsU0+AwY+7eV4Mgo5WnbhfDCQGtpvOtD1vbOiRjPYG6dhmMoFyBjj+pNqQu2X+7DKn0KQ/Gw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.14.tgz",
+      "integrity": "sha512-1c44RcxKEJPrVj62XdmYhxXaU/V7auELCmnD+Ri+UCt+AGxTvzxl9uauQhrFso8gj6ZV1DaORV0sT9XSHOAk8Q==",
       "cpu": [
         "arm64"
       ],
@@ -706,9 +685,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.12.tgz",
-      "integrity": "sha512-kR8cezhYipbbypGkaqCTWIeu4zID17gamC8YTPXYtcN3E5BhhtTnwKBn9I0PJur/T6UVwIEGYzkffNL0lFvxEw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.14.tgz",
+      "integrity": "sha512-EXAFttrdAxZkFQmpvcAQ2bywlWUsONp/9c2lcfvPUhu8vXBBenCXpoq9YkUvVP639ld3YGiYx0YUQ6/VQz3Maw==",
       "cpu": [
         "ia32"
       ],
@@ -722,9 +701,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.12.tgz",
-      "integrity": "sha512-O0UYQVkvfM/jO8a4OwoV0mAKSJw+mjWTAd1MJd/1FCX6uiMdLmMRPK/w6e9OQ0ob2WGxzIm9va/KG0Ja4zIOgg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.14.tgz",
+      "integrity": "sha512-K0QjGbcskx+gY+qp3v4/940qg8JitpXbdxFhRDA1aYoNaPff88+aEwoq45aqJ+ogpxQxmU0ZTjgnrQD/w8iiUg==",
       "cpu": [
         "x64"
       ],
@@ -857,7 +836,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -871,7 +849,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -880,7 +857,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -888,14 +864,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
       "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -904,8 +878,7 @@
     "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@nivo/annotations": {
       "version": "0.83.0",
@@ -1186,6 +1159,52 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz",
+      "integrity": "sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
@@ -1241,6 +1260,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
       "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -1389,7 +1413,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1570,7 +1593,6 @@
       "version": "4.21.9",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
       "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1643,7 +1665,6 @@
       "version": "1.0.30001509",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
       "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1663,7 +1684,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1782,7 +1802,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -1790,8 +1809,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -1858,8 +1876,12 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/countup.js": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.7.0.tgz",
+      "integrity": "sha512-IP9nYLGgW//0If73eXQdFlReGhpFGHaStqB1v82FknxnUWueF6HFuuOXySW4sEDMc88PsZL1EOn/NPkfTZalmQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1985,7 +2007,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2064,8 +2085,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.446",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.446.tgz",
-      "integrity": "sha512-4Gnw7ztEQ/E0eOt5JWfPn9jjeupfUlKoeW5ETKP9nLdWj+4spFoS3Stj19fqlKIaX28UQs0fNX+uKEyoLCBnkw==",
-      "dev": true
+      "integrity": "sha512-4Gnw7ztEQ/E0eOt5JWfPn9jjeupfUlKoeW5ETKP9nLdWj+4spFoS3Stj19fqlKIaX28UQs0fNX+uKEyoLCBnkw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2161,9 +2181,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.12.tgz",
-      "integrity": "sha512-XuOVLDdtsDslXStStduT41op21Ytmf4/BDS46aa3xPJ7X5h2eMWBF1oAe3QjUH3bDksocNXgzGUZ7XHIBya6Tg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.14.tgz",
+      "integrity": "sha512-uNPj5oHPYmj+ZhSQeYQVFZ+hAlJZbAGOmmILWIqrGvPVlNLbyOvU5Bu6Woi8G8nskcx0vwY0iFoMPrzT86Ko+w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2173,35 +2193,34 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.12",
-        "@esbuild/android-arm64": "0.18.12",
-        "@esbuild/android-x64": "0.18.12",
-        "@esbuild/darwin-arm64": "0.18.12",
-        "@esbuild/darwin-x64": "0.18.12",
-        "@esbuild/freebsd-arm64": "0.18.12",
-        "@esbuild/freebsd-x64": "0.18.12",
-        "@esbuild/linux-arm": "0.18.12",
-        "@esbuild/linux-arm64": "0.18.12",
-        "@esbuild/linux-ia32": "0.18.12",
-        "@esbuild/linux-loong64": "0.18.12",
-        "@esbuild/linux-mips64el": "0.18.12",
-        "@esbuild/linux-ppc64": "0.18.12",
-        "@esbuild/linux-riscv64": "0.18.12",
-        "@esbuild/linux-s390x": "0.18.12",
-        "@esbuild/linux-x64": "0.18.12",
-        "@esbuild/netbsd-x64": "0.18.12",
-        "@esbuild/openbsd-x64": "0.18.12",
-        "@esbuild/sunos-x64": "0.18.12",
-        "@esbuild/win32-arm64": "0.18.12",
-        "@esbuild/win32-ia32": "0.18.12",
-        "@esbuild/win32-x64": "0.18.12"
+        "@esbuild/android-arm": "0.18.14",
+        "@esbuild/android-arm64": "0.18.14",
+        "@esbuild/android-x64": "0.18.14",
+        "@esbuild/darwin-arm64": "0.18.14",
+        "@esbuild/darwin-x64": "0.18.14",
+        "@esbuild/freebsd-arm64": "0.18.14",
+        "@esbuild/freebsd-x64": "0.18.14",
+        "@esbuild/linux-arm": "0.18.14",
+        "@esbuild/linux-arm64": "0.18.14",
+        "@esbuild/linux-ia32": "0.18.14",
+        "@esbuild/linux-loong64": "0.18.14",
+        "@esbuild/linux-mips64el": "0.18.14",
+        "@esbuild/linux-ppc64": "0.18.14",
+        "@esbuild/linux-riscv64": "0.18.14",
+        "@esbuild/linux-s390x": "0.18.14",
+        "@esbuild/linux-x64": "0.18.14",
+        "@esbuild/netbsd-x64": "0.18.14",
+        "@esbuild/openbsd-x64": "0.18.14",
+        "@esbuild/sunos-x64": "0.18.14",
+        "@esbuild/win32-arm64": "0.18.14",
+        "@esbuild/win32-ia32": "0.18.14",
+        "@esbuild/win32-x64": "0.18.14"
       }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2210,7 +2229,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2520,6 +2538,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2698,7 +2721,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2781,7 +2803,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2844,7 +2865,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -3290,7 +3310,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -3314,7 +3333,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3391,7 +3409,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -3458,8 +3475,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -3496,8 +3512,7 @@
     "node_modules/node-releases": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
-      "dev": true
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -3750,8 +3765,18 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.25",
@@ -3864,6 +3889,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-countup": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.4.2.tgz",
+      "integrity": "sha512-wdDrNb2lPFGbLb+i0FTgswPbWziubS6KZRII8NRpXmUCoZsi15PFbIHgBz60Dyxd4KPuRvwsK5aawIU4OPP3jA==",
+      "dependencies": {
+        "@rollup/plugin-babel": "^6.0.3",
+        "countup.js": "^2.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-dom": {
@@ -4048,7 +4085,7 @@
       "version": "3.26.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.0.tgz",
       "integrity": "sha512-YzJH0eunH2hr3knvF3i6IkLO/jTjAEwU4HoMUbQl4//Tnl3ou0e7P5SjxdDr8HQJdeUJShlbEHXrrnEHy1l7Yg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4114,7 +4151,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4408,7 +4444,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -4459,7 +4494,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4520,7 +4554,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
       "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4588,9 +4621,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.3.tgz",
-      "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.4.tgz",
+      "integrity": "sha512-4mvsTxjkveWrKDJI70QmelfVqTm+ihFAb6+xf4sjEU2TmUCTlVX87tmg/QooPEMQb/lM9qGHT99ebqPziEd3wg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -4773,8 +4806,7 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^16.1.4",
     "moment": "^2.29.4",
     "react": "^18.2.0",
+    "react-countup": "^6.4.2",
     "react-dom": "^18.2.0",
     "react-json-pretty": "^2.2.0",
     "react-router-dom": "^6.11.2",

--- a/website/src/components/CRONComponents/CRONSummary/CronSummary.jsx
+++ b/website/src/components/CRONComponents/CRONSummary/CronSummary.jsx
@@ -52,7 +52,7 @@ const CronSummary = ({data, setBenchmarktype, setIsLoadingChart, benchmarkType})
             <div className='cronSummary__text'>
                 <span>QPS Total</span>
                 <h3>{data.Name}</h3>
-                <i className="fa-solid fa-arrow-right"></i>
+                <i className="fa-solid fa-arrow-right cron--fa-arrow-right"></i>
             </div>
         </div>
     );

--- a/website/src/components/CRONComponents/CRONSummary/cronSummary.css
+++ b/website/src/components/CRONComponents/CRONSummary/cronSummary.css
@@ -60,7 +60,7 @@ limitations under the License.
     
 }
 
-.fa-arrow-right{
+.cron--fa-arrow-right{
     position: absolute;
     right: 0%;
     top: 60%;

--- a/website/src/pages/Status/Status.jsx
+++ b/website/src/pages/Status/Status.jsx
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
+import React, { useRef } from "react";
 import RingLoader from "react-spinners/RingLoader";
 import { v4 as uuidv4 } from "uuid";
 import useApiCall from "../../utils/Hook";
+import CountUp from "react-countup";
 
 import PreviousExe from "../../components/StatusComponents/PreviousExecutions/PreviousExe";
 import ExeQueue from "../../components/StatusComponents/ExecutionQueue/ExeQueue";
@@ -36,6 +37,12 @@ const Status = () => {
     isLoading: isLoadingPreviousExe,
     error: errorPreviousExe,
   } = useApiCall(`${import.meta.env.VITE_API_URL}recent`);
+  const {
+    data: dataStatusStats,
+    isLoading: isLoadingStatusStats,
+    error: errorStatusStats,
+  } = useApiCall(`${import.meta.env.VITE_API_URL}status/stats`);
+  console.log(dataStatusStats);
 
   return (
     <div className="status">
@@ -52,7 +59,29 @@ const Status = () => {
           </span>
         </div>
 
-        <figure className="statusStats"></figure>
+        <div className="statusStats flex--column">
+          <CountUp
+            start={0}
+            end={dataStatusStats.Benchmark_total}
+            style={{ fontSize: "5rem", color: "#E77002" }}
+            duration={3}
+          />
+          <span className="countUp__title">Benchmark Total</span>
+          <CountUp
+            start={0}
+            end={dataStatusStats.Benchmark_finished}
+            style={{ fontSize: "5rem", color: "#E77002" }}
+            duration={3}
+          />
+          <span className="countUp__title">Successful benchmarks</span>
+          <CountUp
+            start={0}
+            end={dataStatusStats.Benchmark_30Days}
+            style={{ fontSize: "5rem", color: "#E77002" }}
+            duration={3}
+          />
+          <span className="countUp__title">Successful benchmarks</span>
+        </div>
       </article>
       <figure className="line"></figure>
 

--- a/website/src/pages/Status/Status.jsx
+++ b/website/src/pages/Status/Status.jsx
@@ -42,7 +42,6 @@ const Status = () => {
     isLoading: isLoadingStatusStats,
     error: errorStatusStats,
   } = useApiCall(`${import.meta.env.VITE_API_URL}status/stats`);
-  console.log(dataStatusStats);
 
   return (
     <div className="status">
@@ -62,25 +61,25 @@ const Status = () => {
         <div className="statusStats flex--column">
           <CountUp
             start={0}
-            end={dataStatusStats.Benchmark_total}
+            end={dataStatusStats.Total}
             style={{ fontSize: "5rem", color: "#E77002" }}
             duration={3}
           />
-          <span className="countUp__title">Benchmark Total</span>
+          <span className="countUp__title">Total Benchmark</span>
           <CountUp
             start={0}
-            end={dataStatusStats.Benchmark_finished}
+            end={dataStatusStats.Finished}
             style={{ fontSize: "5rem", color: "#E77002" }}
             duration={3}
           />
           <span className="countUp__title">Successful benchmarks</span>
           <CountUp
             start={0}
-            end={dataStatusStats.Benchmark_30Days}
+            end={dataStatusStats.Last30Days}
             style={{ fontSize: "5rem", color: "#E77002" }}
             duration={3}
           />
-          <span className="countUp__title">Successful benchmarks</span>
+          <span className="countUp__title">Total Benchmarks (last 30 days)</span>
         </div>
       </article>
       <figure className="line"></figure>

--- a/website/src/pages/Status/status.css
+++ b/website/src/pages/Status/status.css
@@ -31,6 +31,7 @@ limitations under the License.
 .status__top__text {
   width: 50%;
   margin-right: 200px;
+  height: 500px;
 }
 
 .status__top__text h2 {
@@ -38,7 +39,6 @@ limitations under the License.
   font-size: 6rem;
   font-weight: 100;
   margin-bottom: 50px;
-  margin-top: 20px;
   width: 100%;
 }
 
@@ -50,6 +50,7 @@ limitations under the License.
 .statusStats {
   color: white;
   min-width: 300px;
+  height: 500px;
 }
 
 .countUp__title {

--- a/website/src/pages/Status/status.css
+++ b/website/src/pages/Status/status.css
@@ -14,154 +14,148 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.status{
-    padding : 0px 50px 50px 50px;
-    background-color: #1F1D1D;  
-    min-height: 100vh;
+.status {
+  padding: 0px 50px 50px 50px;
+  background-color: #1f1d1d;
+  min-height: 100vh;
 }
 
-    /*STATUS TOP*/
+/*STATUS TOP*/
 
-.status__top{
-    margin-top: 100px;
-    align-items: center;
-    
-    
+.status__top {
+  margin-top: 100px;
+  align-items: center;
+  height: 100%;
 }
 
-.status__top__text{
-    width: 50%;
-    margin-right: 200px;
-    
+.status__top__text {
+  width: 50%;
+  margin-right: 200px;
 }
 
-.status__top__text h2{
-    color: white;
-    font-size: 6rem;
-    font-weight:100;
-    margin-bottom: 50px;
-    margin-top: 20px;
-    width: 100%
+.status__top__text h2 {
+  color: white;
+  font-size: 6rem;
+  font-weight: 100;
+  margin-bottom: 50px;
+  margin-top: 20px;
+  width: 100%;
 }
 
-.status__top__text span{
-    color: #B5ADAD;
-    width: 60%;
-    line-height: 40px;
+.status__top__text span {
+  color: #b5adad;
+  width: 60%;
+  line-height: 40px;
 }
-.statusStats{
-    border: solid 2px white;
-    width: 400px;
-    height: 400px;
-}
-
-.status h3{
-    font-size: 3rem;
-    font-weight: 200;
-    margin-bottom: 100px;
-    text-align: center;
+.statusStats {
+  color: white;
+  min-width: 300px;
 }
 
+.countUp__title {
+  margin-bottom: 50px;
+  font-size: 1.2rem;
+}
+.status h3 {
+  font-size: 3rem;
+  font-weight: 200;
+  margin-bottom: 100px;
+  text-align: center;
+}
 
-.hiddenDesktop{
+.hiddenDesktop {
+  display: none;
+}
+
+/*PREVIOUS EXECUTIONS*/
+
+.previousExe {
+  color: white;
+}
+.previousExe__top {
+  justify-content: space-between;
+}
+.previousExe__top__line {
+  border: #b5adad 1px solid;
+  margin-top: 10px;
+}
+.previousExe__top span {
+  text-align: center;
+}
+
+.grey--background {
+  background-color: #343a40;
+}
+
+/* EXECUTION QUEUE */
+
+.queue {
+  color: white;
+  margin-bottom: 200px;
+  text-align: center;
+}
+.queue__top__line {
+  border: #b5adad 1px solid;
+  margin-top: 10px;
+}
+.queue__top {
+  justify-content: space-around;
+}
+
+/* SPINNER */
+
+.loadingSpinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 100px 0px;
+}
+
+.apiError {
+  height: 50vh;
+  color: #e77002;
+  margin-top: 200px;
+  text-align: center;
+  font-size: 3rem;
+}
+
+/* MEDIA QUERIES FOR TABLETS */
+@media only screen and (max-width: 1225px) {
+  .status {
+    padding: 0px 20px 50px 20px;
+  }
+  .status__top__text h2 {
+    font-size: 4rem;
+  }
+  .statusStats {
+    width: 300px;
+  }
+  .hiddenDesktop {
+    display: block;
+  }
+  .hiddenTablet {
     display: none;
-}
-
-    /*PREVIOUS EXECUTIONS*/
-
-.previousExe{
-    color: white;
-}
-.previousExe__top{
-    justify-content: space-between;
-}
-.previousExe__top__line{
-    border: #B5ADAD 1px solid;
-    margin-top: 10px;
-}
-.previousExe__top span{
+  }
+  .statusStats {
     text-align: center;
-    
-}
-
-.grey--background{
-    background-color: #343A40;
-}
-
-     /* EXECUTION QUEUE */
-
-.queue{
-    color: white;
-    margin-bottom: 200px;
-    text-align: center;
-}
-.queue__top__line{
-    border: #B5ADAD 1px solid;
-    margin-top: 10px;
-}
-.queue__top{
-    justify-content: space-around;
-}
-
-    /* SPINNER */
-
-.loadingSpinner{
-    display:flex;
+  }
+  .status__top {
+    flex-direction: column;
     justify-content: center;
-    align-items: center;
-    margin: 100px 0px;
-}
-
-.apiError{
-    height: 50vh;
-    color: #E77002;
-    margin-top: 200px;
+  }
+  .status__top__text {
+    width: 100%;
+    margin-right: 0px;
     text-align: center;
-    font-size: 3rem;
+  }
+  .statusStats {
+    margin-top: 50px;
+  }
 }
 
-
- /* MEDIA QUERIES FOR TABLETS */
- @media only screen and (max-width: 1225px) {
-    .status{
-        padding: 0px 20px 50px 20px;
-    }
-    .status__top__text h2{
-        font-size: 4rem;
-    }
-    .statusStats{
-        width: 300px;
-
-    }
-    .hiddenDesktop{
-        display: block;
-    }
-    .hiddenTablet{
-        display: none;
-    }
-    
-
- }
-
-
-  /* MEDIA QUERIES FOR MOBILE */
-@media only screen and (max-width: 767px){
-    .status__top{
-        flex-direction: column;
-        justify-content: center;
-    }
-    .status__top__text{
-        width: 100%;
-        margin-right: 0px;
-        text-align: center;
-    }
-    .statusStats{
-        width: 300px;
-        height: 300px;
-        margin-top: 50px;
-
-    }
-    .hiddenMobile{
-        display: none;
-    }
+/* MEDIA QUERIES FOR MOBILE */
+@media only screen and (max-width: 767px) {
+  .hiddenMobile {
+    display: none;
+  }
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve benchmark statistics in the server's API. It includes updates to the codebase to fetch and provide benchmark statistics to the clients.

Changes Made:

Added a new struct benchmarkStats with three fields: Benchmark_total, Benchmark_finished, and Benchmark_30Days. This struct will hold the benchmark statistics.

Implemented the GetBenchmarkStats function which retrieves the benchmark statistics from the database using the provided SQLClient. It executes a SQL query to count the total number of benchmarks, the number of finished benchmarks, and the number of benchmarks within the last 30 days. The query results are then assigned to the respective fields of the benchmarkStats struct.

In the getStatusStats function of the Server struct, the GetBenchmarkStats function is called to fetch the benchmark statistics using the server's dbClient. If an error occurs during the retrieval process, an internal server error response is sent back to the client along with the error message. Otherwise, the benchmark statistics are returned as a JSON response with the status code 200 OK.

Reason for the Change:

The addition of benchmark statistics retrieval enhances the functionality of the server's API by providing valuable information about benchmarks. This allows clients to monitor and analyze the benchmarking process more effectively.