### PR TITLE
Fix failing Golang Lint CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+# The default linter set is kept as-is; this file only filters out a single
+# false positive emitted by govet's "inline" analyzer. On generic standard
+# library helpers (e.g. slices.Contains) it reports
+#   "inline: cannot inline: type parameter inference is not yet supported"
+# which is a limitation of the analyzer, not an issue with our code. See
+# https://github.com/golang/go/issues/66260.
+linters:
+  exclusions:
+    rules:
+      - linters:
+          - govet
+        text: "cannot inline"

--- a/go/admin/admin.go
+++ b/go/admin/admin.go
@@ -81,10 +81,10 @@ func (a *Admin) Init() error {
 		return errors.New(server.ErrorIncorrectConfiguration)
 	}
 
-	if a.Mode != "" && !a.Mode.Correct() {
+	if a.Mode != "" && !a.Correct() {
 		return errors.New(server.ErrorIncorrectMode)
 	} else if a.Mode == "" {
-		a.Mode.UseDefault()
+		a.UseDefault()
 	}
 
 	if slog == nil {
@@ -107,7 +107,7 @@ func (a *Admin) Run() error {
 		return errors.New(server.ErrorIncorrectConfiguration)
 	}
 
-	a.Mode.SetGin()
+	a.SetGin()
 	a.router = gin.Default()
 
 	a.router.Static("/admin/assets", "/go/admin/assets")

--- a/go/admin/api.go
+++ b/go/admin/api.go
@@ -303,7 +303,7 @@ func (a *Admin) handleExecutionsAdd(c *gin.Context) {
 		return
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		slog.Error("Server API returned an error: ", resp.Status)
@@ -370,7 +370,7 @@ func (a *Admin) handleClearQueue(c *gin.Context) {
 		return
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusAccepted {
 		slog.Error("Server API returned an error: ", resp.Status)

--- a/go/cmd/gen/metrics/exec.go
+++ b/go/cmd/gen/metrics/exec.go
@@ -49,7 +49,7 @@ func GenExecMetricsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer rowsExecUUIDs.Close()
+			defer func() { _ = rowsExecUUIDs.Close() }()
 
 			for rowsExecUUIDs.Next() {
 				var uuid string
@@ -63,7 +63,7 @@ func GenExecMetricsCmd() *cobra.Command {
 					return err
 				}
 				exist := rowsExecMetrics.Next()
-				rowsExecMetrics.Close()
+				_ = rowsExecMetrics.Close()
 				if exist {
 					continue
 				}

--- a/go/exec/exec.go
+++ b/go/exec/exec.go
@@ -410,7 +410,7 @@ func (e *Exec) Success() error {
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	if rows.Next() {
 		return nil
 	}
@@ -447,7 +447,7 @@ func GetRecentExecutions(client storage.SQLClient) ([]*Exec, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	for result.Next() {
 		exec := &Exec{
 			ProfileInformation: &ProfileInformation{},
@@ -478,7 +478,7 @@ func GetFinishedExecution(client storage.SQLClient, gitRef, source, workload, pl
 	if err != nil {
 		return "", err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	for result.Next() {
 		err = result.Scan(&eUUID)
 		if err != nil {
@@ -494,7 +494,7 @@ func IsLastExecutionFinished(client storage.SQLClient) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	var status string
 	if result.Next() {
 		err = result.Scan(&status)
@@ -513,7 +513,7 @@ func GetPreviousFromSourceMicrobenchmark(client storage.SQLClient, source, gitRe
 	if err != nil {
 		return
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	for result.Next() {
 		err = result.Scan(&execUUID, &gitRefOut)
 		if err != nil {
@@ -531,7 +531,7 @@ func GetPreviousFromSourceMacrobenchmark(client storage.SQLClient, source, workl
 	if err != nil {
 		return
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	for result.Next() {
 		err = result.Scan(&execUUID, &gitRefOut)
 		if err != nil {
@@ -547,7 +547,7 @@ func getGitRefOfLatestFinishedMatchingSource(client storage.SQLClient, source st
 	if err != nil {
 		return
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	for result.Next() {
 		err = result.Scan(&gitRefOut)
 		if err != nil {
@@ -579,7 +579,7 @@ func getGitRefOfFinishedMatchingSourceGivenTimestamp(client storage.SQLClient, s
 	if err != nil {
 		return
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	for result.Next() {
 		err = result.Scan(&gitRefOut)
 		if err != nil {
@@ -598,7 +598,7 @@ func GetLatestDailyJobForMacrobenchmarks(client storage.SQLClient) (gitSha strin
 		return "", err
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		err = rows.Scan(&gitSha)
 		return gitSha, err
@@ -612,7 +612,7 @@ func Exists(client storage.SQLClient, gitRef, source, workload, status string) (
 	if err != nil {
 		return false, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	return result.Next(), nil
 }
 
@@ -622,7 +622,7 @@ func CountMacroBenchmark(client storage.SQLClient, gitRef, source, workload, sta
 	if err != nil {
 		return 0, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	var nb int
 	if result.Next() {
 		err = result.Scan(&nb)
@@ -683,7 +683,7 @@ func GetHistory(client storage.SQLClient) ([]*History, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 	res := make([]*History, 0)
 	for result.Next() {
 		history := &History{}

--- a/go/exec/metrics/metrics.go
+++ b/go/exec/metrics/metrics.go
@@ -171,7 +171,7 @@ func GetExecutionMetricsSQL(client storage.SQLClient, execUUID string) (Executio
 	if err != nil {
 		return ExecutionMetrics{}, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	result := NewExecMetrics()
 	for rows.Next() {

--- a/go/exec/path_test.go
+++ b/go/exec/path_test.go
@@ -51,7 +51,7 @@ func Test_createDirFromUUID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 			c.Cleanup(func() {
-				os.RemoveAll(tt.args.root)
+				_ = os.RemoveAll(tt.args.root)
 			})
 
 			gotDirPath, err := createDirFromUUID(tt.args.uuid, tt.args.root)

--- a/go/exec/pull_request.go
+++ b/go/exec/pull_request.go
@@ -32,7 +32,7 @@ func GetPullRequestList(client storage.SQLClient) ([]int, error) {
 		return nil, err
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var res []int
 	for rows.Next() {
@@ -69,7 +69,7 @@ func GetPullRequestInfo(client storage.SQLClient, pullNumber int, info github.PR
 		return pullRequestInfo{}, err
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var res pullRequestInfo
 	if rows.Next() {

--- a/go/exec/status.go
+++ b/go/exec/status.go
@@ -51,7 +51,7 @@ func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
 		return BenchmarkStats{}, err
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var res BenchmarkStats
 	if rows.Next() {
@@ -61,7 +61,7 @@ func GetBenchmarkStats(client storage.SQLClient) (BenchmarkStats, error) {
 		}
 	}
 
-	rows.Close()
+	_ = rows.Close()
 
 	rows, err = client.Read(`SELECT 
 			COUNT(*)

--- a/go/infra/ansible/ansible_test.go
+++ b/go/infra/ansible/ansible_test.go
@@ -44,8 +44,8 @@ func TestConfig_MoveRootFolder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 			c.Cleanup(func() {
-				os.RemoveAll(tt.cfg.RootDir)
-				os.RemoveAll(tt.dir)
+				_ = os.RemoveAll(tt.cfg.RootDir)
+				_ = os.RemoveAll(tt.dir)
 			})
 
 			var testFile string

--- a/go/infra/ansible/files.go
+++ b/go/infra/ansible/files.go
@@ -39,7 +39,7 @@ func insertMetaSliceToFile(values []string, file, root, token string) error {
 	}
 	var newContent string
 	for i, val := range values {
-		newContent = strings.Replace(string(content), fmt.Sprintf("%s_%d", token, i), val, -1)
+		newContent = strings.ReplaceAll(string(content), fmt.Sprintf("%s_%d", token, i), val)
 	}
 	err = os.WriteFile(file, []byte(newContent), 0)
 	if err != nil {

--- a/go/server/api.go
+++ b/go/server/api.go
@@ -691,7 +691,7 @@ func IsUserAuthenticated(accessToken string) (bool, error) {
 		slog.Error("Error making request to Github: %v", err)
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK, nil
 }

--- a/go/server/git_test.go
+++ b/go/server/git_test.go
@@ -29,7 +29,7 @@ func TestSetupLocalVitess(t *testing.T) {
 	// Create a temporary folder and try setup vitess
 	tmpDir, err := os.MkdirTemp("", "setup_vitess_*")
 	qt.Assert(t, err, qt.IsNil)
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	s := Server{
 		localVitessPath: tmpDir,
 	}
@@ -49,7 +49,7 @@ func TestSetupLocalVitess(t *testing.T) {
 	// Create a temporary directory and create a vitess folder manually
 	tmpDir, err = os.MkdirTemp("", "setup_vitess_*")
 	qt.Assert(t, err, qt.IsNil)
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	s = Server{
 		localVitessPath: tmpDir,
 	}
@@ -92,7 +92,7 @@ func TestPullLocalVitess(t *testing.T) {
 	// Create a temporary folder and try setup vitess
 	tmpDir, err := os.MkdirTemp("", "setup_vitess_*")
 	qt.Assert(t, err, qt.IsNil)
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	s := Server{
 		localVitessPath: tmpDir,
 	}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -157,10 +157,10 @@ func (s *Server) Init() error {
 		return errors.New(server.ErrorIncorrectConfiguration)
 	}
 
-	if s.Mode != "" && !s.Mode.Correct() {
+	if s.Mode != "" && !s.Correct() {
 		return errors.New(server.ErrorIncorrectMode)
 	} else if s.Mode == "" {
-		s.Mode.UseDefault()
+		s.UseDefault()
 	}
 
 	if slog == nil {
@@ -224,7 +224,7 @@ func (s *Server) Run() error {
 		return err
 	}
 
-	s.Mode.SetGin()
+	s.SetGin()
 	s.router = gin.Default()
 
 	s.router.Use(cors.New(cors.Config{

--- a/go/slack/config.go
+++ b/go/slack/config.go
@@ -51,5 +51,5 @@ func (c *Config) AddToCommand(cmd *cobra.Command) {
 }
 
 func (c Config) IsValid() bool {
-	return !(c.Token == "" || c.Channel == "")
+	return c.Token != "" && c.Channel != ""
 }

--- a/go/storage/influxdb/influxdb.go
+++ b/go/storage/influxdb/influxdb.go
@@ -46,10 +46,10 @@ func (c *Client) Select(query string) ([]map[string]interface{}, error) {
 			result = append(result, queryResult.Record().Values())
 		}
 		if queryResult.Err() != nil {
-			return result, fmt.Errorf("Error executing query %q: %v\n", query, queryResult.Err())
+			return result, fmt.Errorf("error executing query %q: %v", query, queryResult.Err())
 		}
 	} else {
-		return result, fmt.Errorf("Error executing query %q: %v\n", query, err)
+		return result, fmt.Errorf("error executing query %q: %v", query, err)
 	}
 	return result, nil
 }

--- a/go/storage/mysql/config.go
+++ b/go/storage/mysql/config.go
@@ -41,6 +41,6 @@ func (cfg ConfigDB) NewClient() (*Client, error) {
 }
 
 func (cfg ConfigDB) IsValid() bool {
-	return !(cfg.Database == "" || cfg.User == "" || cfg.Host == "")
+	return cfg.Database != "" && cfg.User != "" && cfg.Host != ""
 }
 

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -57,7 +57,7 @@ func (c *Client) Write(query string, args ...interface{}) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer stms.Close()
+	defer func() { _ = stms.Close() }()
 
 	res, err := stms.Exec(args...)
 	if err != nil {

--- a/go/storage/psdb/psdb.go
+++ b/go/storage/psdb/psdb.go
@@ -163,7 +163,7 @@ func (c *Client) Write(query string, args ...interface{}) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer stms.Close()
+	defer func() { _ = stms.Close() }()
 
 	res, err := stms.Exec(args...)
 	if err != nil {

--- a/go/tools/git/git_test.go
+++ b/go/tools/git/git_test.go
@@ -49,7 +49,7 @@ func TestShortenSHA(t *testing.T) {
 
 func TestGetAllVitessReleaseCommitHashOrdering(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	qt.Assert(t, err, qt.IsNil)
 	s, err := getAllVitessReleases(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
@@ -83,7 +83,7 @@ func TestGetAllVitessReleaseCommitHashOrdering(t *testing.T) {
 
 func TestGetAllVitessReleaseCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	qt.Assert(t, err, qt.IsNil)
 	s, err := getAllVitessReleases(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
@@ -266,7 +266,7 @@ func TestCompareReleaseNumbers(t *testing.T) {
 
 func TestGetCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	qt.Assert(t, err, qt.IsNil)
 	out, err := GetCommitHash(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
@@ -287,7 +287,7 @@ func createTemporaryVitessClone() (string, string, error) {
 
 func TestGetAllVitessReleaseBranchCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	qt.Assert(t, err, qt.IsNil)
 	out, err := GetAllVitessReleaseBranchCommitHash(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
@@ -299,7 +299,7 @@ func TestGetAllVitessReleaseBranchCommitHash(t *testing.T) {
 
 func TestGetLatestVitessReleaseBranchCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	qt.Assert(t, err, qt.IsNil)
 	out, err := GetLatestVitessReleaseBranchCommitHash(vitessPath)
 	qt.Assert(t, err, qt.IsNil)
@@ -312,7 +312,7 @@ func TestGetLatestVitessReleaseBranchCommitHash(t *testing.T) {
 
 func TestGetLatestVitessReleaseCommitHash(t *testing.T) {
 	tmpDir, vitessPath, err := createTemporaryVitessClone()
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	qt.Assert(t, err, qt.IsNil)
 	out, err := GetSupportedVitessReleases(vitessPath)
 	qt.Assert(t, err, qt.IsNil)

--- a/go/tools/git/pulls.go
+++ b/go/tools/git/pulls.go
@@ -40,7 +40,7 @@ func GetPullRequestHeadAndBase(url string) (PRInfo, error) {
 	if err != nil {
 		return PRInfo{}, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	res := struct {
 		Number int `json:"number"`
@@ -77,7 +77,7 @@ func getPullRequestsForLabels(labels, repo string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	res := struct {
 		Items []struct {

--- a/go/tools/macrobench/macrobench.go
+++ b/go/tools/macrobench/macrobench.go
@@ -96,7 +96,7 @@ func Run(mabcfg Config) error {
 	if err != nil {
 		return err
 	}
-	defer sqlClient.Close()
+	defer func() { _ = sqlClient.Close() }()
 
 	// get metrics database client
 	metricsClient, err := createMetricsDatabaseClient(mabcfg.MetricsDatabaseConfig)
@@ -205,7 +205,7 @@ func handleSysBenchResults(resStr []byte, sqlClient *psdb.Client, macrobenchID i
 	var results []sysbenchResult
 	err := json.Unmarshal(resStr, &results)
 	if err != nil {
-		return sysbenchResult{}, fmt.Errorf("unmarshal results: %+v\n", err)
+		return sysbenchResult{}, fmt.Errorf("unmarshal results: %+v", err)
 	}
 	if len(results) == 0 {
 		return sysbenchResult{}, errors.New(ErrorNoSysBenchResult)

--- a/go/tools/macrobench/sql.go
+++ b/go/tools/macrobench/sql.go
@@ -65,7 +65,7 @@ func getExecutionGroupResults(workload string, ref string, planner PlannerVersio
 	if err != nil {
 		return executionGroupResults{}, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	results := executionGroupResults{GitRef: ref}
 	var execRes *executionResults
@@ -170,7 +170,7 @@ func getExecutionGroupResultsFromLast30Days(workload string, planner PlannerVers
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var allResults []executionGroupResults
 	var results executionGroupResults
@@ -278,7 +278,7 @@ func getSummaryLast30Days(workload string, planner PlannerVersion, client storag
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var allResults []executionGroupResults
 	var results *executionGroupResults

--- a/go/tools/macrobench/stats.go
+++ b/go/tools/macrobench/stats.go
@@ -159,8 +159,8 @@ func compare(old, new []float64) StatisticalResult {
 		sr.Insignificant = true
 	}
 
-	switch {
-	case sr.Old.Center == sr.New.Center || sr.Old.Center == 0:
+	switch sr.Old.Center {
+	case sr.New.Center, 0:
 		sr.Delta = 0
 	default:
 		sr.Delta = ((sr.New.Center / sr.Old.Center) - 1.0) * 100.0

--- a/go/tools/macrobench/vtgate.go
+++ b/go/tools/macrobench/vtgate.go
@@ -160,7 +160,7 @@ func getVTGateQueryPlans(port string) (VTGateQueryPlanMap, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -241,7 +241,7 @@ func GetVTGateSelectQueryPlansWithFilter(gitRef string, workload Workload, plann
 	if err != nil {
 		return nil, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 
 	parser, err := sqlparser.New(sqlparser.Options{})
 	if err != nil {

--- a/go/tools/microbench/integration/bench_test.go
+++ b/go/tools/microbench/integration/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkAllocs(b *testing.B) {
 		b.Error(err.Error())
 	}
 	for i := 0; i < b.N; i++ {
-		fmt.Fprintln(null, i)
+		_, _ = fmt.Fprintln(null, i)
 	}
 }
 
@@ -55,6 +55,6 @@ func BenchmarkBytes(b *testing.B) {
 	}
 	b.SetBytes(int64(len(b.Name())))
 	for i := 0; i < b.N; i++ {
-		fmt.Fprintln(null, b.Name())
+		_, _ = fmt.Fprintln(null, b.Name())
 	}
 }

--- a/go/tools/microbench/microbench.go
+++ b/go/tools/microbench/microbench.go
@@ -91,7 +91,7 @@ func (b *benchmark) execute(rootDir string, w *os.File) error {
 
 		if benchLine.benchType != "" {
 			log.Printf("%s - %s %f ns/op\n", b.pkgName, benchLine.name, benchLine.results.NanosecondPerOp)
-			fmt.Fprintf(w, "%s - %s %f ns/op\n", b.pkgName, benchLine.name, benchLine.results.NanosecondPerOp)
+			_, _ = fmt.Fprintf(w, "%s - %s %f ns/op\n", b.pkgName, benchLine.name, benchLine.results.NanosecondPerOp)
 			if b.sql != nil {
 				err = benchLine.InsertToMySQL(b.id, b.sql)
 				if err != nil {
@@ -116,7 +116,7 @@ func (b benchmark) executeProfile(rootDir, profileType string, w *os.File) error
 		return err
 	}
 	log.Printf("CPU profile generated %s\n", profileName)
-	fmt.Fprintf(w, "CPU profile generated %s\n", profileName)
+	_, _ = fmt.Fprintf(w, "CPU profile generated %s\n", profileName)
 	return nil
 }
 
@@ -132,7 +132,7 @@ func Run(cfg Config) error {
 		if err != nil {
 			return err
 		}
-		defer sqlClient.Close()
+		defer func() { _ = sqlClient.Close() }()
 	}
 
 	loaded, err := packages.Load(&packages.Config{
@@ -146,14 +146,14 @@ func Run(cfg Config) error {
 
 	benchmarks, err := findBenchmarks(loaded)
 	if err != nil {
-		return fmt.Errorf("%s:\n%s\n", errorInvalidPackageParsing, err)
+		return fmt.Errorf("%s:\n%s", errorInvalidPackageParsing, err)
 	}
 
 	w, err := os.Create(cfg.Output)
 	if err != nil {
 		return err
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	for _, benchmark := range benchmarks {
 		hash, err := git.GetCommitHash(cfg.RootDir)

--- a/go/tools/microbench/microbench_test.go
+++ b/go/tools/microbench/microbench_test.go
@@ -41,7 +41,7 @@ func TestMicroBenchmark(t *testing.T) {
 				c.Assert(gotErr, qt.Not(qt.IsNil))
 
 				// regexp to catch the whole error
-				c.Assert(gotErr, qt.ErrorMatches, tt.errContains+`(.*\n)*`)
+				c.Assert(gotErr, qt.ErrorMatches, tt.errContains+`(?s).*`)
 				return
 			}
 			c.Assert(gotErr, qt.IsNil)

--- a/go/tools/microbench/results.go
+++ b/go/tools/microbench/results.go
@@ -217,7 +217,7 @@ func GetResultsForGitRef(ref string, client storage.SQLClient) (mrs DetailsArray
 	if err != nil {
 		return nil, err
 	}
-	defer result.Close()
+	defer func() { _ = result.Close() }()
 
 	for result.Next() {
 		var res Details
@@ -243,7 +243,7 @@ func GetLatestResultsFor(name, subBenchmarkName string, count int, client storag
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var res Details


### PR DESCRIPTION
## Summary

The **Golang Lint** workflow has been red on `main` because golangci-lint (v2.x, installed via the action's `master` install script) flags pre-existing code with newer `errcheck`/`staticcheck` checks — unrelated to any feature work.

- **errcheck** — handle previously-unchecked error returns (deferred `Close()` on `sql.Rows`/response bodies, `os.RemoveAll` in tests, `fmt.Fprint*`).
- **staticcheck** — QF1008 (redundant embedded `Mode` selector), QF1004 (`strings.ReplaceAll`), QF1001 (De Morgan), QF1002 (tagged switch), ST1005 (error-string capitalization/newlines). Also updates the microbench test whose regex assumed the trailing newline ST1005 removed.
- **govet** — adds a minimal `.golangci.yml` (v2 format) filtering the false positive `cannot inline: type parameter inference is not yet supported` on generic stdlib helpers (`slices.Contains`). Default linter set otherwise unchanged.

## Verification
Ran golangci-lint **v2.12.2** (the exact version CI uses) locally with the CI invocation → **0 issues**; `go build ./go/...` and the unit tests pass.

Split out from the combined CI-fix branch; the Ansible Lint fix is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)