### PR TITLE
Read from read-only MySQL servers

### DIFF
--- a/docs/arewefastyet_api.md
+++ b/docs/arewefastyet_api.md
@@ -15,10 +15,10 @@ arewefastyet api [flags]
       --gh-secret-key string                     Secret key used to authenticate
       --gh-webhook-secret string                 Secrets used to verify the webhooks
   -h, --help                                     help for api
-      --planetscale-db-branch string             PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string           PlanetscaleDB database name.
-      --planetscale-db-host string               Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string                Name of the PlanetscaleDB organization.
+      --planetscale-db-branch string             PlanetScaleDB branch to use. (default "main")
+      --planetscale-db-database string           PlanetScaleDB database name.
+      --planetscale-db-host string               Hostname of the PlanetScaleDB database.
+      --planetscale-db-org string                Name of the PlanetScaleDB organization.
       --planetscale-db-password-read string      Password used to authenticate to the read-only servers of PlanetScaleDB.
       --planetscale-db-password-write string     Password used to authenticate to the write servers of PlanetScaleDB.
       --planetscale-db-user-read string          Username used to authenticate to the read-only servers of PlanetScaleDB.

--- a/docs/arewefastyet_api.md
+++ b/docs/arewefastyet_api.md
@@ -19,8 +19,10 @@ arewefastyet api [flags]
       --planetscale-db-database string           PlanetscaleDB database name.
       --planetscale-db-host string               Hostname of the PlanetscaleDB database.
       --planetscale-db-org string                Name of the PlanetscaleDB organization.
-      --planetscale-db-password string           Password used to authenticate to PlanetscaleDB.
-      --planetscale-db-user string               Username used to authenticate to PlanetscaleDB.
+      --planetscale-db-password-read string      Password used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-password-write string     Password used to authenticate to the write servers of PlanetScaleDB.
+      --planetscale-db-user-read string          Username used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-user-write string         Username used to authenticate to the write servers of PlanetScaleDB.
       --slack-channel string                     Slack channel on which to post messages
       --slack-token string                       Token used to authenticate Slack
       --web-benchmark-config-path string         Path to the configuration file folder for the benchmarks.

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -11,42 +11,35 @@ It handles the creation, configuration, and cleanup of the infrastructure.
 arewefastyet exec [flags]
 ```
 
-### Examples
-
-```
-arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --planetscale-db-database benchmark --planetscale-db-branch main --planetscale-db-org my-org --planetscale-db-service-token <token> --planetscale-db-service-token-name <token name>
---exec-source config_micro_remote --ansible-inventory-file microbench_inventory.yml --ansible-playbook-file microbench.yml --ansible-root-directory ./ansible/
---equinix-instance-type m2.xlarge.x86 --equinix-token tok --equinix-project-id id
-
-```
-
 ### Options
 
 ```
-      --ansible-inventory-file string        Inventory file used by Ansible
-      --ansible-playbook-file string         Playbook file used by Ansible
-      --ansible-root-directory string        Root directory of Ansible
-      --exec-git-ref string                  Git reference on which the benchmarks will run.
-      --exec-go-version string               Defines the golang version that will be used by this execution. (default "1.17")
-      --exec-pull-nb int                     Defines the number of the pull request against which to execute.
-      --exec-root-dir string                 Path to the root directory of exec.
-      --exec-schema string                   Path to the VSchema for this benchmark.
-      --exec-server-address string           The IP address of the server on which the benchmark will be executed.
-      --exec-source string                   Name of the source that triggered the execution.
-      --exec-type string                     Defines the execution type (oltp, tpcc, micro).
-      --exec-vtgate-planner-version string   Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
-  -h, --help                                 help for exec
-      --planetscale-db-branch string         PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string       PlanetscaleDB database name.
-      --planetscale-db-host string           Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string            Name of the PlanetscaleDB organization.
-      --planetscale-db-password string       Password used to authenticate to PlanetscaleDB.
-      --planetscale-db-user string           Username used to authenticate to PlanetscaleDB.
-      --stats-remote-db-database string      Name of the stats remote database.
-      --stats-remote-db-host string          Hostname of the stats remote database.
-      --stats-remote-db-password string      Password to authenticate the stats remote database.
-      --stats-remote-db-port string          Port of the stats remote database.
-      --stats-remote-db-user string          User used to connect to the stats remote database
+      --ansible-inventory-file string          Inventory file used by Ansible
+      --ansible-playbook-file string           Playbook file used by Ansible
+      --ansible-root-directory string          Root directory of Ansible
+      --exec-git-ref string                    Git reference on which the benchmarks will run.
+      --exec-go-version string                 Defines the golang version that will be used by this execution. (default "1.17")
+      --exec-pull-nb int                       Defines the number of the pull request against which to execute.
+      --exec-root-dir string                   Path to the root directory of exec.
+      --exec-schema string                     Path to the VSchema for this benchmark.
+      --exec-server-address string             The IP address of the server on which the benchmark will be executed.
+      --exec-source string                     Name of the source that triggered the execution.
+      --exec-type string                       Defines the execution type (oltp, tpcc, micro).
+      --exec-vtgate-planner-version string     Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
+  -h, --help                                   help for exec
+      --planetscale-db-branch string           PlanetscaleDB branch to use. (default "main")
+      --planetscale-db-database string         PlanetscaleDB database name.
+      --planetscale-db-host string             Hostname of the PlanetscaleDB database.
+      --planetscale-db-org string              Name of the PlanetscaleDB organization.
+      --planetscale-db-password-read string    Password used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-password-write string   Password used to authenticate to the write servers of PlanetScaleDB.
+      --planetscale-db-user-read string        Username used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-user-write string       Username used to authenticate to the write servers of PlanetScaleDB.
+      --stats-remote-db-database string        Name of the stats remote database.
+      --stats-remote-db-host string            Hostname of the stats remote database.
+      --stats-remote-db-password string        Password to authenticate the stats remote database.
+      --stats-remote-db-port string            Port of the stats remote database.
+      --stats-remote-db-user string            User used to connect to the stats remote database
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -27,10 +27,10 @@ arewefastyet exec [flags]
       --exec-type string                       Defines the execution type (oltp, tpcc, micro).
       --exec-vtgate-planner-version string     Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
   -h, --help                                   help for exec
