### PR TITLE
chore(ci): set top-level permissions on workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,6 +2,9 @@ name: Ansible Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/golang_build.yaml
+++ b/.github/workflows/golang_build.yaml
@@ -2,6 +2,9 @@ name: Golang Build CLI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -2,6 +2,9 @@ name: Golang Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/golang_tidy.yaml
+++ b/.github/workflows/golang_tidy.yaml
@@ -2,6 +2,9 @@ name: Golang Tidy
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
I work on software supply chain security and have been hardening GitHub Actions workflows across OSS projects.

Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes. This PR sets `permissions: contents: read` at the workflow level for `.github/workflows/ansible-lint.yml`, `.github/workflows/golang_build.yaml`, `.github/workflows/golang_lint.yaml`, `.github/workflows/golang_tidy.yaml`, which is all these jobs need (checkout plus the build/test steps). Scoping the token to read-only shrinks what a compromised step or dependency can do, a concern made concrete by the March 2025 `tj-actions/changed-files` compromise (CVE-2025-30066), where a leaked write-scoped `GITHUB_TOKEN` was the blast radius.

No job behavior changes; the steps already only read the repository.