### PR TITLE
Fix the branch used by sysbench

### DIFF
--- a/ansible/roles/sysbench/tasks/install.yml
+++ b/ansible/roles/sysbench/tasks/install.yml
@@ -16,7 +16,7 @@
   git:
     repo: https://github.com/planetscale/sysbench
     dest: /src/sysbench
-    version: master
+    version: main
     depth: 1
     force: 1
 


### PR DESCRIPTION
I think someone changed the default branch of https://github.com/planetscale/sysbench without me knowing, leading to `master` not being usable any more. This PR fix the failures in all recent benchmark by fetching sysbench from main.