### PR TITLE
Enhancement: Improved Handling of Null URL Parameters in Query Plan Display

### DIFF
--- a/website/src/components/QueryPlan/QueryPlan.jsx
+++ b/website/src/components/QueryPlan/QueryPlan.jsx
@@ -33,7 +33,6 @@ const QueryPlan = ({ data, isOpen, togglePlan }) => {
   const queryTitleStyle = {
     background: isOpen && window.innerWidth < 1225 ? "orange" : "initial",
   };
-
   return (
     <div className="queryPlan">
       <div

--- a/website/src/pages/MacroQueriesCompare/MacroQueriesCompare.jsx
+++ b/website/src/pages/MacroQueriesCompare/MacroQueriesCompare.jsx
@@ -44,7 +44,7 @@ const MacroQueriesCompare = () => {
   const [dataQueryPlan, setDataQueryPlan] = useState([]);
 
   useEffect(() => {
-    if (!commitLeft || !commitRight || !type) {
+    if (!commitLeft || !commitRight || !type || commitLeft === "null" || commitRight === "null" || type === "null") {
       setError(
         "Error: Some URL parameters are missing. Please provide both 'ltag', 'rtag' and type parameters."
       );


### PR DESCRIPTION
I changed the condition to display the data on the query plan page to avoid getting an error if any of the URL parameters is null.




