### PR TITLE
Rename `type` to `workload`

### DIFF
--- a/ansible/roles/vtctld/tasks/clean.yml
+++ b/ansible/roles/vtctld/tasks/clean.yml
@@ -23,7 +23,7 @@
 
 - name: reinstall systemd unit if needed
   include_tasks: systemd.yml
-  when: arewefastyet_execution_type is undefined or arewefastyet_execution_type != 'micro'
+  when: arewefastyet_execution_workload is undefined or arewefastyet_execution_workload != 'micro'
 
 - name: check if there is a vtctld service
   shell: service vtctld@{{ vitess_cell }} status

--- a/config/benchmarks/micro.yaml
+++ b/config/benchmarks/micro.yaml
@@ -1,5 +1,5 @@
 ## Exec configuration
-exec-type: micro
+exec-workload: micro
 
 ## Ansible
 ansible-inventory-file: microbench_inventory.yml

--- a/config/benchmarks/olap-readonly.yaml
+++ b/config/benchmarks/olap-readonly.yaml
@@ -1,5 +1,5 @@
 ## Exec Config
-exec-type: oltp-readonly-olap
+exec-workload: oltp-readonly-olap
 exec-schema: "./vitess-benchmark/sysbench.json"
 
 ## Minimum Vitess version on which the benchmark should be executed
@@ -13,7 +13,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: oltp_read_only
 macrobench-skip-steps:
-macrobench-type: oltp-readonly-olap
+macrobench-workload: oltp-readonly-olap
 
 ## Sysbench all steps
 macrobench_all_mysql-db: main

--- a/config/benchmarks/oltp-readonly.yaml
+++ b/config/benchmarks/oltp-readonly.yaml
@@ -1,5 +1,5 @@
 ## Exec Config
-exec-type: oltp-readonly
+exec-workload: oltp-readonly
 exec-schema: "./vitess-benchmark/sysbench.json"
 
 ## Minimum Vitess version on which the benchmark should be executed
@@ -13,7 +13,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: oltp_read_write_with_settings
 macrobench-skip-steps:
-macrobench-type: oltp-readonly
+macrobench-workload: oltp-readonly
 
 ## Sysbench all steps
 macrobench_all_mysql-db: main

--- a/config/benchmarks/oltp-set.yaml
+++ b/config/benchmarks/oltp-set.yaml
@@ -1,5 +1,5 @@
 ## Exec Config
-exec-type: oltp-set
+exec-workload: oltp-set
 exec-schema: "./vitess-benchmark/sysbench.json"
 
 ## Minimum Vitess version on which the benchmark should be executed
@@ -13,7 +13,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: oltp_read_write_with_settings
 macrobench-skip-steps:
-macrobench-type: oltp-set
+macrobench-workload: oltp-set
 
 ## Sysbench all steps
 macrobench_all_mysql-db: main

--- a/config/benchmarks/oltp.yaml
+++ b/config/benchmarks/oltp.yaml
@@ -1,5 +1,5 @@
 ## Exec Config
-exec-type: oltp
+exec-workload: oltp
 
 ## Ansible
 ansible-inventory-file: macrobench_sharded_inventory.yml
@@ -11,7 +11,7 @@ exec-schema: "./vitess-benchmark/sysbench.json"
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: oltp_read_write
 macrobench-skip-steps:
-macrobench-type: oltp
+macrobench-workload: oltp
 
 ## Sysbench all steps
 macrobench_all_mysql-db: main

--- a/config/benchmarks/tpcc.yaml
+++ b/config/benchmarks/tpcc.yaml
@@ -1,5 +1,5 @@
 ## Exec configuration
-exec-type: tpcc
+exec-workload: tpcc
 exec-schema: "./vitess-benchmark/tpcc_vschema.json"
 
 ## Ansible
@@ -10,7 +10,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: /src/sysbench-tpcc/tpcc.lua
 macrobench-skip-steps:
-macrobench-type: tpcc
+macrobench-workload: tpcc
 macrobench-working-directory: /src/sysbench-tpcc
 
 ## Sysbench all steps

--- a/config/benchmarks/tpcc_fk.yaml
+++ b/config/benchmarks/tpcc_fk.yaml
@@ -1,5 +1,5 @@
 ## Exec configuration
-exec-type: tpcc_fk
+exec-workload: tpcc_fk
 exec-schema: "./vitess-benchmark/tpcc_fk_vschema.json"
 minimum-version: 18
 
@@ -11,7 +11,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: /src/sysbench-tpcc/tpcc.lua
 macrobench-skip-steps:
-macrobench-type: tpcc_fk
+macrobench-workload: tpcc_fk
 macrobench-working-directory: /src/sysbench-tpcc
 
 ## Sysbench all steps

--- a/config/benchmarks/tpcc_fk_unmanaged.yaml
+++ b/config/benchmarks/tpcc_fk_unmanaged.yaml
@@ -1,5 +1,5 @@
 ## Exec configuration
-exec-type: tpcc_fk_unmanaged
+exec-workload: tpcc_fk_unmanaged
 exec-schema: "./vitess-benchmark/tpcc_fk_unmanaged_vschema.json"
 minimum-version: 18
 
@@ -11,7 +11,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: /src/sysbench-tpcc/tpcc.lua
 macrobench-skip-steps:
-macrobench-type: tpcc_fk_unmanaged
+macrobench-workload: tpcc_fk_unmanaged
 macrobench-working-directory: /src/sysbench-tpcc
 
 ## Sysbench all steps

--- a/config/benchmarks/tpcc_unsharded.yaml
+++ b/config/benchmarks/tpcc_unsharded.yaml
@@ -1,5 +1,5 @@
 ## Exec configuration
