### PR TITLE
Improve understandability of metrics and column names

### DIFF
--- a/website/src/common/MacroBenchmarkTable.tsx
+++ b/website/src/common/MacroBenchmarkTable.tsx
@@ -95,6 +95,8 @@ const formatCellValue = (key: string, value: number) => {
     return secondToMicrosecond(value);
   } else if (key.includes("MemStatsAllocBytes")) {
     return formatByte(Number(fixed(value, 2)));
+  } else if (key.includes("latency")) {
+    return value+"ms"
   }
   return fixed(value, 2);
 };

--- a/website/src/common/MacroBenchmarkTable.tsx
+++ b/website/src/common/MacroBenchmarkTable.tsx
@@ -96,7 +96,7 @@ const formatCellValue = (key: string, value: number) => {
   } else if (key.includes("MemStatsAllocBytes")) {
     return formatByte(Number(fixed(value, 2)));
   } else if (key.includes("latency")) {
-    return value+"ms"
+    return fixed(value, 2)+"ms"
   }
   return fixed(value, 2);
 };

--- a/website/src/pages/ComparePage/ComparePage.tsx
+++ b/website/src/pages/ComparePage/ComparePage.tsx
@@ -98,7 +98,7 @@ export default function Compare() {
             insignificant: data.result.tps.insignificant,
           },
           latency: {
-            title: "Latency",
+            title: "P95 Latency",
             old: data.result.latency.old,
             new: data.result.latency.new,
             p: data.result.latency.p,
@@ -106,7 +106,7 @@ export default function Compare() {
             insignificant: data.result.latency.insignificant,
           },
           errors: {
-            title: "Errors",
+            title: "Errors / Second",
             old: data.result.errors.old,
             new: data.result.errors.new,
             p: data.result.errors.p,

--- a/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
+++ b/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
@@ -80,7 +80,7 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     },
   },
   {
-    header: "Started At",
+    header: "Started",
     accessorKey: "started_at",
     cell: ({ row }) => {
       const date = new Date(row.original.started_at);
@@ -102,7 +102,7 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     },
   },
   {
-    header: "Finished At",
+    header: "Finished",
     accessorKey: "finished_at",
     cell: ({ row }) => {
       const date = new Date(row.original.started_at);
@@ -124,7 +124,7 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     },
   },
   {
-    header: "PR",
+    header: "PR #",
     accessorKey: "pull_nb",
     cell: ({ row }) => {
       // if pull_nb is 0, display N/A
@@ -139,7 +139,7 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     },
   },
   {
-    header: "Go Version",
+    header: "Golang",
     accessorKey: "golang_version",
   },
   {


### PR DESCRIPTION
This PR adds more content to the metrics latency and errors of the compare page so they are more understandable by anyone and does a quick rename of some of the status' column.