### PR TITLE
ci: declare workflow-level `contents: read` on the 6 CI workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,6 +2,9 @@ name: Ansible Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/golang_build.yaml
+++ b/.github/workflows/golang_build.yaml
@@ -2,6 +2,9 @@ name: Golang Build CLI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -2,6 +2,9 @@ name: Golang Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/golang_tidy.yaml
+++ b/.github/workflows/golang_tidy.yaml
@@ -2,6 +2,9 @@ name: Golang Tidy
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/golang_unit_test.yaml
+++ b/.github/workflows/golang_unit_test.yaml
@@ -2,6 +2,9 @@ name: Golang Unit Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/verify_cli_documentation.yml
+++ b/.github/workflows/verify_cli_documentation.yml
@@ -2,6 +2,9 @@ name: Verify CLI Documentation
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Verify CLI Documentation


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 6 CI workflows that only do lint/build/test/verify:

- `ansible-lint.yml`
- `golang_build.yaml`
- `golang_lint.yaml`
- `golang_tidy.yaml`
- `golang_unit_test.yaml`
- `verify_cli_documentation.yml`

None of these call the GitHub API beyond checkout. `deploy.yml` is intentionally left untouched since it does exercise write paths and the scope decision there belongs to maintainers.

Motivation: CVE-2025-30066 (the `tj-actions/changed-files` compromise in March) exfiltrated unspoken `GITHUB_TOKEN` scopes from caller workflow logs. Per-workflow caps make the blast radius predictable irrespective of repo or org default.

YAML validated locally with `yaml.safe_load` on each touched file.