### PR TITLE
Fix flag issues with v19 benchmarks

### DIFF
--- a/ansible/roles/vttablet/templates/vttablet.conf.j2
+++ b/ansible/roles/vttablet/templates/vttablet.conf.j2
@@ -31,9 +31,15 @@ EXTRA_VTTABLET_FLAGS="--alsologtostderr \
     --queryserver-config-pool-size={{ tablet.connection_pool_size | default(vttablet_connection_pool_size) }} \
     --queryserver-config-stream-pool-size={{ tablet.stream_pool_size | default(vttablet_stream_pool_size) }} \
     --queryserver-config-transaction-cap={{ tablet.transaction_cap | default(vttablet_transaction_cap) }} \
-    --queryserver-config-query-timeout=900s \
-    --queryserver-config-schema-reload-time=60s \
-    --queryserver-config-transaction-timeout=300s \
+    {% if vitess_major_version <= 18 %}
+      --queryserver-config-query-timeout=900 \
+      --queryserver-config-schema-reload-time=60 \
+      --queryserver-config-transaction-timeout=300 \
+    {% else %}
+      --queryserver-config-query-timeout=900s \
+      --queryserver-config-schema-reload-time=60s \
+      --queryserver-config-transaction-timeout=300s \
+    {% endif %}
     --grpc_max_message_size=67108864 \
     --db_charset=utf8 \
     {% if pprof_targets is defined %}

--- a/ansible/roles/vttablet/templates/vttablet.conf.j2
+++ b/ansible/roles/vttablet/templates/vttablet.conf.j2
@@ -31,15 +31,9 @@ EXTRA_VTTABLET_FLAGS="--alsologtostderr \
     --queryserver-config-pool-size={{ tablet.connection_pool_size | default(vttablet_connection_pool_size) }} \
     --queryserver-config-stream-pool-size={{ tablet.stream_pool_size | default(vttablet_stream_pool_size) }} \
     --queryserver-config-transaction-cap={{ tablet.transaction_cap | default(vttablet_transaction_cap) }} \
-    {% if vitess_version_name == "latest" %}
-      --queryserver-config-query-timeout=900s \
-      --queryserver-config-schema-reload-time=60s \
-      --queryserver-config-transaction-timeout=300s \
-    {% else %}
-      --queryserver-config-query-timeout=900 \
-      --queryserver-config-schema-reload-time=60 \
-      --queryserver-config-transaction-timeout=300 \
-    {% endif %}
+    --queryserver-config-query-timeout=900s \
+    --queryserver-config-schema-reload-time=60s \
+    --queryserver-config-transaction-timeout=300s \
     --grpc_max_message_size=67108864 \
     --db_charset=utf8 \
     {% if pprof_targets is defined %}

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -391,6 +391,7 @@ func (e *Exec) prepareAnsibleForExecution() error {
 		e.AnsibleConfig.AddExtraVar(ansible.KeyVitessVersionPRNumber, e.PullNB)
 	}
 	e.AnsibleConfig.AddExtraVar(ansible.KeyVtgatePlanner, e.VtgatePlannerVersion)
