### PR TITLE
Use the proper value in the finished at column of status

### DIFF
--- a/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
+++ b/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
@@ -105,7 +105,7 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     header: "Finished",
     accessorKey: "finished_at",
     cell: ({ row }) => {
-      const date = new Date(row.original.started_at);
+      const date = new Date(row.original.finished_at);
       const formatted = formatDistanceToNow(date, {
         addSuffix: true,
       });


### PR DESCRIPTION
The status page was showing the wrong value for the finished at column, this fixes it.