-      --planetscale-db-branch string           PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string         PlanetscaleDB database name.
-      --planetscale-db-host string             Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string              Name of the PlanetscaleDB organization.
+      --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
+      --planetscale-db-database string         PlanetScaleDB database name.
+      --planetscale-db-host string             Hostname of the PlanetScaleDB database.
+      --planetscale-db-org string              Name of the PlanetScaleDB organization.
       --planetscale-db-password-read string    Password used to authenticate to the read-only servers of PlanetScaleDB.
       --planetscale-db-password-write string   Password used to authenticate to the write servers of PlanetScaleDB.
       --planetscale-db-user-read string        Username used to authenticate to the read-only servers of PlanetScaleDB.

--- a/docs/arewefastyet_gen_exec_metrics.md
+++ b/docs/arewefastyet_gen_exec_metrics.md
@@ -15,10 +15,10 @@ arewefastyet gen exec_metrics [flags]
       --influx-password string                 Password used to connect to InfluxDB.
       --influx-port string                     Port on which to InfluxDB listens. (default "8086")
       --influx-username string                 Username used to connect to InfluxDB.
-      --planetscale-db-branch string           PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string         PlanetscaleDB database name.
-      --planetscale-db-host string             Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string              Name of the PlanetscaleDB organization.
+      --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
+      --planetscale-db-database string         PlanetScaleDB database name.
+      --planetscale-db-host string             Hostname of the PlanetScaleDB database.
+      --planetscale-db-org string              Name of the PlanetScaleDB organization.
       --planetscale-db-password-read string    Password used to authenticate to the read-only servers of PlanetScaleDB.
       --planetscale-db-password-write string   Password used to authenticate to the write servers of PlanetScaleDB.
       --planetscale-db-user-read string        Username used to authenticate to the read-only servers of PlanetScaleDB.

--- a/docs/arewefastyet_gen_exec_metrics.md
+++ b/docs/arewefastyet_gen_exec_metrics.md
@@ -9,18 +9,20 @@ arewefastyet gen exec_metrics [flags]
 ### Options
 
 ```
-  -h, --help                             help for exec_metrics
-      --influx-database string           Name of the database to use in InfluxDB.
-      --influx-hostname string           Hostname of InfluxDB.
-      --influx-password string           Password used to connect to InfluxDB.
-      --influx-port string               Port on which to InfluxDB listens. (default "8086")
-      --influx-username string           Username used to connect to InfluxDB.
-      --planetscale-db-branch string     PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string   PlanetscaleDB database name.
-      --planetscale-db-host string       Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string        Name of the PlanetscaleDB organization.
-      --planetscale-db-password string   Password used to authenticate to PlanetscaleDB.
-      --planetscale-db-user string       Username used to authenticate to PlanetscaleDB.
+  -h, --help                                   help for exec_metrics
+      --influx-database string                 Name of the database to use in InfluxDB.
+      --influx-hostname string                 Hostname of InfluxDB.
+      --influx-password string                 Password used to connect to InfluxDB.
+      --influx-port string                     Port on which to InfluxDB listens. (default "8086")
+      --influx-username string                 Username used to connect to InfluxDB.
+      --planetscale-db-branch string           PlanetscaleDB branch to use. (default "main")
+      --planetscale-db-database string         PlanetscaleDB database name.
+      --planetscale-db-host string             Hostname of the PlanetscaleDB database.
+      --planetscale-db-org string              Name of the PlanetscaleDB organization.
+      --planetscale-db-password-read string    Password used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-password-write string   Password used to authenticate to the write servers of PlanetScaleDB.
+      --planetscale-db-user-read string        Username used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-user-write string       Username used to authenticate to the write servers of PlanetScaleDB.
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -10,12 +10,6 @@ Run macro benchmarks using a fork of sysbench (https://github.com/planetscale/sy
 arewefastyet macrobench run [flags]
 ```
 
