### PR TITLE
Highlight more levels of statistical significance

### DIFF
--- a/website/src/common/MacroBenchmarkTable.tsx
+++ b/website/src/common/MacroBenchmarkTable.tsx
@@ -46,6 +46,43 @@ export type MacroBenchmarkTableProps = {
   vitessRefs: VitessRefs | undefined;
 };
 
+const getSignificanceBadge = (p: number) => {
+  let backgroundColor = "";
+  let textColor = "";
+  let val = fixed(p, 3)
+
+  if (p <= 0.01) {
+    backgroundColor = "#2E7D32"
+    textColor = "#FFFFFF"
+  } else if (p <= 0.05) {
+    backgroundColor = "#388E3C"
+    textColor = "#FFFFFF"
+  } else if (p <= 0.10) {
+    backgroundColor = "#6A9A1F"
+    textColor = "#FFFFFF"
+  } else {
+    backgroundColor = "#9E9E9E"
+    textColor = "#000000"
+  }
+
+  return (
+      <Badge style={{backgroundColor: backgroundColor, color: textColor}}>
+        {val}
+      </Badge>
+  );
+};
+
+const getSignificanceText = (p: number) => {
+  if (p <= 0.01) {
+    return "Statistically Significant";
+  } else if (p <= 0.05) {
+    return "Moderate Significance";
+  } else if (p <= 0.10) {
+    return "Marginal Significance";
+  }
+  return "Not Statistically Significant";
+};
+
 const getDeltaBadgeVariant = (key: string, delta: number, p: number) => {
   if (delta === 0) {
     return "warning";
@@ -180,24 +217,20 @@ export default function MacroBenchmarkTable({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div>
-                        <Badge
-                          variant={row.p > 0.05 ? "destructive" : "success"}
-                        >
-                          {fixed(row.p, 3)}
-                        </Badge>
+                        {getSignificanceBadge(row.p)}
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>
                       <p>
-                        {row.insignificant ? "Insignificant" : "Significant"}
+                        {getSignificanceText(row.p)}
                       </p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               </TableCell>
               <TableCell className="lg:w-[150px] text-center text-front">
-                {row.insignificant && <>{fixed(row.delta, 3)}%</>}
-                {!row.insignificant && (
+                {row.p > 0.1 && <>{fixed(row.delta, 3)}%</>}
+                {row.p <= 0.1 && (
                   <Badge variant={getDeltaBadgeVariant(key, row.delta, row.p)}>
                     {fixed(row.delta, 3)}%
                   </Badge>


### PR DESCRIPTION
## Description

When comparing two benchmarks, we used to always have this black and white view of the result: either their significant or they are not. Which in some cases it can be a form of injustice, for instance a p-value of 0.053 would be considered insignificant, thus marked in flashy red, and the delta would not be highlighted, even though the p-value is very close to our threshold (0.050). 

Instead, we now have four different level of statistical significance in the UI: `Statistically Significant` (p <= 0.01), `Moderate Significance` (p <= 0.05), `Marginal Significance` (p <= 0.1), `Not Statistically Significant` (p > 0.1).

**Before**
![image](https://github.com/user-attachments/assets/9dd6c379-681c-46aa-a61c-f431c3d8456c)

**After**
![image](https://github.com/user-attachments/assets/2257def1-17ae-4eb7-afd8-5a09b975e1fb)
