### PR TITLE
Skip vtadmin build

### DIFF
--- a/ansible/roles/vitess_build/tasks/main.yml
+++ b/ansible/roles/vitess_build/tasks/main.yml
@@ -35,7 +35,7 @@
       shell: |
         export TMPDIR=/root/tmp
         cd /go/src/vitess.io/vitess
-        make build
+        NOVTADMINBUILD=1 make build
 
     - name: Remove Vitess binaries
       shell: |


### PR DESCRIPTION
This fixes an issue that was observed after the recent node/vite versions upgrade https://github.com/vitessio/vitess/pull/17606. When building Vitess we were getting an error from npm:
```
failed to load config from /go/src/vitess.io/vitess/web/vtadmin/vite.config.ts
error during build:
Error: The package "@esbuild/linux-x64" could not be found, and is needed by esbuild.
```

This issue is fixable by removing the local dependencies (`rm -rf node_modules package-lock.json`) and re-installing them (`npm install`).

However, we don't actually need to build vtadmin in arewefastyet so let's skip its build altogether.