### PR TITLE
Benchmark the last three major releases of vitess

### DIFF
--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -138,7 +138,7 @@ func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 	}
 	var latestReleases []*Release
 
-	minimumRelease := allReleases[0].Version.Major - 2
+	minimumRelease := allReleases[0].Version.Major - 3
 	for _, release := range allReleases {
 		if release.Version.Major >= minimumRelease {
 			latestReleases = append(latestReleases, release)
@@ -203,7 +203,7 @@ func GetLatestVitessReleaseBranchCommitHash(repoDir string) ([]*Release, error) 
 	}
 	var latestReleaseBranches []*Release
 	// We take the 2 latest major release
-	minimumRelease := res[0].Version.Major - 2
+	minimumRelease := res[0].Version.Major - 3
 	for _, release := range res {
 		if release.Version.Major >= minimumRelease {
 			latestReleaseBranches = append(latestReleaseBranches, release)


### PR DESCRIPTION
This PR enables benchmarks for the last three major releases of Vitess. It was previously set to `-1`, then changed to `-2` in https://github.com/vitessio/arewefastyet/pull/559. 