### PR TITLE
Allow Admin to add PR to execution queue for benchmarking and profiling

### DIFF
--- a/go/admin/api.go
+++ b/go/admin/api.go
@@ -58,6 +58,7 @@ type (
 		Auth               string   `json:"auth"`
 		Source             string   `json:"source"`
 		SHA                string   `json:"sha"`
+		PR                 string   `json:"pr"`
 		Workloads          []string `json:"workloads"`
 		NumberOfExecutions string   `json:"number_of_executions"`
 		EnableProfile      bool     `json:"enable_profile"`
@@ -227,6 +228,7 @@ func (a *Admin) handleExecutionsAdd(c *gin.Context) {
 	requestPayload := executionRequest{
 		Source:             c.PostForm("source"),
 		SHA:                c.PostForm("sha"),
+		PR:                 c.PostForm("pr"),
 		Workloads:          c.PostFormArray("workloads"),
 		NumberOfExecutions: c.PostForm("numberOfExecutions"),
 		EnableProfile:      c.PostForm("enableProfiling") != "",
@@ -234,8 +236,13 @@ func (a *Admin) handleExecutionsAdd(c *gin.Context) {
 		ProfileMode:        c.PostForm("profileMode"),
 	}
 
-	if requestPayload.Source == "" || requestPayload.SHA == "" || len(requestPayload.Workloads) == 0 || requestPayload.NumberOfExecutions == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing required fields: Source, SHA, workflows, numberOfExecutions"})
+	if requestPayload.Source == "" || len(requestPayload.Workloads) == 0 || requestPayload.NumberOfExecutions == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing required fields: Source, workflows, numberOfExecutions"})
+		return
+	}
+
+	if requestPayload.SHA == "" && requestPayload.PR == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Please provide either a SHA or a PR number"})
 		return
 	}
 

--- a/go/admin/templates/add_new_executions.html
+++ b/go/admin/templates/add_new_executions.html
@@ -20,6 +20,15 @@
         name="sha"
       />
     </div>
+    <div>
+      <label class="label">PR</label>
+      <input
+        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        type="number"
+        class="form-control"
+        name="pr"
+      />
+    </div>
     <br>
     <label class="text-lg font-semibold mt-4">Workloads</label>
     <div class="flex flex-row gap-4">

--- a/go/admin/templates/add_new_executions.html
+++ b/go/admin/templates/add_new_executions.html
@@ -21,7 +21,7 @@
       />
     </div>
     <div>
-      <label class="label">PR</label>
+      <label class="label">PR Number</label>
       <input
         class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
         type="number"

--- a/go/tools/git/github.go
+++ b/go/tools/git/github.go
@@ -33,7 +33,7 @@ func GetPullRequestsFromGitHub(labels []string, repo string) ([]PRInfo, error) {
 
 	prInfos := []PRInfo{}
 	for _, pull := range pulls {
-		prInfo, err := getPullRequestHeadAndBase(pull)
+		prInfo, err := GetPullRequestHeadAndBase(pull)
 		if err != nil {
 			return nil, err
 		}

--- a/go/tools/git/pulls.go
+++ b/go/tools/git/pulls.go
@@ -26,11 +26,11 @@ import (
 
 type PRInfo struct {
 	Number int
-	Base string
-	SHA  string
+	Base   string
+	SHA    string
 }
 
-func getPullRequestHeadAndBase(url string) (PRInfo, error) {
+func GetPullRequestHeadAndBase(url string) (PRInfo, error) {
 	client := http.Client{}
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -44,7 +44,7 @@ func getPullRequestHeadAndBase(url string) (PRInfo, error) {
 
 	res := struct {
 		Number int `json:"number"`
-		Head struct {
+		Head   struct {
 			SHA string `json:"sha"`
 		} `json:"head"`
 		Base struct {


### PR DESCRIPTION
This PR adds to Admin page a feature to allow Admins to send PR number for benchmarking instead of SHA