### PR TITLE
Fix lack of Prometheus metrics and improve reliability of collected metrics

### DIFF
--- a/ansible/clean_macrobench.yml
+++ b/ansible/clean_macrobench.yml
@@ -10,13 +10,5 @@
 # limitations under the License.
 
 ---
-- name: Stop prometheus
-  hosts:
-    - all
-  roles:
-    - role: prometheus
-      vars:
-        - prom_start: False
-
 - name: Teardown Cluster
   import_playbook: teardown_cluster.yml

--- a/ansible/macrobench.yml
+++ b/ansible/macrobench.yml
@@ -10,6 +10,13 @@
 # limitations under the License.
 
 ---
+- hosts: prometheus
+  tasks:
+    - name: Update Prometheus labels
+      include_role:
+        name: prometheus
+        tasks_from: update_uuid
+
 - hosts: all
   tasks:
     - name: Ensure users are created
@@ -31,106 +38,6 @@
       include_role:
         name: sysbench
         tasks_from: install
-
-- hosts: prometheus
-  become: yes
-  become_user: root
-  tags:
-    - prometheus
-  roles:
-    - { role: cloudalchemy.prometheus, when: stats_remote_db_host is defined and arewefastyet_last_exec_is_same is undefined }
-  vars:
-    vitess_cluster: 'main'
-    mysqld_targets: "{% set targets = [] -%}{% for host in groups['vttablet'] -%}{% for tablet in hostvars[host]['tablets'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (tablet.mysqld_exporter_port | default(9104) |string )) }}{% endfor -%}{% endfor -%}{{ targets }}"
-    tablet_targets: "{% set targets = [] -%}{% for host in groups['vttablet'] -%}{% for tablet in hostvars[host]['tablets'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (tablet.port | default(16001) | string )) }}{% endfor -%}{% endfor -%}{{ targets }}"
-    gateway_targets: "{% set targets = [] -%}{% for host in groups['vtgate'] -%}{% for gateway in hostvars[host]['gateways'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (gateway.port | default(15001) | string )) }}{% endfor -%}{% endfor -%}{{ targets }}"
-    vtctld_targets: "{% set targets = [] -%}{% for host in groups['vtctld'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (vtctld_port | default(15000) | string )) }}{% endfor -%}{{ targets }}"
-    node_targets: "{% set targets= [] -%}{% for host in groups['all'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':9100' ) }}{% endfor -%}{{ targets }}"
-    prometheus_skip_install: false
-    prometheus_version: 2.49.1
-    prometheus_global:
-      scrape_interval: 15s
-      scrape_timeout: 10s
-      evaluation_interval: 15s
-    prometheus_targets:
-      tablets:
-        - targets: '{{ tablet_targets }}'
-          labels:
-            component: vttablet
-            app: vitess
-            cluster: '{{ vitess_cluster }}'
-            region: '{{ cell }}'
-            keyspace: '{{ keyspace }}'
-            exec_uuid: "{{ arewefastyet_exec_uuid }}"
-      mysqld:
-        - targets: '{{ mysqld_targets }}'
-          labels:
-            component: mysqld
-            app: vitess
-            cluster: '{{ vitess_cluster }}'
-            region: '{{ cell }}'
-            keyspace: '{{ keyspace }}'
-            exec_uuid: "{{ arewefastyet_exec_uuid }}"
-      gateways:
-        - targets: '{{ gateway_targets }}'
-          labels:
-            component: vtgate
-            app: vitess
-            cluster: '{{ vitess_cluster }}'
-            region: '{{ cell }}'
-            exec_uuid: "{{ arewefastyet_exec_uuid }}"
-      vtctld:
-        - targets: '{{ vtctld_targets }}'
-          labels:
-            component: vtctld
-            app: vitess
-            cluster: '{{ vitess_cluster }}'
-            region: '{{ cell }}'
-            exec_uuid: "{{ arewefastyet_exec_uuid }}"
-      nodes:
-        - targets: '{{ node_targets }}'
-          labels:
-            component: node
-            app: vitess
-            cluster: '{{ vitess_cluster }}'
-            exec_uuid: "{{ arewefastyet_exec_uuid }}"
-    prometheus_scrape_configs:
-      - job_name: "node"
-        file_sd_configs:
-          - files:
-              - "{{ prometheus_config_dir }}/file_sd/nodes.yml"
-      - job_name: "vitess-vttablet"
-        file_sd_configs:
-          - files:
-              - "{{ prometheus_config_dir }}/file_sd/tablets.yml"
-      - job_name: "mysql"
-        file_sd_configs:
-          - files:
-              - "{{ prometheus_config_dir }}/file_sd/mysqld.yml"
-      - job_name: "vitess-vtctld"
-        file_sd_configs:
-          - files:
-              - "{{ prometheus_config_dir }}/file_sd/vtctld.yml"
-      - job_name: "vitess-vtgate"
-        file_sd_configs:
-          - files:
-              - "{{ prometheus_config_dir }}/file_sd/gateways.yml"
-    prometheus_remote_write:
-      - url: "http://{{ stats_remote_db_host }}/prom/api/v1/write"
-        basic_auth:
-          username: "{{ stats_remote_db_user }}"
-          password: "{{ stats_remote_db_password }}"
-      - url: "http://{{ stats_remote_db_host }}:{{ stats_remote_db_port }}/api/v1/prom/write?db={{ stats_remote_db_database }}&u={{ stats_remote_db_user }}&p={{ stats_remote_db_password }}"
-    prometheus_external_labels:
-      exec_uuid: "{{ arewefastyet_exec_uuid }}"
-
-- hosts: prometheus
-  tasks:
-    - name: Update Prometheus labels
-      when: arewefastyet_last_exec_is_same is defined
-      include_role:
-        name: prometheus
-        tasks_from: update_uuid
 
 - hosts: macrobench
   roles:

