### PR TITLE
Option to not remove admin executions from the queue

### DIFF
--- a/go/admin/api.go
+++ b/go/admin/api.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -337,8 +336,6 @@ func (a *Admin) handleClearQueue(c *gin.Context) {
 		Auth:                  encryptedToken,
 		RemoveAdminExecutions: c.PostForm("remove_admin") == "true",
 	}
-
-	log.Println(requestPayload)
 
 	jsonData, err := json.Marshal(requestPayload)
 

--- a/go/admin/api.go
+++ b/go/admin/api.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -66,7 +67,8 @@ type (
 	}
 
 	clearQueueRequest struct {
-		Auth string `json:"auth"`
+		Auth                  string `json:"auth"`
+		RemoveAdminExecutions bool   `json:"remove_admin_executions"`
 	}
 )
 
@@ -332,8 +334,11 @@ func (a *Admin) handleClearQueue(c *gin.Context) {
 	}
 
 	requestPayload := clearQueueRequest{
-		Auth: encryptedToken,
+		Auth:                  encryptedToken,
+		RemoveAdminExecutions: c.PostForm("remove_admin") == "true",
 	}
+
+	log.Println(requestPayload)
 
 	jsonData, err := json.Marshal(requestPayload)
 

--- a/go/admin/templates/add_new_executions.html
+++ b/go/admin/templates/add_new_executions.html
@@ -2,7 +2,7 @@
   <form>
     <label class="text-lg font-semibold mt-4">Information</label>
     <div>
-      <label class="label">Source (execution's trigger/reason)</label>
+      <label class="label">Source (leave it to 'admin' unless you don't want these executions to be treated as admin executions)</label>
       <input
         class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
         type="text"

--- a/go/admin/templates/clear_queue.html
+++ b/go/admin/templates/clear_queue.html
@@ -1,17 +1,26 @@
 <div id="content">
   <form>
+    <label class="text-lg font-semibold mt-4">Settings</label>
+    <div class="flex flex-row gap-4">
+      <div class="flex flex-col">
+        <label>
+          <input class="accent-orange-500" type="checkbox" name="remove_admin" value="true" />
+          Remove admin executions
+        </label>
+      </div>
+    </div>
+    <br>
     <button
-      hx-post="/admin/executions/clear"
-      hx-target="#response"
-      class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-      type="submit"
+            hx-post="/admin/executions/clear"
+            hx-target="#response"
+            class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            type="submit"
     >
       Remove every pending executions in the execution queue
     </button>
   </form>
   <div id="response" class="mt-4"></div>
 </div>
-
 <script>
   document.body.addEventListener("htmx:responseError", function(e) {
     error = e.detail.xhr.response;

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -607,7 +607,8 @@ func (s *Server) addExecutions(c *gin.Context) {
 
 func (s *Server) clearExecutionQueue(c *gin.Context) {
 	var req struct {
-		Auth string `json:"auth"`
+		Auth                  string `json:"auth"`
+		RemoveAdminExecutions bool   `json:"remove_admin_executions"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -620,7 +621,7 @@ func (s *Server) clearExecutionQueue(c *gin.Context) {
 		return
 	}
 
-	s.clearQueue()
+	s.clearQueue(req.RemoveAdminExecutions)
 
 	c.JSON(http.StatusAccepted, "")
 }

--- a/go/server/cron.go
+++ b/go/server/cron.go
@@ -206,11 +206,14 @@ func (s *Server) appendToQueue(execElements []*executionQueueElement) {
 	}
 }
 
-func (s *Server) clearQueue() {
+func (s *Server) clearQueue(removeAdmin bool) {
 	mtx.Lock()
 	defer mtx.Unlock()
 	for id, e := range queue {
 		if e.Executing {
+			continue
+		}
+		if id.Source == "admin" && !removeAdmin {
 			continue
 		}
 		delete(queue, id)


### PR DESCRIPTION
## Description

This Pull Request adds an option to the admin UI to allow users to not remove admin executions from the queue. This will be particularly useful when spawning a bunch of admin executions and wanting them to be prioritized when new executions are created by the cron mechanism.