### PR TITLE
Fixing Query Compare Page Link and Adding 'commitleft' and 'commitright' Props to 'macrobenchMobile' Component

### DIFF
--- a/website/src/pages/Macro/Macro.jsx
+++ b/website/src/pages/Macro/Macro.jsx
@@ -178,6 +178,8 @@ const Macro = () => {
                                                     handleSlideChange={handleSlideChange} 
                                                     setCurrentSlideIndexMobile={setCurrentSlideIndexMobile}
                                                     currentSlideIndexMobile={currentSlideIndexMobile}
+                                                    commitHashLeft={commitHashLeft}
+                                                    commitHashRight={commitHashRight}
                                                     textLoading={textLoading}
                                                     />
                                                 </div>


### PR DESCRIPTION
I simply added 'commitleft' and 'commitright' props to my 'macrobenchMobile' component because the link to the 'query compare' page was not functioning otherwise.