--- a/ansible/roles/prometheus/tasks/update_uuid.yml
+++ b/ansible/roles/prometheus/tasks/update_uuid.yml
@@ -12,18 +12,13 @@
 ---
 - name: Replace prometheus exec_uuid label value
   with_items:
-    - 'gateways.yml'
-    - 'mysqld.yml'
-    - 'nodes.yml'
-    - 'tablets.yml'
-    - 'vtctld.yml'
+    - 'prometheus.yml'
+    - 'file_sd/gateways.yml'
+    - 'file_sd/mysqld.yml'
+    - 'file_sd/nodes.yml'
+    - 'file_sd/tablets.yml'
+    - 'file_sd/vtctld.yml'
   lineinfile:
-    path: '/etc/prometheus/file_sd/{{ item }}'
+    path: '/etc/prometheus/{{ item }}'
     regexp: '^(.*)exec_uuid:(.*)$'
     line: '    exec_uuid: {{arewefastyet_exec_uuid}}'
-
-- name: Restart prometheus service
-  service:
-    name: prometheus
-    state: restarted
-    enabled: yes

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -57,24 +57,89 @@
   tags:
     - prometheus
   roles:
-    - cloudalchemy.prometheus
+    - { role: cloudalchemy.prometheus, when: stats_remote_db_host is defined }
   vars:
+    vitess_cluster: 'main'
+    mysqld_targets: "{% set targets = [] -%}{% for host in groups['vttablet'] -%}{% for tablet in hostvars[host]['tablets'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (tablet.mysqld_exporter_port | default(9104) |string )) }}{% endfor -%}{% endfor -%}{{ targets }}"
+    tablet_targets: "{% set targets = [] -%}{% for host in groups['vttablet'] -%}{% for tablet in hostvars[host]['tablets'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (tablet.port | default(16001) | string )) }}{% endfor -%}{% endfor -%}{{ targets }}"
+    gateway_targets: "{% set targets = [] -%}{% for host in groups['vtgate'] -%}{% for gateway in hostvars[host]['gateways'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (gateway.port | default(15001) | string )) }}{% endfor -%}{% endfor -%}{{ targets }}"
+    vtctld_targets: "{% set targets = [] -%}{% for host in groups['vtctld'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':'+ (vtctld_port | default(15000) | string )) }}{% endfor -%}{{ targets }}"
     node_targets: "{% set targets= [] -%}{% for host in groups['all'] -%}{{ targets.append( hostvars[host]['ansible_default_ipv4']['address']+':9100' ) }}{% endfor -%}{{ targets }}"
