### PR TITLE
Revamp all our endpoints that get benchmark results

### DIFF
--- a/go/server/api.go
+++ b/go/server/api.go
@@ -300,7 +300,7 @@ func (s *Server) fkQueriesCompareMacrobenchmarks(c *gin.Context) {
 	c.JSON(http.StatusOK, comparison)
 }
 
-func (s *Server) queriesCompare(c *gin.Context, oldGitRef, newGitRef string, oldWorkload, newWorkload macrobench.Type)[]macrobench.VTGateQueryPlanComparer {
+func (s *Server) queriesCompare(c *gin.Context, oldGitRef, newGitRef string, oldWorkload, newWorkload macrobench.Type) []macrobench.VTGateQueryPlanComparer {
 	oldPlans, err := macrobench.GetVTGateSelectQueryPlansWithFilter(oldGitRef, oldWorkload, macrobench.Gen4Planner, s.dbClient)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
@@ -404,7 +404,7 @@ func (s *Server) getDailySummary(c *gin.Context) {
 
 func (s *Server) getDaily(c *gin.Context) {
 	benchmarkType := c.Query("workload")
-	data, err := macrobench.SearchForLastDays(s.dbClient, benchmarkType, macrobench.Gen4Planner, 31)
+	data, err := macrobench.SearchForLast30Days(s.dbClient, benchmarkType, macrobench.Gen4Planner)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
 		slog.Error(err)

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -382,7 +382,7 @@ func (s *Server) getDailySummary(c *gin.Context) {
 			}
 		}
 	}
-	results, err := macrobench.SearchForLastDaysQPSOnly(s.dbClient, workloads, macrobench.Gen4Planner, 31)
+	results, err := macrobench.SearchForLast30DaysQPSOnly(s.dbClient, workloads, macrobench.Gen4Planner, 31)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
 		slog.Error(err)

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -200,22 +200,22 @@ func handleMetricsResults(client *influxdb.Client, sqlClient *psdb.Client, execU
 	return nil
 }
 
-func handleSysBenchResults(resStr []byte, sqlClient *psdb.Client, macrobenchID int) (result, error) {
+func handleSysBenchResults(resStr []byte, sqlClient *psdb.Client, macrobenchID int) (sysbenchResult, error) {
 	// Parse results
-	var results []result
+	var results []sysbenchResult
 	err := json.Unmarshal(resStr, &results)
 	if err != nil {
-		return result{}, fmt.Errorf("unmarshal results: %+v\n", err)
+		return sysbenchResult{}, fmt.Errorf("unmarshal results: %+v\n", err)
 	}
 	if len(results) == 0 {
-		return result{}, errors.New(ErrorNoSysBenchResult)
+		return sysbenchResult{}, errors.New(ErrorNoSysBenchResult)
 	}
 
 	// Save results
 	if sqlClient != nil {
 		err = results[0].insertToMySQL(macrobenchID, sqlClient)
 		if err != nil {
-			return result{}, err
+			return sysbenchResult{}, err
 		}
 	}
 	return results[0], nil

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -290,9 +290,9 @@ func Search(client storage.SQLClient, sha string, types []string, planner Planne
 	return results, nil
 }
 
-func SearchForLastDays(client storage.SQLClient, macroType string, planner PlannerVersion, days int) ([]StatisticalSingleResult, error) {
+func SearchForLast30Days(client storage.SQLClient, macroType string, planner PlannerVersion) ([]StatisticalSingleResult, error) {
 	var ssrs []StatisticalSingleResult
-	results, err := getBenchmarkResultsLastXDays(client, macroType, planner, days, false)
+	results, err := getExecutionGroupResultsFromLast30Days(macroType, planner, client)
 	if err != nil {
 		return nil, err
 	}

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -301,7 +301,7 @@ func SearchForLast30Days(client storage.SQLClient, macroType string, planner Pla
 	return ssrs, nil
 }
 
-func SearchForLastDaysQPSOnly(client storage.SQLClient, types []string, planner PlannerVersion, days int) (map[string][]ShortStatisticalSingleResult, error) {
+func SearchForLast30DaysQPSOnly(client storage.SQLClient, types []string, planner PlannerVersion, days int) (map[string][]ShortStatisticalSingleResult, error) {
 	results := make(map[string][]ShortStatisticalSingleResult)
 	for _, macroType := range types {
 		resultsForType, err := getSummaryLast30Days(macroType, planner, client)

--- a/go/tools/macrobench/stats.go
+++ b/go/tools/macrobench/stats.go
@@ -167,7 +167,7 @@ func compare(old, new []float64) StatisticalResult {
 	return sr
 }
 
-func performAnalysis(old, new resultAsSlice) StatisticalCompareResults {
+func performAnalysis(old, new executionGroupResultsAsSlice) StatisticalCompareResults {
 	scr := StatisticalCompareResults{
 		ComponentsCPUTime: map[string]StatisticalResult{
 			"vtgate":   {Insignificant: true},


### PR DESCRIPTION
This PR revamps some of our endpoints that get and compare results. The performance were really poor, with for instance a 20 seconds response time for the compare benchmark page, and 25 seconds for the daily results. The response time of these two endpoints was reduced by 88% and 99% on average.

**Before**
```
[GIN] 2024/07/25 - 19:19:40 | 200 | 23.598892375s |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:20:03 | 200 |   23.0457765s |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:20:22 | 200 | 19.204524417s |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:20:24 | 200 | 22.733138458s |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:20:32 | 200 |  19.07924375s |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:20:41 | 200 | 18.771850875s |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:20:59 | 200 | 18.885992375s |             ::1 | GET      "/api/daily?workload=oltp"
```

**After**
```
[GIN] 2024/07/25 - 19:18:23 | 200 |  638.252792ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:24 | 200 |  176.436084ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:26 | 200 |  165.110584ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:26 | 200 |  155.194375ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:27 | 200 |  150.058625ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:28 | 200 |    144.3535ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:29 | 200 |  125.182625ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:29 | 200 |  119.004083ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:30 | 200 |  120.047583ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:31 | 200 |     131.402ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:32 | 200 |  119.589542ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:33 | 200 |  142.467084ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:33 | 200 |    138.0815ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:34 | 200 |  131.591875ms |             ::1 | GET      "/api/daily?workload=oltp"
[GIN] 2024/07/25 - 19:18:35 | 200 |  134.980542ms |             ::1 | GET      "/api/daily?workload=oltp"
```