-exec-type: tpcc_unsharded
+exec-workload: tpcc_unsharded
 exec-schema: "./vitess-benchmark/tpcc_unsharded_vschema.json"
 
 ## Ansible
@@ -10,7 +10,7 @@ ansible-playbook-file: macrobench.yml
 macrobench-sysbench-executable: /usr/local/bin/sysbench
 macrobench-workload-path: /src/sysbench-tpcc/tpcc.lua
 macrobench-skip-steps:
-macrobench-type: tpcc_unsharded
+macrobench-workload: tpcc_unsharded
 macrobench-working-directory: /src/sysbench-tpcc
 
 ## Sysbench all steps

--- a/docs/arewefastyet_api.md
+++ b/docs/arewefastyet_api.md
@@ -15,7 +15,6 @@ arewefastyet api [flags]
       --gh-secret-key string                     Secret key used to authenticate
       --gh-webhook-secret string                 Secrets used to verify the webhooks
   -h, --help                                     help for api
-      --planetscale-db-branch string             PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string           PlanetScaleDB database name.
       --planetscale-db-host string               Hostname of the PlanetScaleDB database.
       --planetscale-db-org string                Name of the PlanetScaleDB organization.

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -24,7 +24,7 @@ arewefastyet exec [flags]
       --exec-schema string                     Path to the VSchema for this benchmark.
       --exec-server-address string             The IP address of the server on which the benchmark will be executed.
       --exec-source string                     Name of the source that triggered the execution.
-      --exec-type string                       Defines the execution type (oltp, tpcc, micro).
+      --exec-workload string                       Defines the execution workload (oltp, tpcc, micro).
       --exec-vtgate-planner-version string     Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
   -h, --help                                   help for exec
       --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -24,8 +24,8 @@ arewefastyet exec [flags]
       --exec-schema string                     Path to the VSchema for this benchmark.
       --exec-server-address string             The IP address of the server on which the benchmark will be executed.
       --exec-source string                     Name of the source that triggered the execution.
-      --exec-workload string                       Defines the execution workload (oltp, tpcc, micro).
       --exec-vtgate-planner-version string     Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
+      --exec-workload string                   Defines the execution workload (oltp, tpcc, micro).
   -h, --help                                   help for exec
       --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string         PlanetScaleDB database name.

--- a/docs/arewefastyet_exec.md
+++ b/docs/arewefastyet_exec.md
@@ -27,7 +27,6 @@ arewefastyet exec [flags]
       --exec-vtgate-planner-version string     Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. (default "V3")
       --exec-workload string                   Defines the execution workload (oltp, tpcc, micro).
   -h, --help                                   help for exec
-      --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string         PlanetScaleDB database name.
       --planetscale-db-host string             Hostname of the PlanetScaleDB database.
       --planetscale-db-org string              Name of the PlanetScaleDB organization.

--- a/docs/arewefastyet_gen_exec_metrics.md
+++ b/docs/arewefastyet_gen_exec_metrics.md
@@ -15,7 +15,6 @@ arewefastyet gen exec_metrics [flags]
       --influx-password string                 Password used to connect to InfluxDB.
       --influx-port string                     Port on which to InfluxDB listens. (default "8086")
       --influx-username string                 Username used to connect to InfluxDB.
-      --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string         PlanetScaleDB database name.
       --planetscale-db-host string             Hostname of the PlanetScaleDB database.
       --planetscale-db-org string              Name of the PlanetScaleDB organization.

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -28,7 +28,6 @@ arewefastyet macrobench run [flags]
       --macrobench-working-directory string        Directory on which to execute sysbench.
       --macrobench-workload Workload               Workload of this macro-benchmark.
       --macrobench-workload-path string            Path to the workload used by sysbench.
-      --planetscale-db-branch string               PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string             PlanetScaleDB database name.
       --planetscale-db-host string                 Hostname of the PlanetScaleDB database.
       --planetscale-db-org string                  Name of the PlanetScaleDB organization.

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -23,7 +23,7 @@ arewefastyet macrobench run [flags]
       --macrobench-git-ref string                  Git SHA referring to the macro benchmark.
       --macrobench-skip-steps string               Slice of sysbench steps to skip.
       --macrobench-sysbench-executable string      Path to the sysbench binary.
-      --macrobench-type Type                       Type of macro benchmark.
+      --macrobench-workload Workload                   Workload of macro-benchmark.
       --macrobench-vtgate-planner-version string   Vtgate planner version running on Vitess
       --macrobench-vtgate-web-ports strings        List of the web port for each VTGate.
       --macrobench-working-directory string        Directory on which to execute sysbench.

--- a/docs/arewefastyet_macrobench_run.md
+++ b/docs/arewefastyet_macrobench_run.md
@@ -23,10 +23,10 @@ arewefastyet macrobench run [flags]
       --macrobench-git-ref string                  Git SHA referring to the macro benchmark.
       --macrobench-skip-steps string               Slice of sysbench steps to skip.
       --macrobench-sysbench-executable string      Path to the sysbench binary.
-      --macrobench-workload Workload                   Workload of macro-benchmark.
       --macrobench-vtgate-planner-version string   Vtgate planner version running on Vitess
       --macrobench-vtgate-web-ports strings        List of the web port for each VTGate.
       --macrobench-working-directory string        Directory on which to execute sysbench.
+      --macrobench-workload Workload               Workload of this macro-benchmark.
       --macrobench-workload-path string            Path to the workload used by sysbench.
       --planetscale-db-branch string               PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string             PlanetScaleDB database name.

--- a/docs/arewefastyet_microbench_run.md
+++ b/docs/arewefastyet_microbench_run.md
@@ -17,7 +17,6 @@ arewefastyet microbench run [root dir] <pkg> <output file> [flags]
   -h, --help                                   help for run
       --microbench-exec-uuid string            UUID of the parent execution, an empty string will set to NULL.
       --microbench-run-profile                 Run goproc profiling for each micro-benchmark.
