### PR TITLE
Remove `cron_pr_base` cron and compare PRs with most recent cron

### DIFF
--- a/go/server/api.go
+++ b/go/server/api.go
@@ -348,21 +348,22 @@ func (s *Server) getPullRequestInfo(c *gin.Context) {
 		slog.Error(err)
 		return
 	}
-	gitPRInfo, err := exec.GetPullRequestInfo(s.dbClient, pullNb)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
-		slog.Error(err)
-		return
-	}
-
 	prInfo, err := s.ghApp.GetPullRequestInfo(pullNb)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
 		slog.Error(err)
 		return
 	}
-	prInfo.Base = gitPRInfo.Main
-	prInfo.Head = gitPRInfo.PR
+
+	gitPRInfo, err := exec.GetPullRequestInfo(s.dbClient, pullNb, prInfo)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, &ErrorAPI{Error: err.Error()})
+		slog.Error(err)
+		return
+	}
+
+	prInfo.Base = gitPRInfo.Base
+	prInfo.Head = gitPRInfo.Head
 	c.JSON(http.StatusOK, prInfo)
 }
 

--- a/go/server/cron_execution.go
+++ b/go/server/cron_execution.go
@@ -52,7 +52,6 @@ func (s *Server) executeSingle(config benchmarkConfig, identifier executionIdent
 	e.GitRef = identifier.GitRef
 	e.VtgatePlannerVersion = identifier.PlannerVersion
 	e.PullNB = identifier.PullNb
-	e.PullBaseBranchRef = identifier.PullBaseRef
 	e.VitessVersion = identifier.Version
 	e.NextBenchmarkIsTheSame = nextIsSame
 	e.ProfileInformation = identifier.Profile

--- a/go/server/cron_handlers.go
+++ b/go/server/cron_handlers.go
@@ -230,14 +230,14 @@ func (s *Server) pullRequestsCronHandler() {
 				}
 
 				if workload == "micro" {
-					elements = append(elements, s.createPullRequestElementWithBaseComparison(config, ref, workload, previousGitRef, "", pullNb, currVersion)...)
+					elements = append(elements, s.createPullRequestElement(config, ref, workload, "", pullNb, currVersion))
 				} else {
 					versions := []macrobench.PlannerVersion{macrobench.V3Planner}
 					if labelInfo.useGen4 {
 						versions = []macrobench.PlannerVersion{macrobench.Gen4Planner}
 					}
 					for _, version := range versions {
-						elements = append(elements, s.createPullRequestElementWithBaseComparison(config, ref, workload, previousGitRef, version, pullNb, currVersion)...)
+						elements = append(elements, s.createPullRequestElement(config, ref, workload, version, pullNb, currVersion))
 					}
 				}
 			}
@@ -249,20 +249,8 @@ func (s *Server) pullRequestsCronHandler() {
 	}
 }
 
-func (s *Server) createPullRequestElementWithBaseComparison(config benchmarkConfig, ref, workload, previousGitRef string, plannerVersion macrobench.PlannerVersion, pullNb int, gitVersion git.Version) []*executionQueueElement {
-	var elements []*executionQueueElement
-
-	newExecutionElement := s.createSimpleExecutionQueueElement(config, exec.SourcePullRequest, ref, workload, string(plannerVersion), true, pullNb, gitVersion, nil)
-	newExecutionElement.identifier.PullBaseRef = previousGitRef
-	elements = append(elements, newExecutionElement)
-
-	if previousGitRef != "" {
-		previousElement := s.createSimpleExecutionQueueElement(config, exec.SourcePullRequestBase, previousGitRef, workload, string(plannerVersion), false, pullNb, gitVersion, nil)
-		previousElement.compareWith = append(previousElement.compareWith, newExecutionElement.identifier)
-		newExecutionElement.compareWith = append(newExecutionElement.compareWith, previousElement.identifier)
-		elements = append(elements, previousElement)
-	}
-	return elements
+func (s *Server) createPullRequestElement(config benchmarkConfig, ref, workload string, plannerVersion macrobench.PlannerVersion, pullNb int, gitVersion git.Version) *executionQueueElement {
+	return s.createSimpleExecutionQueueElement(config, exec.SourcePullRequest, ref, workload, string(plannerVersion), true, pullNb, gitVersion, nil)
 }
 
 func (s *Server) tagsCronHandler() {

--- a/go/tools/github/github.go
+++ b/go/tools/github/github.go
@@ -113,12 +113,15 @@ func (a *App) Init() error {
 }
 
 type PRInfo struct {
-	ID        int
-	Author    string
-	Title     string
-	CreatedAt *time.Time
-	Base      string
-	Head      string
+	ID         int
+	Author     string
+	Title      string
+	CreatedAt  *time.Time
+	Base       string
+	BaseRef    string
+	Head       string
+	IsMerged   bool
+	MergedTime *time.Time
 }
 
 func (a *App) GetPullRequestInfo(prNumber int) (PRInfo, error) {
@@ -129,10 +132,14 @@ func (a *App) GetPullRequestInfo(prNumber int) (PRInfo, error) {
 	}
 
 	createAt := pr.GetCreatedAt().Time
+	mergedAt := pr.GetMergedAt()
 	return PRInfo{
-		ID:        prNumber,
-		Author:    pr.User.GetLogin(),
-		Title:     pr.GetTitle(),
-		CreatedAt: &createAt,
+		ID:         prNumber,
+		Author:     pr.User.GetLogin(),
+		Title:      pr.GetTitle(),
+		CreatedAt:  &createAt,
+		IsMerged:   pr.GetMerged(),
+		MergedTime: mergedAt.GetTime(),
+		BaseRef:    pr.GetBase().GetRef(),
 	}, nil
 }


### PR DESCRIPTION
## Description

This PR entirely removes the execution of the `cron_pr_base` benchmarks and instead compares the result of a PR with the most recent cron benchmark on the base branch of the Pull Request.

This will essentially reduce the time needed to benchmark PRs by 50%, which is a major win.