### PR TITLE
List all compatible version of vitess that were benchmarked

### DIFF
--- a/go/server/api.go
+++ b/go/server/api.go
@@ -150,7 +150,7 @@ type VitessGitRefReleases struct {
 
 func (s *Server) getLatestVitessGitRef(c *gin.Context) {
 	var response VitessGitRefReleases
-	allReleases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
+	allReleases, err := git.GetAllComparableVitessReleases(s.getVitessPath())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
 		slog.Error(err)

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -277,7 +277,7 @@ func (s *Server) tagsCronHandler() {
 
 	configs := s.getConfigFiles()
 
-	releases, err := git.GetLatestVitessReleaseCommitHash(s.getVitessPath())
+	releases, err := git.GetSupportedVitessReleases(s.getVitessPath())
 	if err != nil {
 		slog.Error(err)
 		return

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -66,7 +66,7 @@ func (s *Server) mainBranchCronHandler() ([]*executionQueueElement, error) {
 	}
 
 	// getting the latest release from local fork of Vitess
-	lastRelease, err := git.GetLastReleaseAndCommitHash(vitessPath)
+	lastRelease, err := git.GetLastestRelease(vitessPath)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (s *Server) releaseBranchesCronHandler() ([]*executionQueueElement, error) 
 	for _, release := range releases {
 		ref := release.CommitHash
 		source := exec.SourceReleaseBranch + release.Name
-		lastPatchRelease, err := git.GetLastPatchReleaseAndCommitHash(vitesLocalPath, release.Version)
+		lastPatchRelease, err := git.GetLastestPatchReleaseOfGivenMajorVersion(vitesLocalPath, release.Version)
 		if err != nil && !strings.Contains(err.Error(), "could not find the latest patch release") {
 			slog.Warn(err.Error())
 			continue

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -132,8 +132,11 @@ func GetAllVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 	return res, nil
 }
 
-// GetLatestVitessReleaseCommitHash gets the lastest major vitess releases and the commit hashes given the directory of the clone of vitess
-func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
+// GetSupportedVitessReleases returns a slice of all the currently supported Vitess releases.
+// The last 3 releases are the currently supported releases.
+// With the VEP-6 (https://github.com/vitessio/enhancements/pull/12), starting from when we EOL v20.0
+// only two major releases will be supported in Vitess.
+func GetSupportedVitessReleases(repoDir string) ([]*Release, error) {
 	allReleases, err := GetAllVitessReleaseCommitHash(repoDir)
 	if err != nil || len(allReleases) == 0 {
 		return nil, err
@@ -147,6 +150,27 @@ func GetLatestVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 		}
 	}
 	return latestReleases, nil
+}
+
+// GetAllComparableVitessReleases returns a slice of all the Vitess releases that can safely be
+// compared in arewefastyet. Meaning, all the releases that have been benchmarked with a compatible
+// methodology as the one currently used in arewefastyet.
+func GetAllComparableVitessReleases(repoDir string) ([]*Release, error) {
+	allReleases, err := GetAllVitessReleaseCommitHash(repoDir)
+	if err != nil || len(allReleases) == 0 {
+		return nil, err
+	}
+	var comparableReleases []*Release
+
+	// This is the oldest major version of Vitess that contains up-to-date results on arewefastyet.
+	const firstComparableReleaseMajorVersion = 18
+	for _, release := range allReleases {
+		if release.Version.Major >= firstComparableReleaseMajorVersion {
+			comparableReleases = append(comparableReleases, release)
+		}
+	}
+
+	return comparableReleases, nil
 }
 
 // GetAllVitessReleaseBranchCommitHash gets all the vitess release branches and the commit hashes given the directory of the clone of vitess

--- a/go/tools/git/git.go
+++ b/go/tools/git/git.go
@@ -56,8 +56,8 @@ func GetPlannerVersions() []macrobench.PlannerVersion {
 	return []macrobench.PlannerVersion{macrobench.Gen4Planner}
 }
 
-// GetAllVitessReleaseCommitHash gets all the vitess releases and the commit hashes given the directory of the clone of vitess
-func GetAllVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
+// getAllVitessReleases gets all the vitess releases and the commit hashes given the directory of the clone of vitess
+func getAllVitessReleases(repoDir string) ([]*Release, error) {
 	out, err := ExecCmd(repoDir, "git", "show-ref", "--tags", "-d")
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func GetAllVitessReleaseCommitHash(repoDir string) ([]*Release, error) {
 // With the VEP-6 (https://github.com/vitessio/enhancements/pull/12), starting from when we EOL v20.0
 // only two major releases will be supported in Vitess.
 func GetSupportedVitessReleases(repoDir string) ([]*Release, error) {
-	allReleases, err := GetAllVitessReleaseCommitHash(repoDir)
+	allReleases, err := getAllVitessReleases(repoDir)
 	if err != nil || len(allReleases) == 0 {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func GetSupportedVitessReleases(repoDir string) ([]*Release, error) {
 // compared in arewefastyet. Meaning, all the releases that have been benchmarked with a compatible
 // methodology as the one currently used in arewefastyet.
 func GetAllComparableVitessReleases(repoDir string) ([]*Release, error) {
-	allReleases, err := GetAllVitessReleaseCommitHash(repoDir)
+	allReleases, err := getAllVitessReleases(repoDir)
 	if err != nil || len(allReleases) == 0 {
 		return nil, err
 	}
@@ -238,18 +238,18 @@ func GetLatestVitessReleaseBranchCommitHash(repoDir string) ([]*Release, error) 
 	return latestReleaseBranches, nil
 }
 
-// GetLastReleaseAndCommitHash gets the last release number along with the commit hash given the directory of the clone of vitess
-func GetLastReleaseAndCommitHash(repoDir string) (*Release, error) {
-	res, err := GetAllVitessReleaseCommitHash(repoDir)
+// GetLastestRelease gets the last release number along with the commit hash given the directory of the clone of vitess
+func GetLastestRelease(repoDir string) (*Release, error) {
+	res, err := getAllVitessReleases(repoDir)
 	if err != nil {
 		return nil, err
 	}
 	return res[0], nil
 }
 
-// GetLastPatchReleaseAndCommitHash gets the last release number given the major and minor release number along with the commit hash given the directory of the clone of vitess
-func GetLastPatchReleaseAndCommitHash(repoDir string, version Version) (*Release, error) {
-	res, err := GetAllVitessReleaseCommitHash(repoDir)
+// GetLastestPatchReleaseOfGivenMajorVersion gets the last release number given the major and minor release number along with the commit hash given the directory of the clone of vitess
+func GetLastestPatchReleaseOfGivenMajorVersion(repoDir string, version Version) (*Release, error) {
+	res, err := getAllVitessReleases(repoDir)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func GetVersionForCommitSHA(repoDir, sha string) (Version, error) {
 	matchRelease := regexp.MustCompile(`release-([0-9]+).0`)
 	for _, branch := range branches {
 		if strings.Contains(branch, "origin/main") {
-			lastRelease, err := GetLastReleaseAndCommitHash(repoDir)
+			lastRelease, err := GetLastestRelease(repoDir)
 			if err != nil {
 				return Version{}, err
 			}
@@ -380,7 +380,7 @@ func GetVersionForCommitSHA(repoDir, sha string) (Version, error) {
 			if err != nil {
 				return Version{}, err
 			}
-			lastPatch, err := GetLastPatchReleaseAndCommitHash(repoDir, Version{Major: majorV})
+			lastPatch, err := GetLastestPatchReleaseOfGivenMajorVersion(repoDir, Version{Major: majorV})
 			if err != nil {
 				return Version{}, err
 			}

--- a/go/tools/git/git_test.go
+++ b/go/tools/git/git_test.go
@@ -314,7 +314,7 @@ func TestGetLatestVitessReleaseCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
 	defer os.RemoveAll(tmpDir)
 	qt.Assert(t, err, qt.IsNil)
-	out, err := GetLatestVitessReleaseCommitHash(vitessPath)
+	out, err := GetSupportedVitessReleases(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
 	for _, release := range out {
 		qt.Assert(t, len(release.CommitHash), qt.Equals, 40)

--- a/go/tools/git/git_test.go
+++ b/go/tools/git/git_test.go
@@ -51,7 +51,7 @@ func TestGetAllVitessReleaseCommitHashOrdering(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
 	defer os.RemoveAll(tmpDir)
 	qt.Assert(t, err, qt.IsNil)
-	s, err := GetAllVitessReleaseCommitHash(vitessPath)
+	s, err := getAllVitessReleases(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
 
 	// ordered releases from v10.0.1 to v9.0.0-rc1
@@ -85,7 +85,7 @@ func TestGetAllVitessReleaseCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
 	defer os.RemoveAll(tmpDir)
 	qt.Assert(t, err, qt.IsNil)
-	s, err := GetAllVitessReleaseCommitHash(vitessPath)
+	s, err := getAllVitessReleases(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, s, qt.Any(qt.DeepEquals), &Release{
 		Name:       "5.0.1",


### PR DESCRIPTION
For the longest time we have only benchmarked and shown the last 3 supported releases of vitess. We want to keep doing the former, and change to 2 releases after v20.0 is EOL because of https://github.com/vitessio/enhancements/pull/12. But we want to change the latter: as soon as a new release is out, we use to stop displaying the results of the oldest major release on the website. When we released v21.0, v18.0 was now 4 major versions behind main, meaning it wouldn't be shown on the website.

With this PR, we are now displaying all versions of vitess that were benchmarked with a compatible method than the one currently used by arewefastyet. Meaning, that if in the future, when e.g. v21.0 is the current latest version of Vitess, we change the methodology of arewefastyet enough that it "discards" all the previous results we had collected, then v19.0 will be the oldest compatible version of vitess that was benchmarked with the new methodology.