+    prometheus_skip_install: false
+    prometheus_version: 2.49.1
+    prometheus_global:
+      scrape_interval: 15s
+      scrape_timeout: 10s
+      evaluation_interval: 15s
     prometheus_targets:
+      tablets:
+        - targets: '{{ tablet_targets }}'
+          labels:
+            component: vttablet
+            app: vitess
+            cluster: '{{ vitess_cluster }}'
+            region: '{{ cell }}'
+            keyspace: '{{ keyspace }}'
+            exec_uuid: "exec_uuid"
+      mysqld:
+        - targets: '{{ mysqld_targets }}'
+          labels:
+            component: mysqld
+            app: vitess
+            cluster: '{{ vitess_cluster }}'
+            region: '{{ cell }}'
+            keyspace: '{{ keyspace }}'
+            exec_uuid: "exec_uuid"
+      gateways:
+        - targets: '{{ gateway_targets }}'
+          labels:
+            component: vtgate
+            app: vitess
+            cluster: '{{ vitess_cluster }}'
+            region: '{{ cell }}'
+            exec_uuid: "exec_uuid"
+      vtctld:
+        - targets: '{{ vtctld_targets }}'
+          labels:
+            component: vtctld
+            app: vitess
+            cluster: '{{ vitess_cluster }}'
+            region: '{{ cell }}'
+            exec_uuid: "exec_uuid"
       nodes:
-      - targets: '{{ node_targets }}'
-        labels:
-          component: node
+        - targets: '{{ node_targets }}'
+          labels:
+            component: node
+            app: vitess
+            cluster: '{{ vitess_cluster }}'
+            exec_uuid: "exec_uuid"
     prometheus_scrape_configs:
       - job_name: "node"
         file_sd_configs:
           - files:
               - "{{ prometheus_config_dir }}/file_sd/nodes.yml"
+      - job_name: "vitess-vttablet"
+        file_sd_configs:
+          - files:
+              - "{{ prometheus_config_dir }}/file_sd/tablets.yml"
+      - job_name: "mysql"
+        file_sd_configs:
+          - files:
+              - "{{ prometheus_config_dir }}/file_sd/mysqld.yml"
+      - job_name: "vitess-vtctld"
+        file_sd_configs:
+          - files:
+              - "{{ prometheus_config_dir }}/file_sd/vtctld.yml"
+      - job_name: "vitess-vtgate"
+        file_sd_configs:
+          - files:
+              - "{{ prometheus_config_dir }}/file_sd/gateways.yml"
+    prometheus_remote_write:
+      - url: "http://{{ stats_remote_db_host }}/prom/api/v1/write"
+        basic_auth:
+          username: "{{ stats_remote_db_user }}"
+          password: "{{ stats_remote_db_password }}"
+      - url: "http://{{ stats_remote_db_host }}:{{ stats_remote_db_port }}/api/v1/prom/write?db={{ stats_remote_db_database }}&u={{ stats_remote_db_user }}&p={{ stats_remote_db_password }}"
+    prometheus_external_labels:
+      exec_uuid: "exec_uuid"
 
-- name: Stop prometheus
-  hosts:
-    - all
-  roles:
-    - role: prometheus
-      vars:
-        - prom_start: False


### PR DESCRIPTION
We used to re-start the Prometheus service between each benchmark (whether it was the same one or not) which led to Prometheus replaying the WAL after every restart and being unavailable to collect metrics during this time. This issue was not very visible before #517 as benchmarks were long, but since benchmarks run fairly fast now, the issue is obvious and leads to benchmarks having 0 metrics collected. Also this issue is not easily reproducible on the dev host machine as the whole setup of benchmark is a lot longer there.

With this PR we are not keeping Prometheus running all the time on the host machine and using hot reloading of the configuration files to change the `exec_uuid` label.