### PR TITLE
Fix: Daily page crash handled

### DIFF
--- a/website/src/pages/DailyPage/DailyPage.tsx
+++ b/website/src/pages/DailyPage/DailyPage.tsx
@@ -127,6 +127,7 @@ export default function DailyPage() {
     },
   ];
 
+try{
   for (const item of dataDaily) {
     const xValue = item.git_ref.slice(0, 8);
 
@@ -199,6 +200,9 @@ export default function DailyPage() {
       x: xValue,
       y: item.components_mem_stats_alloc_bytes.vttablet.center,
     });
+  }
+} catch(error){
+    console.log(error);
   }
 
   const allChartData: {


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bug fix
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
fixes #549 


**Screenshots/videos:**

https://github.com/vitessio/arewefastyet/assets/112820522/367ea7b2-a9cc-42e4-aaf8-ce1638124604



<!--Add screenshots or videos wherever possible.-->

|  Before | After |
|  -----  | ----- |
|    The daily page caused the screen to go blank because dataDaily couldn't be fetched, making it non-iterable and causing a crash.    |    Added error handling to ensure the page loads even if dataDaily cannot be fetched, preventing the site from crashing. The root issue with fetching dataDaily still needs to be resolved.

**Does this PR introduce a breaking change?**
No it doesn't

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

kindly review @frouioui 