### PR TITLE
Skip `oltp-readonly-olap`

### DIFF
--- a/go/server/server.go
+++ b/go/server/server.go
@@ -169,12 +169,16 @@ func (s *Server) Init() error {
 	}
 
 	s.benchmarkConfig = map[string]benchmarkConfig{
-		"micro":              {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New(), skip: true},
-		"oltp":               {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
-		"oltp-set":           {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
-		"oltp-readonly":      {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
-		"oltp-readonly-olap": {file: path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"), v: viper.New()},
-		"tpcc":               {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
+		"micro":         {file: path.Join(s.benchmarkConfigPath, "micro.yaml"), v: viper.New(), skip: true},
+		"oltp":          {file: path.Join(s.benchmarkConfigPath, "oltp.yaml"), v: viper.New()},
+		"oltp-set":      {file: path.Join(s.benchmarkConfigPath, "oltp-set.yaml"), v: viper.New()},
+		"oltp-readonly": {file: path.Join(s.benchmarkConfigPath, "oltp-readonly.yaml"), v: viper.New()},
+
+		// TODO: oltp-readonly-olap benchmarks are skipped for now as they fail very often due to
+		// MySQL connections being dropped. This issue will be investigated soon.
+		"oltp-readonly-olap": {file: path.Join(s.benchmarkConfigPath, "olap-readonly.yaml"), v: viper.New(), skip: true},
+
+		"tpcc": {file: path.Join(s.benchmarkConfigPath, "tpcc.yaml"), v: viper.New()},
 	}
 	for configName, config := range s.benchmarkConfig {
 		config.v.SetConfigFile(config.file)


### PR DESCRIPTION
The `oltp-readonly-olap` has been consistently failing due to MySQL connections being dropped. Let's skip this benchmark for now to free the execution queue as much as possible while I investigate why the workload fails on Vitess.