+	e.AnsibleConfig.AddExtraVar(ansible.KeyVitessMajorVersion, e.VitessVersion.Major)
 	e.AnsibleConfig.AddExtraVar(ansible.KeyVitessSchema, e.vitessSchemaPath)
 	e.vitessConfig.addToAnsible(&e.AnsibleConfig)
 

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -48,13 +48,12 @@ const (
 )
 
 type Exec struct {
-	UUID              uuid.UUID
-	RawUUID           string
-	AnsibleConfig     ansible.Config
-	Source            string
-	GitRef            string
-	VitessVersion     git.Version
-	VitessVersionName string
+	UUID          uuid.UUID
+	RawUUID       string
+	AnsibleConfig ansible.Config
+	Source        string
+	GitRef        string
+	VitessVersion git.Version
 
 	// NextBenchmarkIsTheSame is set to true if the next benchmark has the same config
 	// as the current one. This allows us to do some optimization in Ansible and speed
@@ -161,9 +160,6 @@ const (
 	SourcePullRequestBase = "cron_pr_base"
 	SourceTag             = "cron_tags_"
 	SourceReleaseBranch   = "cron_"
-
-	VitessLatestVersion   = "latest"
-	VitessPreviousVersion = "v_"
 )
 
 // NewExec creates a new *Exec given the string representation of an uuid.UUID.
@@ -308,11 +304,6 @@ func (e *Exec) Prepare() error {
 		return err
 	}
 
-	err = e.defineVersionNameOfVitess()
-	if err != nil {
-		return err
-	}
-
 	err = prepareVitessConfiguration(e.rawVitessConfig, e.VitessVersion, &e.vitessConfig)
 	if err != nil {
 		return err
@@ -400,7 +391,6 @@ func (e *Exec) prepareAnsibleForExecution() error {
 		e.AnsibleConfig.AddExtraVar(ansible.KeyVitessVersionPRNumber, e.PullNB)
 	}
 	e.AnsibleConfig.AddExtraVar(ansible.KeyVtgatePlanner, e.VtgatePlannerVersion)
-	e.AnsibleConfig.AddExtraVar(ansible.KeyVitessVersionName, e.VitessVersionName)
 	e.AnsibleConfig.AddExtraVar(ansible.KeyVitessSchema, e.vitessSchemaPath)
 	e.vitessConfig.addToAnsible(&e.AnsibleConfig)
 
@@ -430,22 +420,6 @@ func (e *Exec) handleStepEnd(err error) {
 	if err != nil {
 		_, _ = e.clientDB.Insert("UPDATE execution SET finished_at = CURRENT_TIME, status = ? WHERE uuid = ?", StatusFailed, e.UUID.String())
 	}
-}
-
-func (e *Exec) defineVersionNameOfVitess() error {
-	release, err := git.GetLastReleaseAndCommitHash(e.RepoDir)
-	if err != nil {
-		return err
-	}
-
-	// Main branch
-	if e.Source == SourceCron || release.Version.Major <= e.VitessVersion.Major {
-		e.VitessVersionName = VitessLatestVersion
-		return nil
-	}
-
-	e.VitessVersionName = fmt.Sprintf("%s%d", VitessPreviousVersion, e.VitessVersion.Major)
-	return nil
 }
 
 func GetRecentExecutions(client storage.SQLClient) ([]*Exec, error) {

--- a/go/infra/ansible/vars.go
+++ b/go/infra/ansible/vars.go
@@ -70,11 +70,6 @@ const (
 	// number that the execution will benchmark.
 	KeyVitessVersionPRNumber = "vitess_git_version_pr_nb"
 
-	// KeyVitessVersionName corresponding value in the map is the name of the vitess
-	// version on which the benchmarks will be executed. For instance: 'latest', '14',
-	// '13', ...
-	KeyVitessVersionName = "vitess_version_name"
-
 	// KeyVtgatePlanner corresponding value in the map is the query planner version
 	// that will be used to execute the benchmark.
 	KeyVtgatePlanner = "vitess_planner_version"

--- a/go/infra/ansible/vars.go
+++ b/go/infra/ansible/vars.go
@@ -70,6 +70,10 @@ const (
 	// number that the execution will benchmark.
 	KeyVitessVersionPRNumber = "vitess_git_version_pr_nb"
 
+	// KeyVitessMajorVersion corresponding value in the map is an int set to the major
+	// release increment of Vitess.
+	KeyVitessMajorVersion = "vitess_major_version"
+
 	// KeyVtgatePlanner corresponding value in the map is the query planner version
 	// that will be used to execute the benchmark.
 	KeyVtgatePlanner = "vitess_planner_version"

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -138,9 +138,7 @@ func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 	}
 	var latestReleases []*Release
 
-	// We take the 2 latest major release
-	// TODO: @Florent: use the three latest major releases once v17 is out
-	minimumRelease := allReleases[0].Version.Major - 1
+	minimumRelease := allReleases[0].Version.Major - 2
 	for _, release := range allReleases {
 		if release.Version.Major >= minimumRelease {
 			latestReleases = append(latestReleases, release)
@@ -205,8 +203,7 @@ func GetLatestVitessReleaseBranchCommitHash(repoDir string) ([]*Release, error) 
 	}
 	var latestReleaseBranches []*Release
 	// We take the 2 latest major release
-	// TODO: @Florent: use the three latest major releases once v17 is out
-	minimumRelease := res[0].Version.Major - 1
+	minimumRelease := res[0].Version.Major - 2
 	for _, release := range res {
 		if release.Version.Major >= minimumRelease {
 			latestReleaseBranches = append(latestReleaseBranches, release)


### PR DESCRIPTION
This PR fixes an issue we had since the release of `v20.0.0-rc1` in our `v19` benchmarks. Some of the flag were not using the proper formatting. This was fixed by changing the Jinja template to read an int that corresponds to the major version of vitess we are trying to benchmark, instead of using the non-scalable `is_latest` and `v_xx` from before.