### PR TITLE
Fix the value of the binary to profile in the admin

### DIFF
--- a/go/admin/templates/add_new_executions.html
+++ b/go/admin/templates/add_new_executions.html
@@ -136,8 +136,8 @@
               name="binaryToProfile"
       >
         <option value="" disabled selected>Select a binary</option>
-        <option value="binary1">vtgate</option>
-        <option value="binary2">vttablet</option>
+        <option value="vtgate">vtgate</option>
+        <option value="vttablet">vttablet</option>
       </select>
 
       <label class="label">Profile Mode</label>


### PR DESCRIPTION
We were sending the wrong values when selecting a binary to profile in the admin.