### PR TITLE
Run admin benchmark with the highest priority

### DIFF
--- a/go/cmd/api/api.go
+++ b/go/cmd/api/api.go
@@ -19,6 +19,8 @@
 package api
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 	"github.com/vitessio/arewefastyet/go/server"
 )
@@ -30,6 +32,7 @@ func ApiCmd() *cobra.Command {
 		Use:   "api",
 		Short: "Starts the api server of arewefastyet and the CRON service",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Println("Starting server...")
 			err := srv.Init()
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description

This PR enables the queue watched to always run admin executions first, with the highest priority.

Fixes https://github.com/vitessio/arewefastyet/issues/618