### PR TITLE
Fix: Compare page and Foreign key page  responsiveness 

### DIFF
--- a/website/src/pages/ComparePage/components/Hero.tsx
+++ b/website/src/pages/ComparePage/components/Hero.tsx
@@ -20,20 +20,20 @@ export default function Hero(props: { gitRef: any; setGitRef: any }) {
   const { gitRef, setGitRef } = props;
 
   return (
-    <section className="flex flex-col h-[32vh] pt-[8vh] justify-center items-center">
-      <h1 className="mb-3 text-front text-opacity-70">
+    <section className="h-[30vh] pt-[5vh] flex flex-col justify-center items-center">
+      <h1 className="mb-3 text-front text-opacity-70 text-center">
         Enter SHAs to compare commits
       </h1>
-      <div className="flex overflow-hidden bg-gradient-to-br from-primary to-theme p-[2px] rounded-full">
+      <div className="flex flex-col md:flex-row overflow-hidden bg-gradient-to-br from-primary to-theme p-[3px] rounded-full w-full md:w-1/2">
         <ComparisonInput
           name="old"
-          className="rounded-l-full"
+          className="md:rounded-l-full rounded-t-full md:rounded-tr-none"
           setGitRef={setGitRef}
           gitRef={gitRef}
         />
         <ComparisonInput
           name="new"
-          className="rounded-r-full "
+          className="md:rounded-r-full rounded-b-full md:rounded-bl-none"
           setGitRef={setGitRef}
           gitRef={gitRef}
         />
@@ -56,7 +56,7 @@ function ComparisonInput(props: {
       name={name}
       className={twMerge(
         className,
-        "relative text-xl px-6 py-2 bg-background focus:border-none focus:outline-none border border-primary"
+        "relative text-lg px-4 py-2 bg-background focus:border-none focus:outline-none border border-primary w-full"
       )}
       defaultValue={gitRef[name]}
       placeholder={`${name} SHA`}

--- a/website/src/pages/ForeignKeysPage/components/Hero.tsx
+++ b/website/src/pages/ForeignKeysPage/components/Hero.tsx
@@ -17,19 +17,15 @@ import React from "react";
 import Dropdown from "../../../common/Dropdown";
 import { twMerge } from "tailwind-merge";
 
-export default function Hero(props: {
-  refs: any;
-  gitRef: any;
-  setGitRef: any;
-}) {
+export default function Hero(props: { refs: any; gitRef: any; setGitRef: any }) {
   const { refs, gitRef, setGitRef } = props;
 
   return (
-    <section className="flex h-[60vh] pt-[10vh] items-center p-page">
-      <div className="flex basis-1/2 flex-col">
+    <section className="flex h-[60vh] pt-[30vh] md:pt-[15vh] lg:pt-[15vh] items-center p-page">
+      <div className="flex basis-full md:basis-1/2 flex-col">
         <h2 className="text-8xl text-primary">Foreign Keys</h2>
-        <p className="my-6 leading-loose">
-          Support for Foreign Keys have been added to Vitess in v18.0.0. We want
+        <p className="my-6 leading-loose text-sm md:text-base lg:text-lg">
+          Support for Foreign Keys has been added to Vitess in v18.0.0. We want
           to be able to compare the performance of Vitess with and without
           Foreign Keys.
           <br />
@@ -39,9 +35,9 @@ export default function Hero(props: {
           <br />
           - TPCC_UNSHARDED, with an unsharded keyspace
           <br />
-          - TPCC_FK, with Foreign Keys enabled and set to vitess managed
+          - TPCC_FK, with Foreign Keys enabled and set to Vitess managed
           <br />
-          - TPCC_FK_UNMANAGED, with Foreign Keys enabled and set to vitess
+          - TPCC_FK_UNMANAGED, with Foreign Keys enabled and set to Vitess
           unmanaged
           <br />
           Use the dropdown on the right to select which version of Vitess you
@@ -55,7 +51,7 @@ export default function Hero(props: {
           {refs && refs.length > 0 && (
             <div className="flex gap-x-24">
               <Dropdown.Container
-                className="w-[20vw] py-2 border border-primary rounded-md mb-[1px] text-lg shadow-xl"
+                className="w-full md:w-[20vw] py-2 border border-primary rounded-md mb-[1px] text-lg shadow-xl"
                 defaultIndex={refs
                   .map((r: { Name: any }) => r.Name)
                   .indexOf(gitRef.tag)}
@@ -69,7 +65,7 @@ export default function Hero(props: {
                   <Dropdown.Option
                     key={key}
                     className={twMerge(
-                      "w-[20vw] relative border-front border border-t-transparent border-opacity-60 bg-background py-2 font-medium hover:bg-accent",
+                      "w-full md:w-[20vw] relative border-front border border-t-transparent border-opacity-60 bg-background py-2 font-medium hover:bg-accent",
                       key === 0 && "rounded-t border-t-front",
                       key === refs.length - 1 && "rounded-b"
                     )}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
In the compare page, the search bar wasn't responsive when viewed on mobile devices. 

In Foreign Key page the title was not responsive.
Bugfix

-  Related to #500

**Screenshots/videos:**

Before
![image](https://github.com/vitessio/arewefastyet/assets/69034460/f1485a00-ee30-4625-aced-218d941e89e7)
![image](https://github.com/vitessio/arewefastyet/assets/69034460/2fdaf5d2-e7df-4159-b17e-de1c480e829e)

After
![image](https://github.com/vitessio/arewefastyet/assets/69034460/f6a83303-0abe-40cd-8818-343ce3e0c317)
![image](https://github.com/vitessio/arewefastyet/assets/69034460/45cfd2be-7f0d-4557-8aed-43dddd1f9b64)

**Does this PR introduce a breaking change?**

none
