### PR TITLE
Attach profile information to an execution

### DIFF
--- a/go/exec/status.go
+++ b/go/exec/status.go
@@ -42,7 +42,7 @@ func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
 			(SELECT COUNT(uuid) FROM execution) AS count_status,
 			(SELECT COUNT(DISTINCT git_ref) FROM execution) AS count_commits,
 			(SELECT COUNT(*) FROM execution WHERE started_at >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)) AS count_all,
-			(SELECT AVG(TIMESTAMPDIFF(MINUTE, started_at, finished_at)) AS avg_duration_minutes FROM execution WHERE started_at IS NOT NULL AND finished_at IS NOT NULL AND status NOT IN ('failed', 'started') ORDER BY avg_duration_minutes ASC) AS avg_duration_minutes
+			(SELECT IFNULL(AVG(TIMESTAMPDIFF(MINUTE, started_at, finished_at)), 0) AS avg_duration_minutes FROM execution WHERE profile_binary IS NULL AND started_at IS NOT NULL AND finished_at IS NOT NULL AND status NOT IN ('failed', 'started') ORDER BY avg_duration_minutes ASC) AS avg_duration_minutes
 		FROM 
 			execution
 		LIMIT 1;`)

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -43,10 +43,12 @@ type ErrorAPI struct {
 }
 
 type ExecutionQueue struct {
-	Source   string `json:"source"`
-	GitRef   string `json:"git_ref"`
-	Workload string `json:"workload"`
-	PullNb   int    `json:"pull_nb"`
+	Source        string `json:"source"`
+	GitRef        string `json:"git_ref"`
+	Workload      string `json:"workload"`
+	PullNb        int    `json:"pull_nb"`
+	ProfileBinary string `json:"profile_binary"`
+	ProfileMode   string `json:"profile_mode"`
 }
 
 type RecentExecutions struct {
@@ -59,6 +61,8 @@ type RecentExecutions struct {
 	GolangVersion string     `json:"golang_version"`
 	StartedAt     *time.Time `json:"started_at"`
 	FinishedAt    *time.Time `json:"finished_at"`
+	ProfileBinary string     `json:"profile_binary"`
+	ProfileMode   string     `json:"profile_mode"`
 }
 
 type ExecutionMetadatas struct {
@@ -102,6 +106,8 @@ func (s *Server) getRecentExecutions(c *gin.Context) {
 			GolangVersion: e.GolangVersion,
 			StartedAt:     e.StartedAt,
 			FinishedAt:    e.FinishedAt,
+			ProfileBinary: e.ProfileInformation.Binary,
+			ProfileMode:   e.ProfileInformation.Mode,
 		})
 		if !slices.Contains(response.Workloads, e.Workload) {
 			response.Workloads = append(response.Workloads, e.Workload)
@@ -124,11 +130,18 @@ func (s *Server) getExecutionsQueue(c *gin.Context) {
 		if e.Executing {
 			continue
 		}
+		var profileBinary, profileMode string
+		if e.identifier.Profile != nil {
+			profileBinary = e.identifier.Profile.Binary
+			profileMode = e.identifier.Profile.Mode
+		}
 		response.Executions = append(response.Executions, ExecutionQueue{
-			Source:   e.identifier.Source,
-			GitRef:   e.identifier.GitRef,
-			Workload: e.identifier.Workload,
-			PullNb:   e.identifier.PullNb,
+			Source:        e.identifier.Source,
+			GitRef:        e.identifier.GitRef,
+			Workload:      e.identifier.Workload,
+			PullNb:        e.identifier.PullNb,
+			ProfileBinary: profileBinary,
+			ProfileMode:   profileMode,
 		})
 		if !slices.Contains(response.Workloads, e.identifier.Workload) {
 			response.Workloads = append(response.Workloads, e.identifier.Workload)

--- a/go/tools/macrobench/sql.go
+++ b/go/tools/macrobench/sql.go
@@ -53,6 +53,7 @@ func getExecutionGroupResults(workload string, ref string, planner PlannerVersio
             metrics AS m ON e.uuid = m.exec_uuid
         WHERE 
             e.status = 'finished'
+            AND e.profile_binary IS NULL
             AND e.git_ref = ? 
             AND info.vtgate_planner_version = ? 
             AND info.workload = ?
@@ -156,6 +157,7 @@ func getExecutionGroupResultsFromLast30Days(workload string, planner PlannerVers
             metrics AS m ON e.uuid = m.exec_uuid
         WHERE 
             e.finished_at BETWEEN DATE(NOW()) - INTERVAL 30 DAY AND DATE(NOW() + INTERVAL 1 DAY)
+            AND e.profile_binary IS NULL
             AND e.source = 'cron'
             AND e.status = 'finished'
             AND info.vtgate_planner_version = ? 
@@ -262,7 +264,8 @@ func getSummaryLast30Days(workload string, planner PlannerVersion, client storag
         JOIN 
             macrobenchmark_results AS results ON info.macrobenchmark_id = results.macrobenchmark_id
         WHERE 
-            e.finished_at BETWEEN DATE(NOW()) - INTERVAL 30 DAY AND DATE(NOW() + INTERVAL 1 DAY) 
+            e.finished_at BETWEEN DATE(NOW()) - INTERVAL 30 DAY AND DATE(NOW() + INTERVAL 1 DAY)
+            AND e.profile_binary IS NULL
             AND e.status = "finished" 
             AND e.source = "cron" 
             AND info.vtgate_planner_version = ? 

--- a/website/src/pages/StatusPage/components/ExecutionQueue/Columns.tsx
+++ b/website/src/pages/StatusPage/components/ExecutionQueue/Columns.tsx
@@ -29,6 +29,8 @@ export type ExecutionQueueExecution = {
   git_ref: string;
   workload: string;
   pull_nb: number;
+  profile_binary: string;
+  profile_mode: string;
 };
 
 export const columns: ColumnDef<ExecutionQueueExecution>[] = [
@@ -72,5 +74,18 @@ export const columns: ColumnDef<ExecutionQueueExecution>[] = [
         </div>
       );
     },
+  },
+  {
+    header: "Profile",
+    accessorKey: "profile_binary",
+    cell: ({row}) => {
+      if (row.original.profile_mode !== "" && row.original.profile_binary !== "") {
+        return (
+            <div>
+              <Badge variant={"progress"}>{row.original.profile_binary}|{row.original.profile_mode}</Badge>
+            </div>
+        )
+      }
+    }
   },
 ];

--- a/website/src/pages/StatusPage/components/ExecutionQueue/Execution.tsx
+++ b/website/src/pages/StatusPage/components/ExecutionQueue/Execution.tsx
@@ -63,6 +63,8 @@ export default function ExecutionQueue() {
         git_ref: value.git_ref,
         workload: value.workload,
         pull_nb: value.pull_nb,
+        profile_binary: value.profile_binary,
+        profile_mode: value.profile_mode,
       };
     });
 

--- a/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
+++ b/website/src/pages/StatusPage/components/PreviousExecutions/Columns.tsx
@@ -35,6 +35,8 @@ export type PreviousExecutionExecution = {
   golang_version: string;
   started_at: string;
   finished_at: string;
+  profile_binary: string;
+  profile_mode: string;
 };
 
 export type PreviousExecution = {
@@ -169,6 +171,19 @@ export const columns: ColumnDef<PreviousExecutionExecution>[] = [
     filterFn: (row, id, value) => {
       return value.includes(row.getValue(id));
     },
+  },
+  {
+    header: "Profile",
+    accessorKey: "profile_binary",
+    cell: ({row}) => {
+      if (row.original.profile_mode !== "" && row.original.profile_binary !== "") {
+        return (
+            <div>
+              <Badge variant={"progress"}>{row.original.profile_binary}|{row.original.profile_mode}</Badge>
+            </div>
+        )
+      }
+    }
   },
   {
     id: "actions",


### PR DESCRIPTION
## Description

This Pull Request enhances the SQL schema of our `execution` table to contain information about profiling. This has several benefits: we can ignore profiled benchmarks when doing a comparison, we can show which benchmarks were profiled in the status page.

Preview:
![image](https://github.com/user-attachments/assets/22425ee6-351a-4c80-9f35-7cadd453a7e0)
![image](https://github.com/user-attachments/assets/b1006e69-76e9-4954-b26f-7d9a38fd15d6)