-      --planetscale-db-branch string           PlanetScaleDB branch to use. (default "main")
       --planetscale-db-database string         PlanetScaleDB database name.
       --planetscale-db-host string             Hostname of the PlanetScaleDB database.
       --planetscale-db-org string              Name of the PlanetScaleDB organization.

--- a/go/exec/cmd.go
+++ b/go/exec/cmd.go
@@ -27,7 +27,7 @@ const (
 	flagRootExec             = "exec-root-dir"
 	flagGitRefExec           = "exec-git-ref"
 	flagSourceExec           = "exec-source"
-	flagExecType             = "exec-type"
+	flagExecWorkload         = "exec-workload"
 	flagVtgatePlannerVersion = "exec-vtgate-planner-version"
 	flagExecPullNB           = "exec-pull-nb"
 	flagGolangVersion        = "exec-go-version"
@@ -40,7 +40,7 @@ func (e *Exec) AddToViper(v *viper.Viper) (err error) {
 	_ = v.UnmarshalKey(flagRootExec, &e.rootDir)
 	_ = v.UnmarshalKey(flagGitRefExec, &e.GitRef)
 	_ = v.UnmarshalKey(flagSourceExec, &e.Source)
-	_ = v.UnmarshalKey(flagExecType, &e.Workload)
+	_ = v.UnmarshalKey(flagExecWorkload, &e.Workload)
 	_ = v.UnmarshalKey(flagVtgatePlannerVersion, &e.VtgatePlannerVersion)
 	_ = v.UnmarshalKey(flagExecPullNB, &e.PullNB)
 	_ = v.UnmarshalKey(flagGolangVersion, &e.GolangVersion)
@@ -58,7 +58,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&e.rootDir, flagRootExec, "", "Path to the root directory of exec.")
 	cmd.Flags().StringVar(&e.GitRef, flagGitRefExec, "", "Git reference on which the benchmarks will run.")
 	cmd.Flags().StringVar(&e.Source, flagSourceExec, "", "Name of the source that triggered the execution.")
-	cmd.Flags().StringVar(&e.Workload, flagExecType, "", "Defines the execution type (oltp, tpcc, micro).")
+	cmd.Flags().StringVar(&e.Workload, flagExecWorkload, "", "Defines the execution workload (oltp, tpcc, micro).")
 	cmd.Flags().StringVar(&e.VtgatePlannerVersion, flagVtgatePlannerVersion, "V3", "Defines the vtgate planner version to use. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback.")
 	cmd.Flags().IntVar(&e.PullNB, flagExecPullNB, 0, "Defines the number of the pull request against which to execute.")
 	cmd.Flags().StringVar(&e.GolangVersion, flagGolangVersion, "1.17", "Defines the golang version that will be used by this execution.")
@@ -68,7 +68,7 @@ func (e *Exec) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagRootExec, cmd.Flags().Lookup(flagRootExec))
 	_ = viper.BindPFlag(flagGitRefExec, cmd.Flags().Lookup(flagGitRefExec))
 	_ = viper.BindPFlag(flagSourceExec, cmd.Flags().Lookup(flagSourceExec))
-	_ = viper.BindPFlag(flagExecType, cmd.Flags().Lookup(flagExecType))
+	_ = viper.BindPFlag(flagExecWorkload, cmd.Flags().Lookup(flagExecWorkload))
 	_ = viper.BindPFlag(flagExecPullNB, cmd.Flags().Lookup(flagExecPullNB))
 	_ = viper.BindPFlag(flagGolangVersion, cmd.Flags().Lookup(flagGolangVersion))
 	_ = viper.BindPFlag(flagServerAddress, cmd.Flags().Lookup(flagServerAddress))

--- a/go/infra/ansible/vars.go
+++ b/go/infra/ansible/vars.go
@@ -33,9 +33,8 @@ const (
 	// current benchmark.
 	KeyExecUUID = "arewefastyet_exec_uuid"
 
-	// KeyExecutionType corresponding value in the map is the type of execution for
-	// this benchmark.
-	KeyExecutionType = "arewefastyet_execution_type"
+	// KeyExecutionWorkload corresponding value in the map is the workload we will execute.
+	KeyExecutionWorkload = "arewefastyet_execution_workload"
 
 	// KeyBenchmarkConfigPath corresponding value in the map is the path to the configuration
 	// file that will be used to execute the benchmark by arewefastyet inside the benchmarking

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -391,8 +391,8 @@ func (s *Server) getDailySummary(c *gin.Context) {
 }
 
 func (s *Server) getDaily(c *gin.Context) {
-	benchmarkType := c.Query("workload")
-	data, err := macrobench.SearchForLast30Days(s.dbClient, benchmarkType, macrobench.Gen4Planner)
+	workload := c.Query("workload")
+	data, err := macrobench.SearchForLast30Days(s.dbClient, workload, macrobench.Gen4Planner)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
 		slog.Error(err)

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -258,7 +258,7 @@ func (s *Server) queriesCompareMacrobenchmarks(c *gin.Context) {
 	workload := macrobench.Workload(c.Query("workload"))
 
 	if leftGitRef == "" || rightGitRef == "" || workload == "" {
-		c.JSON(http.StatusBadRequest, &ErrorAPI{Error: "The gitref left and right and where the macrotype are incorrect are missing. Please kindly add them."})
+		c.JSON(http.StatusBadRequest, &ErrorAPI{Error: "The gitref left and right and/or the workload are missing"})
 		return
 	}
 

--- a/go/server/cron_execution.go
+++ b/go/server/cron_execution.go
@@ -37,7 +37,7 @@ func (s *Server) executeSingle(config benchmarkConfig, identifier executionIdent
 				err = errSuccess
 				return
 			}
-			slog.Info("Finished execution: UUID: [", e.UUID.String(), "], Git Ref: [", identifier.GitRef, "], Type: [", identifier.Workload, "]")
+			slog.Info("Finished execution: UUID: [", e.UUID.String(), "], Git Ref: [", identifier.GitRef, "], Workload: [", identifier.Workload, "]")
 		}
 	}()
 
@@ -70,7 +70,7 @@ func (s *Server) executeSingle(config benchmarkConfig, identifier executionIdent
 		}
 	}
 