-### Examples
-
-```
-arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-db-branch main --planetscale-db-org my-org --planetscale-db-service-token <token> --planetscale-db-service-token-name <token name>
-```
-
 ### Options
 
 ```
@@ -38,8 +32,10 @@ arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-
       --planetscale-db-database string             PlanetscaleDB database name.
       --planetscale-db-host string                 Hostname of the PlanetscaleDB database.
       --planetscale-db-org string                  Name of the PlanetscaleDB organization.
-      --planetscale-db-password string             Password used to authenticate to PlanetscaleDB.
-      --planetscale-db-user string                 Username used to authenticate to PlanetscaleDB.
+      --planetscale-db-password-read string        Password used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-password-write string       Password used to authenticate to the write servers of PlanetScaleDB.
+      --planetscale-db-user-read string            Username used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-user-write string           Username used to authenticate to the write servers of PlanetScaleDB.
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -28,10 +28,10 @@ arewefastyet macrobench run [flags]
       --macrobench-vtgate-web-ports strings        List of the web port for each VTGate.
       --macrobench-working-directory string        Directory on which to execute sysbench.
       --macrobench-workload-path string            Path to the workload used by sysbench.
-      --planetscale-db-branch string               PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string             PlanetscaleDB database name.
-      --planetscale-db-host string                 Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string                  Name of the PlanetscaleDB organization.
+      --planetscale-db-branch string               PlanetScaleDB branch to use. (default "main")
+      --planetscale-db-database string             PlanetScaleDB database name.
+      --planetscale-db-host string                 Hostname of the PlanetScaleDB database.
+      --planetscale-db-org string                  Name of the PlanetScaleDB organization.
       --planetscale-db-password-read string        Password used to authenticate to the read-only servers of PlanetScaleDB.
       --planetscale-db-password-write string       Password used to authenticate to the write servers of PlanetScaleDB.
       --planetscale-db-user-read string            Username used to authenticate to the read-only servers of PlanetScaleDB.

--- a/docs/arewefastyet_microbench_run.md
+++ b/docs/arewefastyet_microbench_run.md
@@ -11,24 +11,20 @@ The output can also be outputted to <output file>.
 arewefastyet microbench run [root dir] <pkg> <output file> [flags]
 ```
 
-### Examples
-
-```
-arewastyet microbenchmark run ~/vitess ./go/vt/sqlparser output.txt
-```
-
 ### Options
 
 ```
-  -h, --help                             help for run
-      --microbench-exec-uuid string      UUID of the parent execution, an empty string will set to NULL.
-      --microbench-run-profile           Run goproc profiling for each micro-benchmark.
-      --planetscale-db-branch string     PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string   PlanetscaleDB database name.
-      --planetscale-db-host string       Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string        Name of the PlanetscaleDB organization.
-      --planetscale-db-password string   Password used to authenticate to PlanetscaleDB.
-      --planetscale-db-user string       Username used to authenticate to PlanetscaleDB.
+  -h, --help                                   help for run
+      --microbench-exec-uuid string            UUID of the parent execution, an empty string will set to NULL.
+      --microbench-run-profile                 Run goproc profiling for each micro-benchmark.
+      --planetscale-db-branch string           PlanetscaleDB branch to use. (default "main")
+      --planetscale-db-database string         PlanetscaleDB database name.
+      --planetscale-db-host string             Hostname of the PlanetscaleDB database.
+      --planetscale-db-org string              Name of the PlanetscaleDB organization.
+      --planetscale-db-password-read string    Password used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-password-write string   Password used to authenticate to the write servers of PlanetScaleDB.
+      --planetscale-db-user-read string        Username used to authenticate to the read-only servers of PlanetScaleDB.
+      --planetscale-db-user-write string       Username used to authenticate to the write servers of PlanetScaleDB.
 ```
 
 ### Options inherited from parent commands

--- a/docs/arewefastyet_microbench_run.md
+++ b/docs/arewefastyet_microbench_run.md
@@ -17,10 +17,10 @@ arewefastyet microbench run [root dir] <pkg> <output file> [flags]
   -h, --help                                   help for run
       --microbench-exec-uuid string            UUID of the parent execution, an empty string will set to NULL.
       --microbench-run-profile                 Run goproc profiling for each micro-benchmark.
-      --planetscale-db-branch string           PlanetscaleDB branch to use. (default "main")
-      --planetscale-db-database string         PlanetscaleDB database name.
-      --planetscale-db-host string             Hostname of the PlanetscaleDB database.
-      --planetscale-db-org string              Name of the PlanetscaleDB organization.
+      --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
+      --planetscale-db-database string         PlanetScaleDB database name.
+      --planetscale-db-host string             Hostname of the PlanetScaleDB database.
+      --planetscale-db-org string              Name of the PlanetScaleDB organization.
       --planetscale-db-password-read string    Password used to authenticate to the read-only servers of PlanetScaleDB.
       --planetscale-db-password-write string   Password used to authenticate to the write servers of PlanetScaleDB.
       --planetscale-db-user-read string        Username used to authenticate to the read-only servers of PlanetScaleDB.

