### PR TITLE
fix color of the error badge when comparing two benchmarks

### DIFF
--- a/website/src/common/MacroBenchmarkTable.tsx
+++ b/website/src/common/MacroBenchmarkTable.tsx
@@ -90,7 +90,8 @@ const getDeltaBadgeVariant = (key: string, delta: number, p: number) => {
   if (
     key.includes("CpuTime") ||
     key.includes("Mem") ||
-    key.includes("latency")
+    key.includes("latency") ||
+    key.includes("errors")
   ) {
     if (delta < 0) {
       return "success";


### PR DESCRIPTION
Small fix to the error row in the benchmark comparison table
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/6ca2dfaf-9d54-4866-a4f3-8ab67c36325c" />

here the error delta should be green