-	slog.Info("Starting execution: UUID: [", e.UUID.String(), "], Git Ref: [", identifier.GitRef, "], Type: [", identifier.Workload, "]")
+	slog.Info("Starting execution: UUID: [", e.UUID.String(), "], Git Ref: [", identifier.GitRef, "], Workload: [", identifier.Workload, "]")
 	err = e.Prepare()
 	if err != nil {
 		nErr := fmt.Errorf(fmt.Sprintf("prepare error: %v", err))

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -87,8 +87,11 @@ type Server struct {
 	prLabelTrigger   string
 	prLabelTriggerV3 string
 
+	// benchmarkConfig is a map with the workload name as the key and the configuration
+	// of that given workload as a value of the map. The value is a benchmarkConfig which
+	// contains the file (yaml) configuration of the benchmark.
 	benchmarkConfig map[string]benchmarkConfig
-	benchmarkTypes  []string
+	workloads       []string
 
 	sourceFilter        []string
 	excludeSourceFilter []string
@@ -188,15 +191,15 @@ func (s *Server) Init() error {
 		"tpcc_fk":           {file: path.Join(s.benchmarkConfigPath, "tpcc_fk.yaml"), v: viper.New()},
 		"tpcc_fk_unmanaged": {file: path.Join(s.benchmarkConfigPath, "tpcc_fk_unmanaged.yaml"), v: viper.New()},
 	}
-	for configName, config := range s.benchmarkConfig {
+	for workload, config := range s.benchmarkConfig {
 		config.v.SetConfigFile(config.file)
 		if err := config.v.ReadInConfig(); err != nil {
 			slog.Error(err)
 		}
-		if configName == "micro" {
+		if workload == "micro" {
 			continue
 		}
-		s.benchmarkTypes = append(s.benchmarkTypes, strings.ToUpper(configName))
+		s.workloads = append(s.workloads, strings.ToUpper(workload))
 	}
 	return nil
 }

--- a/go/storage/psdb/psdb.go
+++ b/go/storage/psdb/psdb.go
@@ -36,7 +36,6 @@ const (
 	flagPsdbUserRead      = "planetscale-db-user-read"
 	flagPsdbHost          = "planetscale-db-host"
 	flagPsdbDatabase      = "planetscale-db-database"
-	flagPsdbBranch        = "planetscale-db-branch"
 
 	errorClientConnectionNotInitialized = "the client connection to the database is not initialized"
 
@@ -56,7 +55,6 @@ type (
 	Config struct {
 		organisation string
 		database     string
-		branch       string
 		hostname     string
 		authWrite    auth
 		authRead     auth
@@ -74,7 +72,7 @@ func (au auth) isValid() bool {
 }
 
 func (cfg *Config) IsValid() bool {
-	return cfg.organisation != "" && cfg.database != "" && cfg.branch != "" && cfg.hostname != "" && cfg.authWrite.isValid() && cfg.authRead.isValid()
+	return cfg.organisation != "" && cfg.database != "" && cfg.hostname != "" && cfg.authWrite.isValid() && cfg.authRead.isValid()
 }
 
 func (cfg *Config) AddToViper(v *viper.Viper) {
@@ -82,7 +80,6 @@ func (cfg *Config) AddToViper(v *viper.Viper) {
 	_ = v.UnmarshalKey(flagPsdbOrg, &cfg.organisation)
 	_ = v.UnmarshalKey(flagPsdbHost, &cfg.hostname)
 	_ = v.UnmarshalKey(flagPsdbDatabase, &cfg.database)
-	_ = v.UnmarshalKey(flagPsdbBranch, &cfg.branch)
 
 	// Write authentication
 	_ = v.UnmarshalKey(flagPsdbPasswordWrite, &cfg.authWrite.password)
@@ -98,11 +95,9 @@ func (cfg *Config) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cfg.organisation, flagPsdbOrg, "", "Name of the PlanetScaleDB organization.")
 	cmd.Flags().StringVar(&cfg.hostname, flagPsdbHost, "", "Hostname of the PlanetScaleDB database.")
 	cmd.Flags().StringVar(&cfg.database, flagPsdbDatabase, "", "PlanetScaleDB database name.")
-	cmd.Flags().StringVar(&cfg.branch, flagPsdbBranch, "main", "PlanetScaleDB branch to use.")
 	_ = viper.BindPFlag(flagPsdbOrg, cmd.Flags().Lookup(flagPsdbOrg))
 	_ = viper.BindPFlag(flagPsdbHost, cmd.Flags().Lookup(flagPsdbHost))
 	_ = viper.BindPFlag(flagPsdbDatabase, cmd.Flags().Lookup(flagPsdbDatabase))
-	_ = viper.BindPFlag(flagPsdbBranch, cmd.Flags().Lookup(flagPsdbBranch))
 
 	// Write authentication
 	cmd.Flags().StringVar(&cfg.authWrite.username, flagPsdbUserWrite, "", "Username used to authenticate to the write servers of PlanetScaleDB.")

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -58,8 +58,8 @@ type Config struct {
 	// sysbench steps.
 	SkipSteps string
 
-	// Type will be used to differentiate macro benchmarks.
-	Type Type
+	// Workload will be used to differentiate macro benchmarks.
+	Workload Workload
 
 	// Source defines from where the macro benchmark is triggered.
 	// This field is used to distinguish runs triggered by webhooks,
@@ -91,7 +91,7 @@ const (
 	flagSysbenchExecutable   = "macrobench-sysbench-executable"
 	flagSysbenchPath         = "macrobench-workload-path"
 	flagSkipSteps            = "macrobench-skip-steps"
-	flagType                 = "macrobench-type"
+	flagWorkload             = "macrobench-workload"
 	flagGitRef               = "macrobench-git-ref"
 	flagWorkingDirectory     = "macrobench-working-directory"
 	flagExecUUID             = "macrobench-exec-uuid"
@@ -108,7 +108,7 @@ func (mabcfg *Config) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&mabcfg.WorkloadPath, flagSysbenchPath, "", "Path to the workload used by sysbench.")
 	cmd.Flags().StringVar(&mabcfg.SysbenchExec, flagSysbenchExecutable, "", "Path to the sysbench binary.")
 	cmd.Flags().StringVar(&mabcfg.SkipSteps, flagSkipSteps, "", "Slice of sysbench steps to skip.")
-	cmd.Flags().Var(&mabcfg.Type, flagType, "Type of macro benchmark.")
+	cmd.Flags().Var(&mabcfg.Workload, flagWorkload, "Workload of this macro-benchmark.")
 	cmd.Flags().StringVar(&mabcfg.VtgatePlannerVersion, flagVtgatePlannerVersion, "", "Vtgate planner version running on Vitess")
 	cmd.Flags().StringVar(&mabcfg.GitRef, flagGitRef, "", "Git SHA referring to the macro benchmark.")
 	cmd.Flags().StringVar(&mabcfg.WorkingDirectory, flagWorkingDirectory, "", "Directory on which to execute sysbench.")
@@ -118,7 +118,7 @@ func (mabcfg *Config) AddToCommand(cmd *cobra.Command) {
 	_ = viper.BindPFlag(flagSysbenchPath, cmd.Flags().Lookup(flagSysbenchPath))
 	_ = viper.BindPFlag(flagSysbenchExecutable, cmd.Flags().Lookup(flagSysbenchExecutable))
 	_ = viper.BindPFlag(flagSkipSteps, cmd.Flags().Lookup(flagSkipSteps))
-	_ = viper.BindPFlag(flagType, cmd.Flags().Lookup(flagType))
+	_ = viper.BindPFlag(flagWorkload, cmd.Flags().Lookup(flagWorkload))
 	_ = viper.BindPFlag(flagGitRef, cmd.Flags().Lookup(flagGitRef))
 	_ = viper.BindPFlag(flagVtgatePlannerVersion, cmd.Flags().Lookup(flagVtgatePlannerVersion))
 	_ = viper.BindPFlag(flagWorkingDirectory, cmd.Flags().Lookup(flagWorkingDirectory))
@@ -143,7 +143,7 @@ func (mabcfg Config) insertBenchmarkToSQL(client storage.SQLClient) (newMacroBen
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}
 	query := "INSERT INTO macrobenchmark(exec_uuid, commit, vtgate_planner_version, type) VALUES(NULLIF(?, ''), ?, ?, ?)"
-	res, err := client.Write(query, mabcfg.execUUID, mabcfg.GitRef, mabcfg.VtgatePlannerVersion, mabcfg.Type.ToUpper().String())
+	res, err := client.Write(query, mabcfg.execUUID, mabcfg.GitRef, mabcfg.VtgatePlannerVersion, mabcfg.Workload.ToUpper().String())
 	if err != nil {
 		return 0, err
 	}

--- a/go/tools/macrobench/config.go
+++ b/go/tools/macrobench/config.go
@@ -142,7 +142,7 @@ func (mabcfg Config) insertBenchmarkToSQL(client storage.SQLClient) (newMacroBen
 	if client == nil {
 		return 0, errors.New(mysql.ErrorClientConnectionNotInitialized)
 	}
-	query := "INSERT INTO macrobenchmark(exec_uuid, commit, vtgate_planner_version, type) VALUES(NULLIF(?, ''), ?, ?, ?)"
+	query := "INSERT INTO macrobenchmark(exec_uuid, commit, vtgate_planner_version, workload) VALUES(NULLIF(?, ''), ?, ?, ?)"
 	res, err := client.Write(query, mabcfg.execUUID, mabcfg.GitRef, mabcfg.VtgatePlannerVersion, mabcfg.Workload.ToUpper().String())
 	if err != nil {
 		return 0, err

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -196,24 +196,24 @@ func (mrs sysbenchResultArray) resultsArrayToSlice() executionGroupResultsAsSlic
 	return ras
 }
 
-func Compare(client storage.SQLClient, old, new string, types []string, planner PlannerVersion) (map[string]StatisticalCompareResults, error) {
-	results := make(map[string]StatisticalCompareResults, len(types))
+func Compare(client storage.SQLClient, old, new string, workloads []string, planner PlannerVersion) (map[string]StatisticalCompareResults, error) {
+	results := make(map[string]StatisticalCompareResults, len(workloads))
 	mu := sync.Mutex{}
 	wg := sync.WaitGroup{}
 
 	var err error
-	for _, macroType := range types {
+	for _, workload := range workloads {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
 			var oldResult, newResult executionGroupResults
-			oldResult, err = getExecutionGroupResults(macroType, old, planner, client)
+			oldResult, err = getExecutionGroupResults(workload, old, planner, client)
 			if err != nil {
 				return
 			}
 
-			newResult, err = getExecutionGroupResults(macroType, new, planner, client)
+			newResult, err = getExecutionGroupResults(workload, new, planner, client)
 			if err != nil {
 				return
 			}
@@ -221,7 +221,7 @@ func Compare(client storage.SQLClient, old, new string, types []string, planner 
 			if len(oldResult.Results) == 0 && len(newResult.Results) == 0 {
 				mu.Lock()
 				defer mu.Unlock()
-				results[macroType] = StatisticalCompareResults{
+				results[workload] = StatisticalCompareResults{
 					ComponentsCPUTime: map[string]StatisticalResult{
 						"vtgate":   {},
 						"vttablet": {},
@@ -241,7 +241,7 @@ func Compare(client storage.SQLClient, old, new string, types []string, planner 
 
 			mu.Lock()
 			defer mu.Unlock()
-			results[macroType] = scr
+			results[workload] = scr
 		}()
 	}
 	wg.Wait()
@@ -280,15 +280,15 @@ func CompareFKs(client storage.SQLClient, oldWorkload, newWorkload string, sha s
 	return scr, nil
 }
 
-func Search(client storage.SQLClient, sha string, types []string, planner PlannerVersion) (map[string]StatisticalSingleResult, error) {
-	results := make(map[string]StatisticalSingleResult, len(types))
-	for _, macroType := range types {
-		result, err := getExecutionGroupResults(macroType, sha, planner, client)
+func Search(client storage.SQLClient, sha string, workloads []string, planner PlannerVersion) (map[string]StatisticalSingleResult, error) {
+	results := make(map[string]StatisticalSingleResult, len(workloads))
+	for _, workload := range workloads {
+		result, err := getExecutionGroupResults(workload, sha, planner, client)
 		if err != nil {
 			return nil, err
 		}
 		if len(result.Results) == 0 {
-			results[macroType] = StatisticalSingleResult{
+			results[workload] = StatisticalSingleResult{
 				ComponentsCPUTime: map[string]StatisticalSummary{
 					"vtgate":   {},
 					"vttablet": {},
@@ -300,14 +300,14 @@ func Search(client storage.SQLClient, sha string, types []string, planner Planne
 			}
 			continue
 		}
-		results[macroType] = result.toStatisticalSingleResult()
+		results[workload] = result.toStatisticalSingleResult()
 	}
 	return results, nil
 }
 
-func SearchForLast30Days(client storage.SQLClient, macroType string, planner PlannerVersion) ([]StatisticalSingleResult, error) {
+func SearchForLast30Days(client storage.SQLClient, workload string, planner PlannerVersion) ([]StatisticalSingleResult, error) {
 	var ssrs []StatisticalSingleResult
-	results, err := getExecutionGroupResultsFromLast30Days(macroType, planner, client)
+	results, err := getExecutionGroupResultsFromLast30Days(workload, planner, client)
 	if err != nil {
 		return nil, err
 	}
@@ -318,10 +318,10 @@ func SearchForLast30Days(client storage.SQLClient, macroType string, planner Pla
 	return ssrs, nil
 }
 
-func SearchForLast30DaysQPSOnly(client storage.SQLClient, types []string, planner PlannerVersion, days int) (map[string][]ShortStatisticalSingleResult, error) {
+func SearchForLast30DaysQPSOnly(client storage.SQLClient, workloads []string, planner PlannerVersion) (map[string][]ShortStatisticalSingleResult, error) {
 	results := make(map[string][]ShortStatisticalSingleResult)
-	for _, macroType := range types {
-		resultsForType, err := getSummaryLast30Days(macroType, planner, client)
+	for _, workload := range workloads {
+		resultsForType, err := getSummaryLast30Days(workload, planner, client)
 		if err != nil {
 			return nil, err
 		}
@@ -331,7 +331,7 @@ func SearchForLast30DaysQPSOnly(client storage.SQLClient, types []string, planne
 			if len(result.Results) < 6 {
 				continue
 			}
-			results[macroType] = append(results[macroType], result.toShortStatisticalSingleResult())
+			results[workload] = append(results[workload], result.toShortStatisticalSingleResult())
 		}
 	}
 	return results, nil

--- a/go/tools/macrobench/results.go
+++ b/go/tools/macrobench/results.go
@@ -321,12 +321,12 @@ func SearchForLast30Days(client storage.SQLClient, workload string, planner Plan
 func SearchForLast30DaysQPSOnly(client storage.SQLClient, workloads []string, planner PlannerVersion) (map[string][]ShortStatisticalSingleResult, error) {
 	results := make(map[string][]ShortStatisticalSingleResult)
 	for _, workload := range workloads {
-		resultsForType, err := getSummaryLast30Days(workload, planner, client)
+		workloadResult, err := getSummaryLast30Days(workload, planner, client)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, result := range resultsForType {
+		for _, result := range workloadResult {
 			// If we do not have a decent number of results in the set of benchmark, let's skip the result.
 			if len(result.Results) < 6 {
 				continue

--- a/go/tools/macrobench/sql.go
+++ b/go/tools/macrobench/sql.go
@@ -55,7 +55,7 @@ func getExecutionGroupResults(workload string, ref string, planner PlannerVersio
             e.status = 'finished'
             AND e.git_ref = ? 
             AND info.vtgate_planner_version = ? 
-            AND info.type = ?
+            AND info.workload = ?
         ORDER BY 
             e.uuid, m.name
     `
@@ -159,7 +159,7 @@ func getExecutionGroupResultsFromLast30Days(workload string, planner PlannerVers
             AND e.source = 'cron'
             AND e.status = 'finished'
             AND info.vtgate_planner_version = ? 
-            AND info.type = ?
+            AND info.workload = ?
         ORDER BY 
             e.finished_at ASC, e.uuid, m.name
     `
@@ -266,7 +266,7 @@ func getSummaryLast30Days(workload string, planner PlannerVersion, client storag
             AND e.status = "finished" 
             AND e.source = "cron" 
             AND info.vtgate_planner_version = ? 
-            AND info.type = ? 
+            AND info.workload = ? 
         ORDER BY 
             e.finished_at ASC
     `
@@ -312,10 +312,7 @@ func getSummaryLast30Days(workload string, planner PlannerVersion, client storag
 	return allResults, nil
 }
 
-// insertToMySQL inserts the given MacroBenchmarkResult to MySQL using a *mysql.Client.
-// The MacroBenchmarkResults gets added in one of macrobenchmark's children tables.
-// Depending on the MacroBenchmarkType, the insert will be routed to a specific children table.
-// The children table sysbenchQPS is also inserted.
+// insertToMySQL inserts the given sysbenchResult to MySQL.
 func (mbr *sysbenchResult) insertToMySQL(macrobenchmarkID int, client storage.SQLClient) error {
 	if client == nil {
 		return errors.New(mysql.ErrorClientConnectionNotInitialized)

--- a/go/tools/macrobench/sql.go
+++ b/go/tools/macrobench/sql.go
@@ -27,8 +27,7 @@ import (
 )
 
 // getExecutionGroupResults the results of an execution group
-func getExecutionGroupResults(macroType string, ref string, planner PlannerVersion, client storage.SQLClient) (executionGroupResults, error) {
-	upperMacroType := strings.ToUpper(macroType)
+func getExecutionGroupResults(workload string, ref string, planner PlannerVersion, client storage.SQLClient) (executionGroupResults, error) {
 	query := `
         SELECT 
             IFNULL(e.uuid, '') AS exec_uuid, 
@@ -61,7 +60,7 @@ func getExecutionGroupResults(macroType string, ref string, planner PlannerVersi
             e.uuid, m.name
     `
 
-	rows, err := client.Read(query, ref, planner, upperMacroType)
+	rows, err := client.Read(query, ref, planner, strings.ToUpper(workload))
 	if err != nil {
 		return executionGroupResults{}, err
 	}
@@ -130,8 +129,7 @@ func getExecutionGroupResults(macroType string, ref string, planner PlannerVersi
 	return results, nil
 }
 
-func getExecutionGroupResultsFromLast30Days(macroType string, planner PlannerVersion, client storage.SQLClient) ([]executionGroupResults, error) {
-	upperMacroType := strings.ToUpper(macroType)
+func getExecutionGroupResultsFromLast30Days(workload string, planner PlannerVersion, client storage.SQLClient) ([]executionGroupResults, error) {
 	query := `
         SELECT 
             IFNULL(e.uuid, '') AS exec_uuid, 
@@ -166,7 +164,7 @@ func getExecutionGroupResultsFromLast30Days(macroType string, planner PlannerVer
             e.finished_at ASC, e.uuid, m.name
     `
 
-	rows, err := client.Read(query, planner, upperMacroType)
+	rows, err := client.Read(query, planner, strings.ToUpper(workload))
 	if err != nil {
 		return nil, err
 	}
@@ -252,8 +250,7 @@ func getExecutionGroupResultsFromLast30Days(macroType string, planner PlannerVer
 	return allResults, nil
 }
 
-func getSummaryLast30Days(macroType string, planner PlannerVersion, client storage.SQLClient) ([]executionGroupResults, error) {
-	upperMacroType := strings.ToUpper(macroType)
+func getSummaryLast30Days(workload string, planner PlannerVersion, client storage.SQLClient) ([]executionGroupResults, error) {
 	query := `
         SELECT 
             e.git_ref, 
@@ -274,7 +271,7 @@ func getSummaryLast30Days(macroType string, planner PlannerVersion, client stora
             e.finished_at ASC
     `
 
-	rows, err := client.Read(query, planner, upperMacroType)
+	rows, err := client.Read(query, planner, strings.ToUpper(workload))
 	if err != nil {
 		return nil, err
 	}

--- a/go/tools/macrobench/types.go
+++ b/go/tools/macrobench/types.go
@@ -23,28 +23,28 @@ import (
 )
 
 type (
-	// Type determines the type of a macro benchmark.
-	Type string
+	// Workload determines the workload of a macro-benchmark.
+	Workload string
 )
 
 // Type implements Cobra flag.Value interface.
-func (mbtype *Type) Type() string {
-	return "Type"
+func (mbtype *Workload) Type() string {
+	return "Workload"
 }
 
 // Set implements Cobra flag.Value interface.
-func (mbtype *Type) Set(s string) error {
-	*mbtype = Type(s)
+func (mbtype *Workload) Set(s string) error {
+	*mbtype = Workload(s)
 	return nil
 }
 
-// ToUpper returns a new Type in upper case.
-func (mbtype Type) ToUpper() Type {
-	return Type(strings.ToUpper(string(mbtype)))
+// ToUpper returns a new Workload in upper case.
+func (mbtype Workload) ToUpper() Workload {
+	return Workload(strings.ToUpper(string(mbtype)))
 }
 
-// String returns the given Type as a string.
+// String returns the given Workload as a string.
 // It also implements the flag.Value interface.
-func (mbtype Type) String() string {
+func (mbtype Workload) String() string {
 	return string(mbtype)
 }

--- a/go/tools/macrobench/vtgate.go
+++ b/go/tools/macrobench/vtgate.go
@@ -215,7 +215,7 @@ func getVTGatesQueryPlans(ports []string) (VTGateQueryPlanMap, error) {
 	return res, nil
 }
 
-func GetVTGateSelectQueryPlansWithFilter(gitRef string, macroType Type, planner PlannerVersion, client storage.SQLClient) ([]VTGateQueryPlan, error) {
+func GetVTGateSelectQueryPlansWithFilter(gitRef string, workload Workload, planner PlannerVersion, client storage.SQLClient) ([]VTGateQueryPlan, error) {
 	query := "select " +
 		"qp.`key` as `key`, " +
 		"qp.plan as plan, " +
@@ -237,7 +237,7 @@ func GetVTGateSelectQueryPlansWithFilter(gitRef string, macroType Type, planner 
 		"order by qp.`key` " +
 		"limit 1500;"
 
-	result, err := client.Read(query, macroType.String(), gitRef, string(planner))
+	result, err := client.Read(query, workload.String(), gitRef, string(planner))
 	if err != nil {
 		return nil, err
 	}

--- a/go/tools/macrobench/vtgate.go
+++ b/go/tools/macrobench/vtgate.go
@@ -66,7 +66,7 @@ type VTGateQueryPlanComparer struct {
 type VTGateQueryPlanMap map[string]VTGateQueryPlanValue
 
 func CompareVTGateQueryPlans(left, right []VTGateQueryPlan) []VTGateQueryPlanComparer {
-	res := []VTGateQueryPlanComparer{}
+	var res []VTGateQueryPlanComparer
 	for i, plan := range left {
 		newCompare := VTGateQueryPlanComparer{
 			Key:  plan.Key,
@@ -229,7 +229,7 @@ func GetVTGateSelectQueryPlansWithFilter(gitRef string, workload Workload, plann
 		"qp.macrobenchmark_id = ma.macrobenchmark_id " +
 		"and ex.uuid = qp.exec_uuid " +
 		"and ex.uuid = ma.exec_uuid " +
-		"and ex.type = ? " +
+		"and ex.workload = ? " +
 		"and ma.commit = ? " +
 		"and ma.vtgate_planner_version = ? " +
 		"group by " +

--- a/website/src/common/Macrobench.tsx
+++ b/website/src/common/Macrobench.tsx
@@ -28,7 +28,7 @@ export default function Macrobench({ data, gitRef, commits }) {
           Click
           <Link
             className="text-primary"
-            to={`/macrobench/queries/compare?ltag=${commits.old}&rtag=${commits.new}&type=${data.type}`}
+            to={`/macrobench/queries/compare?ltag=${commits.old}&rtag=${commits.new}&workload=${data.type}`}
           >
             here
           </Link>

--- a/website/src/pages/ComparePage/ComparePage.tsx
+++ b/website/src/pages/ComparePage/ComparePage.tsx
@@ -83,7 +83,7 @@ export default function Compare() {
                   <Card className="border-border">
                     <CardHeader className="flex flex-col gap-4 md:gap-0 md:flex-row justify-between pt-6">
                       <CardTitle className="text-2xl md:text-4xl">
-                        {macro.type}
+                        {macro.workload}
                       </CardTitle>
                       <Button
                         variant="outline"
@@ -92,7 +92,7 @@ export default function Compare() {
                       >
                         <PlusCircledIcon className="mr-2 h-4 w-4 text-primary" />
                         <Link
-                          to={`/macrobench/queries/compare?old=${gitRef.old}&new=${gitRef.new}&workload=${macro.type}`}
+                          to={`/macrobench/queries/compare?old=${gitRef.old}&new=${gitRef.new}&workload=${macro.workload}`}
                         >
                           See Query Plan{" "}
                         </Link>

--- a/website/src/pages/ForeignKeysPage/ForeignKeysPage.tsx
+++ b/website/src/pages/ForeignKeysPage/ForeignKeysPage.tsx
@@ -131,7 +131,7 @@ export default function ForeignKeys() {
                     >
                       <PlusCircledIcon className="mr-2 h-4 w-4 text-primary" />
                       {/* <Link
-                          to={`/macrobench/queries/compare?ltag=${gitRef.old}&rtag=${gitRef.new}&type=${macro.type}`}
+                          to={`/macrobench/queries/compare?ltag=${gitRef.old}&rtag=${gitRef.new}&workload=${macro.workload}`}
                         > */}
                       See Query Plan {/* </Link> */}
                     </Button>

--- a/website/src/pages/HomePage/components/HomePageHero.tsx
+++ b/website/src/pages/HomePage/components/HomePageHero.tsx
@@ -122,7 +122,7 @@ export default function HomePageHero() {
                   dailySummary.name === "TPCC"
                 ) {
                   return (
-                    <Link key={index} to={`/daily?type=${dailySummary.name}`}>
+                    <Link key={index} to={`/daily?workload=${dailySummary.name}`}>
                       <DailySummary
                         data={dailySummary}
                         workload={workload}

--- a/website/src/pages/MacroQueriesComparePage/MacroQueriesComparePage.tsx
+++ b/website/src/pages/MacroQueriesComparePage/MacroQueriesComparePage.tsx
@@ -36,7 +36,7 @@ export default function MacroQueriesComparePage() {
   } = useApiCall<MacroQueriesPlan[]>(
     `${import.meta.env.VITE_API_URL}macrobench/compare/queries?ltag=${
       commits.oldGitRef
-    }&rtag=${commits.newGitRef}&type=${workload}`
+    }&rtag=${commits.newGitRef}&workload=${workload}`
   );
 
   let filterConfigs: FilterConfigs[] = [

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -24,7 +24,7 @@ export type statusDataTypes = {
   source: string;
   started_at: string;
   finished_at: string;
-  type_of: string;
+  workload: string;
   pull_nb?: number;
   golang_version: string;
   status: string;
@@ -114,7 +114,7 @@ export interface CompareResult {
 }
 
 export interface CompareData {
-  type: string;
+  workload: string;
   result: CompareResult;
 }
 


### PR DESCRIPTION
This PR changes `type` to `workload` in the execution table and rename this in a bunch of place.