### PR TITLE
Fix how we handle unfinished execution

### DIFF
--- a/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
+++ b/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
@@ -105,6 +105,12 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     header: "Finished",
     accessorKey: "finished_at",
     cell: ({ row }) => {
+      if (row.original.finished_at == null) {
+        return (
+            "N/A"
+        );
+      }
+
       const date = new Date(row.original.finished_at);
       const formatted = formatDistanceToNow(date, {
         addSuffix: true,


### PR DESCRIPTION
Something went wrong in my last PR (#580) and it started showing unfinished benchmark as 00000 Unix timestamp, this PR fixes it by showing "N/A" if the benchmark does not have a finished at value:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/8b4e3e09-cfb5-45ca-8def-5ad2952dea8e">
