### PR TITLE
Improve the text in the charts' legends

### DIFF
--- a/website/src/pages/DailyPage/components/DailyCharts.tsx
+++ b/website/src/pages/DailyPage/components/DailyCharts.tsx
@@ -98,10 +98,10 @@ const chartMetadas = [
   {
     title: "QPS (Queries per second)",
     metrics: [
-      { dataKey: "qpsReads", legend: "QPS Reads" },
-      { dataKey: "qpsWrites", legend: "QPS Writes" },
-      { dataKey: "qpsOther", legend: "QPS Other" },
-      { dataKey: "qpsTotal", legend: "QPS Total" },
+      { dataKey: "qpsReads", legend: "Reads" },
+      { dataKey: "qpsWrites", legend: "Writes" },
+      { dataKey: "qpsOther", legend: "Other" },
+      { dataKey: "qpsTotal", legend: "Total" },
     ],
   },
   {
@@ -115,17 +115,17 @@ const chartMetadas = [
   {
     title: "CPU / query (μs)",
     metrics: [
-      { dataKey: "cpuTimeVtgate", legend: "CPU Time Vtgate" },
-      { dataKey: "cpuTimeVttablet", legend: "CPU Time Vttablet" },
-      { dataKey: "cpuTimeTotal", legend: "CPU Time Total" },
+      { dataKey: "cpuTimeVtgate", legend: "Vtgate" },
+      { dataKey: "cpuTimeVttablet", legend: "Vttablet" },
+      { dataKey: "cpuTimeTotal", legend: "Total" },
     ],
   },
   {
     title: "Allocated / query (bytes)",
     metrics: [
-      { dataKey: "memBytesVtgate", legend: "Mem Bytes Vtgate" },
-      { dataKey: "memBytesVttablet", legend: "Mem Bytes Vttablet" },
-      { dataKey: "memBytesTotal", legend: "Mem Bytes Total" },
+      { dataKey: "memBytesVtgate", legend: "Vtgate" },
+      { dataKey: "memBytesVttablet", legend: "Vttablet" },
+      { dataKey: "memBytesTotal", legend: "Total" },
     ],
   },
 ];


### PR DESCRIPTION
Quick update as to how the text in the charts' legends look like.

**Before**
<img width="411" alt="image" src="https://github.com/user-attachments/assets/1a2f1ffa-73ae-4d68-9ece-56f3882b2762">


**After**
<img width="411" alt="image" src="https://github.com/user-attachments/assets/8083500b-6053-4f41-bfbb-bff178dc1522">