--- a/go/cmd/exec/exec.go
+++ b/go/cmd/exec/exec.go
@@ -37,10 +37,6 @@ func ExecCmd() *cobra.Command {
 		Short:   "Execute a task",
 		Long: `Execute a task based on the given terraform and ansible configuration.
 It handles the creation, configuration, and cleanup of the infrastructure.`,
-		Example: `arewefastyet exec --exec-git-ref 4a70d3d226113282554b393a97f893d133486b94  --planetscale-db-database benchmark --planetscale-db-branch main --planetscale-db-org my-org --planetscale-db-service-token <token> --planetscale-db-service-token-name <token name>
---exec-source config_micro_remote --ansible-inventory-file microbench_inventory.yml --ansible-playbook-file microbench.yml --ansible-root-directory ./ansible/
---equinix-instance-type m2.xlarge.x86 --equinix-token tok --equinix-project-id id
-`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer func() {
 				if errSuccess := ex.Success(); errSuccess != nil {

--- a/go/cmd/gen/metrics/exec.go
+++ b/go/cmd/gen/metrics/exec.go
@@ -45,7 +45,7 @@ func GenExecMetricsCmd() *cobra.Command {
 				return err
 			}
 
-			rowsExecUUIDs, err := clientSQL.Select("select uuid from execution where status = ?", exec.StatusFinished)
+			rowsExecUUIDs, err := clientSQL.Read("select uuid from execution where status = ?", exec.StatusFinished)
 			if err != nil {
 				return err
 			}
@@ -58,7 +58,7 @@ func GenExecMetricsCmd() *cobra.Command {
 					return err
 				}
 
-				rowsExecMetrics, err := clientSQL.Select("select id from metrics where exec_uuid = ? limit 1", uuid)
+				rowsExecMetrics, err := clientSQL.Read("select id from metrics where exec_uuid = ? limit 1", uuid)
 				if err != nil {
 					return err
 				}

--- a/go/cmd/macrobench/run.go
+++ b/go/cmd/macrobench/run.go
@@ -36,9 +36,8 @@ func run() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return macrobench.Run(mabcfg)
 		},
-		Short:   "Run macro benchmarks and store the output in the mysql configuration provided.",
-		Long:    "Run macro benchmarks using a fork of sysbench (https://github.com/planetscale/sysbench for OLTP and https://github.com/planetscale/sysbench-TPCC for TPCC)  and store the output in the mysql configuration provided.",
-		Example: "arewastyet macrobenchmark run --planetscale-db-database benchmark --planetscale-db-branch main --planetscale-db-org my-org --planetscale-db-service-token <token> --planetscale-db-service-token-name <token name>",
+		Short: "Run macro benchmarks and store the output in the mysql configuration provided.",
+		Long:  "Run macro benchmarks using a fork of sysbench (https://github.com/planetscale/sysbench for OLTP and https://github.com/planetscale/sysbench-TPCC for TPCC)  and store the output in the mysql configuration provided.",
 	}
 	mabcfg.AddToCommand(cmd)
 	return cmd

--- a/go/cmd/microbench/run.go
+++ b/go/cmd/microbench/run.go
@@ -32,7 +32,6 @@ func run() *cobra.Command {
 		Short: "Run micro benchmarks from the <root dir> on <pkg>, and outputs to <output file>.",
 		Long: `Runs all the micro benchmarks from the <root dir> on <pkg>, and parses the output and saves it to mysql if the configuration is provided. 
 The output can also be outputted to <output file>.`,
-		Example: "arewastyet microbenchmark run ~/vitess ./go/vt/sqlparser output.txt",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			idx := 0
 			if len(args) == 3 {

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -161,13 +161,13 @@ func InsertExecutionMetrics(client storage.SQLClient, execUUID string, execMetri
 			execUUID, "ComponentsMemStatsAllocBytes." + k, v,
 		}...)
 	}
-	_, err := client.Insert(query, args...)
+	_, err := client.Write(query, args...)
 	return err
 }
 
 func GetExecutionMetricsSQL(client storage.SQLClient, execUUID string) (ExecutionMetrics, error) {
 	query := "select `name`, value from metrics where exec_uuid = ?"
-	rows, err := client.Select(query, execUUID)
+	rows, err := client.Read(query, execUUID)
 	if err != nil {
 		return ExecutionMetrics{}, err
 	}

--- a/go/exec/pull_request.go
+++ b/go/exec/pull_request.go
@@ -16,12 +16,12 @@
  * /
  */
 
-package exec 
+package exec
 
 import "github.com/vitessio/arewefastyet/go/storage"
 
 func GetPullRequestList(client storage.SQLClient) ([]int, error) {
-	rows, err := client.Select("select pull_nb from execution where pull_nb > 0 group by pull_nb order by pull_nb desc")
+	rows, err := client.Read("select pull_nb from execution where pull_nb > 0 group by pull_nb order by pull_nb desc")
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func GetPullRequestList(client storage.SQLClient) ([]int, error) {
 
 	var res []int
 	for rows.Next() {
-		var pullNumber int 
+		var pullNumber int
 		err = rows.Scan(&pullNumber)
 		if err != nil {
 			return nil, err
@@ -45,8 +45,8 @@ type pullRequestInfo struct {
 	PR   string
 }
 
-func GetPullRequestInfo(client storage.SQLClient, pullNumber int) (pullRequestInfo, error){
-	rows, err := client.Select("select cron_pr.git_ref as pr, cron_pr_base.git_ref as main from (select git_ref from execution where pull_nb = ? and status = 'finished' and source = 'cron_pr' order by started_at desc limit 1) cron_pr , (select git_ref from execution where pull_nb = ? and status = 'finished' and source = 'cron_pr_base' order by started_at desc limit 1) cron_pr_base ", pullNumber, pullNumber)
+func GetPullRequestInfo(client storage.SQLClient, pullNumber int) (pullRequestInfo, error) {
+	rows, err := client.Read("select cron_pr.git_ref as pr, cron_pr_base.git_ref as main from (select git_ref from execution where pull_nb = ? and status = 'finished' and source = 'cron_pr' order by started_at desc limit 1) cron_pr , (select git_ref from execution where pull_nb = ? and status = 'finished' and source = 'cron_pr_base' order by started_at desc limit 1) cron_pr_base ", pullNumber, pullNumber)
 	if err != nil {
 		return pullRequestInfo{}, err
 	}

--- a/go/exec/status.go
+++ b/go/exec/status.go
@@ -37,7 +37,7 @@ type BenchmarkStats struct {
 }
 
 func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
-	rows, err := client.Select(`SELECT
+	rows, err := client.Read(`SELECT
 			(SELECT COUNT(uuid) FROM execution) AS count_status,
 			(SELECT COUNT(DISTINCT git_ref) FROM execution) AS count_commits,
 			(SELECT COUNT(*) FROM execution WHERE started_at >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)) AS count_all
@@ -61,7 +61,7 @@ func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
 
 	rows.Close()
 
-	rows, err = client.Select(`SELECT 
+	rows, err = client.Read(`SELECT 
 			COUNT(*)
 		FROM
 			execution

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
 	_ "github.com/go-sql-driver/mysql"
 )
 
@@ -48,7 +49,7 @@ func (c *Client) Close() error {
 	return c.db.Close()
 }
 
-func (c *Client) Insert(query string, args ...interface{}) (int64, error) {
+func (c *Client) Write(query string, args ...interface{}) (int64, error) {
 	if c.db == nil {
 		return 0, errors.New(ErrorClientConnectionNotInitialized)
 	}
@@ -65,7 +66,7 @@ func (c *Client) Insert(query string, args ...interface{}) (int64, error) {
 	return res.LastInsertId()
 }
 
-func (c *Client) Select(query string, args ...interface{}) (*sql.Rows, error) {
+func (c *Client) Read(query string, args ...interface{}) (*sql.Rows, error) {
 	if c.db == nil {
 		return nil, errors.New(ErrorClientConnectionNotInitialized)
 	}

--- a/go/storage/psdb/psdb.go
+++ b/go/storage/psdb/psdb.go
@@ -22,91 +22,130 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 const (
-	flagPsdbOrg      = "planetscale-db-org"
-	flagPsdbPassword = "planetscale-db-password"
-	flagPsdbUser     = "planetscale-db-user"
-	flagPsdbHost     = "planetscale-db-host"
-	flagPsdbDatabase = "planetscale-db-database"
-	flagPsdbBranch   = "planetscale-db-branch"
+	flagPsdbOrg           = "planetscale-db-org"
+	flagPsdbPasswordWrite = "planetscale-db-password-write"
+	flagPsdbUserWrite     = "planetscale-db-user-write"
+	flagPsdbPasswordRead  = "planetscale-db-password-read"
+	flagPsdbUserRead      = "planetscale-db-user-read"
+	flagPsdbHost          = "planetscale-db-host"
+	flagPsdbDatabase      = "planetscale-db-database"
+	flagPsdbBranch        = "planetscale-db-branch"
 
 	ErrorClientConnectionNotInitialized = "the client connection to the database is not initialized"
 )
 
 type (
+	auth struct {
+		username string
+		password string
+	}
+
 	Config struct {
-		Org      string
-		Database string
-		Branch   string
-		User string
-		Password string
-		Host string
+		Org       string
+		Database  string
+		Branch    string
+		Host      string
+		authWrite auth
+		authRead  auth
 	}
 
 	Client struct {
-		Config *Config
-		dial   *sql.DB
+		Config  *Config
+		writeDB *sql.DB
+		readDB  *sql.DB
 	}
 )
 
-func (cfg Config) IsValid() bool {
-	return !(cfg.User == "" || cfg.Password == "" || cfg.Host == "" || cfg.Org == "" || cfg.Database == "" || cfg.Branch == "")
+func (au auth) isValid() bool {
+	return au.username != "" && au.password != ""
+}
+
+func (cfg *Config) IsValid() bool {
+	return cfg.Org != "" && cfg.Database != "" && cfg.Branch != "" && cfg.Host != "" && cfg.authWrite.isValid() && cfg.authRead.isValid()
 }
 
 func (cfg *Config) AddToViper(v *viper.Viper) {
+	// General settings
 	_ = v.UnmarshalKey(flagPsdbOrg, &cfg.Org)
 	_ = v.UnmarshalKey(flagPsdbHost, &cfg.Host)
-	_ = v.UnmarshalKey(flagPsdbPassword, &cfg.Password)
-	_ = v.UnmarshalKey(flagPsdbUser, &cfg.User)
 	_ = v.UnmarshalKey(flagPsdbDatabase, &cfg.Database)
 	_ = v.UnmarshalKey(flagPsdbBranch, &cfg.Branch)
+
+	// Write authentication
+	_ = v.UnmarshalKey(flagPsdbPasswordWrite, &cfg.authWrite.password)
+	_ = v.UnmarshalKey(flagPsdbUserWrite, &cfg.authWrite.username)
+
+	// Read authentication
+	_ = v.UnmarshalKey(flagPsdbPasswordWrite, &cfg.authWrite.password)
+	_ = v.UnmarshalKey(flagPsdbUserWrite, &cfg.authWrite.username)
 }
 
 func (cfg *Config) AddToCommand(cmd *cobra.Command) {
+	// General settings
 	cmd.Flags().StringVar(&cfg.Org, flagPsdbOrg, "", "Name of the PlanetscaleDB organization.")
-	cmd.Flags().StringVar(&cfg.User, flagPsdbUser, "", "Username used to authenticate to PlanetscaleDB.")
-	cmd.Flags().StringVar(&cfg.Password, flagPsdbPassword, "", "Password used to authenticate to PlanetscaleDB.")
 	cmd.Flags().StringVar(&cfg.Host, flagPsdbHost, "", "Hostname of the PlanetscaleDB database.")
 	cmd.Flags().StringVar(&cfg.Database, flagPsdbDatabase, "", "PlanetscaleDB database name.")
 	cmd.Flags().StringVar(&cfg.Branch, flagPsdbBranch, "main", "PlanetscaleDB branch to use.")
-
 	_ = viper.BindPFlag(flagPsdbOrg, cmd.Flags().Lookup(flagPsdbOrg))
 	_ = viper.BindPFlag(flagPsdbHost, cmd.Flags().Lookup(flagPsdbHost))
-	_ = viper.BindPFlag(flagPsdbUser, cmd.Flags().Lookup(flagPsdbUser))
-	_ = viper.BindPFlag(flagPsdbPassword, cmd.Flags().Lookup(flagPsdbPassword))
 	_ = viper.BindPFlag(flagPsdbDatabase, cmd.Flags().Lookup(flagPsdbDatabase))
 	_ = viper.BindPFlag(flagPsdbBranch, cmd.Flags().Lookup(flagPsdbBranch))
+
+	// Write authentication
+	cmd.Flags().StringVar(&cfg.authWrite.username, flagPsdbUserWrite, "", "Username used to authenticate to the write servers of PlanetScaleDB.")
+	cmd.Flags().StringVar(&cfg.authWrite.password, flagPsdbPasswordWrite, "", "Password used to authenticate to the write servers of PlanetScaleDB.")
+	_ = viper.BindPFlag(flagPsdbUserWrite, cmd.Flags().Lookup(flagPsdbUserWrite))
+	_ = viper.BindPFlag(flagPsdbPasswordWrite, cmd.Flags().Lookup(flagPsdbPasswordWrite))
+
+	// Read authentication
+	cmd.Flags().StringVar(&cfg.authRead.username, flagPsdbUserRead, "", "Username used to authenticate to the read-only servers of PlanetScaleDB.")
+	cmd.Flags().StringVar(&cfg.authRead.password, flagPsdbPasswordRead, "", "Password used to authenticate to the read-only servers of PlanetScaleDB.")
+	_ = viper.BindPFlag(flagPsdbUserRead, cmd.Flags().Lookup(flagPsdbUserRead))
+	_ = viper.BindPFlag(flagPsdbPasswordRead, cmd.Flags().Lookup(flagPsdbPasswordRead))
 }
 
-func (cfg Config) NewClient() (*Client, error) {
-	client := &Client{
-		Config: &cfg,
-	}
+func (cfg *Config) connectionString(a auth) string {
+	return fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true&tls=true&interpolateParams=true", a.username, a.password, cfg.Host, cfg.Database)
+}
 
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true&tls=true", cfg.User, cfg.Password, cfg.Host, cfg.Database))
+func (cfg *Config) NewClient() (*Client, error) {
+	// Open a connection pool to the write servers
+	writedb, err := sql.Open("mysql", cfg.connectionString(cfg.authWrite))
 	if err != nil {
 		return nil, err
 	}
-	client.dial = db
-	return client, nil
+
+	// Open a connection pool to the read-only servers
+	readdb, err := sql.Open("mysql", cfg.connectionString(cfg.authRead))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		Config:  cfg,
+		writeDB: writedb,
+		readDB:  readdb,
+	}, nil
 }
 
 func (c *Client) Close() error {
-	if c.dial == nil {
+	if c.writeDB == nil {
 		return errors.New(ErrorClientConnectionNotInitialized)
 	}
-	return c.dial.Close()
+	return c.writeDB.Close()
 }
 
 func (c *Client) Insert(query string, args ...interface{}) (int64, error) {
-	if c.dial == nil {
+	if c.writeDB == nil {
 		return 0, errors.New(ErrorClientConnectionNotInitialized)
 	}
-	stms, err := c.dial.Prepare(query)
+	stms, err := c.writeDB.Prepare(query)
 	if err != nil {
 		return 0, err
 	}
@@ -120,10 +159,10 @@ func (c *Client) Insert(query string, args ...interface{}) (int64, error) {
 }
 
 func (c *Client) Select(query string, args ...interface{}) (*sql.Rows, error) {
-	if c.dial == nil {
+	if c.readDB == nil {
 		return nil, errors.New(ErrorClientConnectionNotInitialized)
 	}
-	rows, err := c.dial.Query(query, args...)
+	rows, err := c.readDB.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/storage/storage.go
+++ b/go/storage/storage.go
@@ -21,6 +21,6 @@ package storage
 import "database/sql"
 
 type SQLClient interface {
-	Insert(query string, args ...interface{}) (int64, error)
-	Select(query string, args ...interface{}) (*sql.Rows, error)
+	Write(query string, args ...interface{}) (int64, error)
+	Read(query string, args ...interface{}) (*sql.Rows, error)
 }

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -143,7 +143,7 @@ func (mabcfg Config) insertBenchmarkToSQL(client storage.SQLClient) (newMacroBen
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}
 	query := "INSERT INTO macrobenchmark(exec_uuid, commit, vtgate_planner_version, type) VALUES(NULLIF(?, ''), ?, ?, ?)"
-	res, err := client.Insert(query, mabcfg.execUUID, mabcfg.GitRef, mabcfg.VtgatePlannerVersion, mabcfg.Type.ToUpper().String())
+	res, err := client.Write(query, mabcfg.execUUID, mabcfg.GitRef, mabcfg.VtgatePlannerVersion, mabcfg.Type.ToUpper().String())
 	if err != nil {
 		return 0, err
 	}

--- a/go/tools/macrobench/sql.go
+++ b/go/tools/macrobench/sql.go
@@ -40,7 +40,7 @@ func getResultsForGitRefAndPlanner(macroType string, ref string, planner Planner
 		"AND info.macrobenchmark_id = results.macrobenchmark_id " +
 		"AND info.type = ?"
 
-	result, err := client.Select(query, ref, planner, upperMacroType)
+	result, err := client.Read(query, ref, planner, upperMacroType)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func getResultsLastXDays(macroType string, source string, planner PlannerVersion
 		"AND info.type = ? " +
 		"ORDER BY e.finished_at "
 
-	result, err := client.Select(query, lastDays, source, planner, upperMacroType)
+	result, err := client.Read(query, lastDays, source, planner, upperMacroType)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func getSummaryLastXDays(macroType string, source string, planner PlannerVersion
 		"AND info.type = ? " +
 		"ORDER BY e.finished_at "
 
-	result, err := client.Select(query, lastDays, source, planner, upperMacroType)
+	result, err := client.Read(query, lastDays, source, planner, upperMacroType)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (mbr *result) insertToMySQL(macrobenchmarkID int, client storage.SQLClient)
 
 	// insert result
 	queryResult := "INSERT INTO macrobenchmark_results(macrobenchmark_id, queries, tps, latency, errors, reconnects, time, threads, total_qps, reads_qps, writes_qps, other_qps) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-	_, err := client.Insert(queryResult, macrobenchmarkID, mbr.Queries, mbr.TPS, mbr.Latency, mbr.Errors, mbr.Reconnects, mbr.Time, mbr.Threads, mbr.QPS.Total, mbr.QPS.Reads, mbr.QPS.Writes, mbr.QPS.Other)
+	_, err := client.Write(queryResult, macrobenchmarkID, mbr.Queries, mbr.TPS, mbr.Latency, mbr.Errors, mbr.Reconnects, mbr.Time, mbr.Threads, mbr.QPS.Total, mbr.QPS.Reads, mbr.QPS.Writes, mbr.QPS.Other)
 	if err != nil {
 		return err
 	}

--- a/go/tools/macrobench/vtgate.go
+++ b/go/tools/macrobench/vtgate.go
@@ -237,7 +237,7 @@ func GetVTGateSelectQueryPlansWithFilter(gitRef string, macroType Type, planner 
 		"order by qp.`key` " +
 		"limit 1500;"
 
-	result, err := client.Select(query, macroType.String(), gitRef, string(planner))
+	result, err := client.Read(query, macroType.String(), gitRef, string(planner))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func insertVTGateQueryMapToMySQL(client storage.SQLClient, execUUID string, resu
 	query := "INSERT INTO query_plans(`exec_uuid`, `macrobenchmark_id`, `key`, `plan`, `exec_count`, `exec_time`, `rows`, `errors`) VALUES(?, ?, ?, ?, ?, ?, ?, ?)"
 	for key, value := range result {
 		normalizeVTGateQueryPlan(&value)
-		_, err := client.Insert(query, execUUID, macrobenchmarkID, key, fmt.Sprintf("%v", value.Instructions), value.ExecCount, value.ExecTime, value.RowsReturned, value.Errors)
+		_, err := client.Write(query, execUUID, macrobenchmarkID, key, fmt.Sprintf("%v", value.Instructions), value.ExecCount, value.ExecTime, value.RowsReturned, value.Errors)
 		if err != nil {
 			return err
 		}

--- a/go/tools/microbench/line.go
+++ b/go/tools/microbench/line.go
@@ -21,10 +21,11 @@ package microbench
 import (
 	"errors"
 	"fmt"
-	"github.com/vitessio/arewefastyet/go/storage"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/vitessio/arewefastyet/go/storage"
 )
 
 type microType string
@@ -157,7 +158,7 @@ func (line *lineRun) parseGeneralBenchmark() error {
 
 func (line *lineRun) InsertToMySQL(microBenchID int64, client storage.SQLClient) error {
 	query := "INSERT INTO microbenchmark_details(microbenchmark_no, name, bench_type, n, ns_per_op, mb_per_sec, bytes_per_op, allocs_per_op) VALUES(?, ?, ?, ?, ?, ?, ?, ?)"
-	res, err := client.Insert(query, microBenchID, line.name, line.benchType, line.results.Op, line.results.NanosecondPerOp, line.results.MBs, line.results.BytesPerOp, line.results.AllocsPerOp)
+	res, err := client.Write(query, microBenchID, line.name, line.benchType, line.results.Op, line.results.NanosecondPerOp, line.results.MBs, line.results.BytesPerOp, line.results.AllocsPerOp)
 	if err != nil {
 		return err
 	}

--- a/go/tools/microbench/microbench.go
+++ b/go/tools/microbench/microbench.go
@@ -53,7 +53,7 @@ type benchmark struct {
 
 func (b *benchmark) registerToMySQL(client storage.SQLClient) error {
 	query := "INSERT INTO microbenchmark(exec_uuid, pkg_name, name, git_ref) VALUES(NULLIF(?, ''), ?, ?, ?)"
-	res, err := client.Insert(query, b.execUUID, b.pkgName, b.name, b.gitHash)
+	res, err := client.Write(query, b.execUUID, b.pkgName, b.name, b.gitHash)
 	if err != nil {
 		return err
 	}

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -211,7 +211,7 @@ func (mbd DetailsArray) mergeUsingCondition(compareCondition func(i, j int) bool
 // GetResultsForGitRef will fetch and return a DetailsArray
 // containing all the Details linked to the given git commit SHA.
 func GetResultsForGitRef(ref string, client storage.SQLClient) (mrs DetailsArray, err error) {
-	result, err := client.Select("select m.pkg_name, m.name, md.name, md.n, md.ns_per_op, md.bytes_per_op,"+
+	result, err := client.Read("select m.pkg_name, m.name, md.name, md.n, md.ns_per_op, md.bytes_per_op,"+
 		" md.allocs_per_op, md.mb_per_sec FROM execution e, microbenchmark m, microbenchmark_details md where m.git_ref = ? AND "+
 		"md.microbenchmark_no = m.microbenchmark_no and e.uuid = m.exec_uuid and e.status = \"finished\" order by m.microbenchmark_no desc", ref)
 	if err != nil {
@@ -239,7 +239,7 @@ func GetLatestResultsFor(name, subBenchmarkName string, count int, client storag
 		" md.allocs_per_op, md.mb_per_sec, m.started_at  from (select microbenchmark_no, pkg_name, name, microbenchmark.git_ref, started_at" +
 		" from microbenchmark join execution on exec_uuid = uuid where name = ? and source = \"cron\" and status = \"finished\" order by started_at desc limit ?) m, " +
 		"microbenchmark_details md where md.microbenchmark_no = m.microbenchmark_no and md.name = ?"
-	rows, err := client.Select(query, name, count, subBenchmarkName)
+	rows, err := client.Read(query, name, count, subBenchmarkName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR changes how we read and write to our MySQL database. Since we use PlanetScale DB as our MySQL storage, I have changed our connection logic to now connect to both a read-only and the primary server. The read-only connection pool will now be used for all our select queries. On top of that I have finally added some settings to our connection pool that will prevent it from opening hundreds of connections. I have tested this end-to-end with the PlanetScale DB UI, and reads are well directed to the read-only nodes, and the connections disconnect properly after 3 minutes.
